### PR TITLE
feat: adhere to Vercel Build Output API

### DIFF
--- a/.changeset/three-moons-obey.md
+++ b/.changeset/three-moons-obey.md
@@ -1,0 +1,5 @@
+---
+"vocs": minor
+---
+
+Adhere to Vercel [Build Output API](https://vercel.com/docs/build-output-api/v3) for zero-config Vercel deployments.

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,15 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "files": {
-    "ignore": ["_lib", "dist", "**/node_modules", "tsconfig.json", "tsconfig.*.json", ".vocs"]
+    "ignore": [
+      "_lib",
+      "dist",
+      "**/node_modules",
+      "tsconfig.json",
+      "tsconfig.*.json",
+      ".vercel",
+      ".vocs"
+    ]
   },
   "formatter": {
     "enabled": true,

--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -31,8 +31,8 @@ export async function build({ clean, logLevel, outDir, publicDir }: BuildParamet
       },
       onBundleEnd({ error }) {
         if (error) {
-          if (useLogger) spinner.client.fail('bundles failed to build')
-          return
+          if (useLogger) spinner.client.fail(`bundles failed to build: ${error.message}`)
+          process.exit(1)
         }
 
         if (useLogger) spinner.client.succeed('bundles built')
@@ -43,8 +43,8 @@ export async function build({ clean, logLevel, outDir, publicDir }: BuildParamet
       },
       onPrerenderEnd({ error }) {
         if (error) {
-          if (useLogger) spinner.client.fail('bundles failed to build')
-          return
+          if (useLogger) spinner.client.fail(`prerendering failed: ${error.message}`)
+          process.exit(1)
         }
 
         if (useLogger) spinner.prerender.succeed('prerendered pages')

--- a/src/vite/build.ts
+++ b/src/vite/build.ts
@@ -110,5 +110,5 @@ export async function build({
     hooks?.onScriptsEnd?.({ error: error as Error })
   }
 
-  if (outDir_resolved === vercelBuildOutputDir) writeBuildOutputConfig()
+  if (outDir_resolved.startsWith(vercelBuildOutputDir)) writeBuildOutputConfig()
 }

--- a/src/vite/build.ts
+++ b/src/vite/build.ts
@@ -6,7 +6,9 @@ import * as vite from 'vite'
 import { postbuild } from './plugins/postbuild.js'
 import { prerender } from './prerender.js'
 import * as cache from './utils/cache.js'
+import { resolveOutDir } from './utils/resolveOutDir.js'
 import { resolveVocsConfig } from './utils/resolveVocsConfig.js'
+import { vercelBuildOutputDir, writeBuildOutputConfig } from './utils/vercel.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -31,13 +33,13 @@ export async function build({
   logger,
   hooks,
   logLevel = 'silent',
-  outDir = 'dist',
+  outDir,
   publicDir = 'public',
 }: BuildParameters = {}) {
   const { config } = await resolveVocsConfig()
   const { rootDir } = config
 
-  const outDir_resolved = resolve(rootDir, outDir)
+  const outDir_resolved = resolveOutDir(rootDir, outDir)
   const publicDir_resolved = resolve(rootDir, publicDir)
 
   if (clean) cache.clear()
@@ -107,4 +109,6 @@ export async function build({
   } catch (error) {
     hooks?.onScriptsEnd?.({ error: error as Error })
   }
+
+  if (outDir_resolved === vercelBuildOutputDir) writeBuildOutputConfig()
 }

--- a/src/vite/plugins/search.ts
+++ b/src/vite/plugins/search.ts
@@ -95,7 +95,7 @@ export async function search(): Promise<Plugin> {
         searchPromise = undefined
         const json = index.toJSON()
         hash = hash_(JSON.stringify(json), 8)
-        const dir = join(resolve(config.rootDir, 'dist'), '.vocs')
+        const dir = join(viteConfig?.build?.outDir!, '.vocs')
         fs.ensureDirSync(dir)
         fs.writeJSONSync(join(dir, `search-index-${hash}.json`), json)
       }

--- a/src/vite/prerender.ts
+++ b/src/vite/prerender.ts
@@ -3,17 +3,18 @@ import { dirname, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import pc from 'picocolors'
 import type { Logger } from 'vite'
+import { resolveOutDir } from './utils/resolveOutDir.js'
 import { resolveVocsConfig } from './utils/resolveVocsConfig.js'
 
 type PrerenderParameters = { logger?: Logger; outDir?: string }
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
-export async function prerender({ logger, outDir = 'dist' }: PrerenderParameters) {
+export async function prerender({ logger, outDir }: PrerenderParameters) {
   const { config } = await resolveVocsConfig()
   const { rootDir } = config
 
-  const outDir_resolved = resolve(rootDir, outDir)
+  const outDir_resolved = resolveOutDir(rootDir, outDir)
 
   const template = readFileSync(resolve(outDir_resolved, 'index.html'), 'utf-8')
   const mod = await import(resolve(__dirname, './.vocs/dist/index.server.js'))

--- a/src/vite/utils/resolveOutDir.ts
+++ b/src/vite/utils/resolveOutDir.ts
@@ -5,7 +5,7 @@ export function resolveOutDir(rootDir: string, outDir?: string) {
   if (typeof outDir === 'undefined') {
     // If we're in a Vercel environment, use the Vercel Build Output directory.
     // https://vercel.com/docs/build-output-api/v3
-    if (process.env.VERCEL) return vercelBuildOutputDir
+    if (process.env.VERCEL) return resolve(vercelBuildOutputDir, 'static')
   }
   return resolve(rootDir, outDir ?? 'dist')
 }

--- a/src/vite/utils/resolveOutDir.ts
+++ b/src/vite/utils/resolveOutDir.ts
@@ -1,0 +1,11 @@
+import { resolve } from 'node:path'
+import { vercelBuildOutputDir } from './vercel.js'
+
+export function resolveOutDir(rootDir: string, outDir?: string) {
+  if (typeof outDir === 'undefined') {
+    // If we're in a Vercel environment, use the Vercel Build Output directory.
+    // https://vercel.com/docs/build-output-api/v3
+    if (process.env.VERCEL) return vercelBuildOutputDir
+  }
+  return resolve(rootDir, outDir ?? 'dist')
+}

--- a/src/vite/utils/vercel.ts
+++ b/src/vite/utils/vercel.ts
@@ -1,0 +1,8 @@
+import { resolve } from 'node:path'
+import { default as fs } from 'fs-extra'
+
+export const vercelBuildOutputDir = resolve(process.cwd(), '.vercel/output')
+
+export function writeBuildOutputConfig() {
+  fs.writeJsonSync(resolve(vercelBuildOutputDir, 'config.json'), { version: 3 })
+}


### PR DESCRIPTION
Adhering to the Vercel Build Output API spec means that consumers can deploy to Vercel with zero-configuration (no need to set output directories, etc).