### PR TITLE
feat: supports base URL for all locations

### DIFF
--- a/src/app/index.client.tsx
+++ b/src/app/index.client.tsx
@@ -10,14 +10,21 @@ import { removeTempStyles } from './utils/removeTempStyles.js'
 hydrate()
 
 async function hydrate() {
-  await hydrateLazyRoutes(routes)
+  const basename = getBasename()
+
+  await hydrateLazyRoutes(routes, basename)
   removeTempStyles()
 
-  const router = createBrowserRouter(routes)
+  const router = createBrowserRouter(routes, { basename })
   hydrateRoot(
     document.getElementById('app')!,
     <ConfigProvider>
       <RouterProvider router={router} />
     </ConfigProvider>,
   )
+}
+
+function getBasename() {
+  const ogUrlMeta = document.querySelector('meta[property="og:url"]')
+  return ogUrlMeta?.getAttribute?.('content') || undefined
 }

--- a/src/app/index.client.tsx
+++ b/src/app/index.client.tsx
@@ -25,6 +25,6 @@ async function hydrate() {
 }
 
 function getBasename() {
-  const ogUrlMeta = document.querySelector('meta[property="og:url"]')
-  return ogUrlMeta?.getAttribute?.('content') || undefined
+  const basenameMeta = document.querySelector('meta[property="route-basename"]')
+  return basenameMeta?.getAttribute?.('content') || undefined
 }

--- a/src/app/index.server.tsx
+++ b/src/app/index.server.tsx
@@ -16,6 +16,7 @@ import { resolveVocsConfig } from '../vite/utils/resolveVocsConfig.js'
 import { ConfigProvider } from './hooks/useConfig.js'
 import { routes } from './routes.js'
 import { createFetchRequest } from './utils/createFetchRequest.js'
+import { getRouteBasename } from '../vite/utils/rewriteConfig.js'
 
 export async function prerender(location: string) {
   const unwrappedRoutes = (
@@ -34,11 +35,11 @@ export async function prerender(location: string) {
   ).filter(Boolean) as RouteObject[]
 
   const { config } = await resolveVocsConfig()
-  const { baseUrl } = config
+  const basename = getRouteBasename(config)
 
   const body = renderToString(
     <ConfigProvider config={config}>
-      <StaticRouter location={`${baseUrl || ''}${location}`} basename={baseUrl}>
+      <StaticRouter location={`${basename}${location}`} basename={basename}>
         <Routes>
           {unwrappedRoutes.map((route) => (
             <Route key={route.path} path={route.path} element={route.element} />
@@ -53,9 +54,9 @@ export async function prerender(location: string) {
 
 export async function render(req: Request) {
   const { config } = await resolveVocsConfig()
-  const { baseUrl } = config
+  const basename = getRouteBasename(config)
 
-  const { query, dataRoutes } = createStaticHandler(routes, { basename: baseUrl })
+  const { query, dataRoutes } = createStaticHandler(routes, { basename })
   const fetchRequest = createFetchRequest(req)
   const context = (await query(fetchRequest)) as StaticHandlerContext
 

--- a/src/app/index.server.tsx
+++ b/src/app/index.server.tsx
@@ -34,10 +34,11 @@ export async function prerender(location: string) {
   ).filter(Boolean) as RouteObject[]
 
   const { config } = await resolveVocsConfig()
+  const { baseUrl } = config
 
   const body = renderToString(
     <ConfigProvider config={config}>
-      <StaticRouter location={location}>
+      <StaticRouter location={`${baseUrl || ''}${location}`} basename={baseUrl}>
         <Routes>
           {unwrappedRoutes.map((route) => (
             <Route key={route.path} path={route.path} element={route.element} />
@@ -51,15 +52,16 @@ export async function prerender(location: string) {
 }
 
 export async function render(req: Request) {
-  const { query, dataRoutes } = createStaticHandler(routes)
+  const { config } = await resolveVocsConfig()
+  const { baseUrl } = config
+
+  const { query, dataRoutes } = createStaticHandler(routes, { basename: baseUrl })
   const fetchRequest = createFetchRequest(req)
   const context = (await query(fetchRequest)) as StaticHandlerContext
 
   if (context instanceof Response) throw context
 
   const router = createStaticRouter(dataRoutes, context)
-
-  const { config } = await resolveVocsConfig()
 
   const body = renderToString(
     <ConfigProvider config={config}>

--- a/src/app/root.tsx
+++ b/src/app/root.tsx
@@ -10,6 +10,7 @@ import { useConfig } from './hooks/useConfig.js'
 import { useOgImageUrl } from './hooks/useOgImageUrl.js'
 import { PageDataContext } from './hooks/usePageData.js'
 import { type Module } from './types.js'
+import { getRouteBasename } from '../vite/utils/rewriteConfig.js'
 
 export function Root(props: {
   children: ReactNode
@@ -55,6 +56,8 @@ function Head({ frontmatter }: { frontmatter: Module['frontmatter'] }) {
 
   const enableTitleTemplate = config.title && !title.includes(config.title)
 
+  const basename = getRouteBasename(config)
+
   return (
     <Helmet
       defaultTitle={config.title}
@@ -64,10 +67,13 @@ function Head({ frontmatter }: { frontmatter: Module['frontmatter'] }) {
       {title && <title>{title}</title>}
 
       {/* Base URL */}
-      {baseUrl && import.meta.env.PROD && <base href={baseUrl} />}
+      {/* {baseUrl && import.meta.env.PROD && <base href={baseUrl} />} */}
 
       {/* Description */}
       {description !== 'undefined' && <meta name="description" content={description} />}
+
+      {/* route basename */}
+      {basename && <meta property="route-basename" content={basename} />}
 
       {/* Icons */}
       {iconUrl && typeof iconUrl === 'string' && (

--- a/src/app/utils/hydrateLazyRoutes.ts
+++ b/src/app/utils/hydrateLazyRoutes.ts
@@ -1,8 +1,8 @@
 import { type RouteObject, matchRoutes } from 'react-router-dom'
 
-export async function hydrateLazyRoutes(routes: RouteObject[]) {
+export async function hydrateLazyRoutes(routes: RouteObject[], basename?: string) {
   // Determine if any of the initial routes are lazy
-  const lazyMatches = matchRoutes(routes, window.location)?.filter((m) => m.route.lazy)
+  const lazyMatches = matchRoutes(routes, window.location, basename)?.filter((m) => m.route.lazy)
 
   // Load the lazy matches and update the routes before creating your router
   // so we can hydrate the SSR-rendered content synchronously

--- a/src/cli/commands/preview.ts
+++ b/src/cli/commands/preview.ts
@@ -1,8 +1,11 @@
 import pc from 'picocolors'
 import { createLogger } from 'vite'
 import { version } from '../version.js'
+import { resolveVocsConfig } from '../../vite/utils/resolveVocsConfig.js'
 
 export async function preview() {
+  const { config } = await resolveVocsConfig()
+  const { basename } = config
   const { preview } = await import('../../vite/preview.js')
   const server = await preview()
 
@@ -13,6 +16,8 @@ export async function preview() {
   logger.info('')
 
   logger.info(
-    `  ${pc.green('➜')}  ${pc.bold('Local')}:   ${pc.cyan(`http://localhost:${server.port}`)}`,
+    `  ${pc.green('➜')}  ${pc.bold('Local')}:   ${pc.cyan(
+      `http://localhost:${server.port}${basename || ''}`,
+    )}`,
   )
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,6 +48,16 @@ export type Config<
      */
     baseUrl?: string
     /**
+     * Route basename
+     *
+     * @example
+     * /prefix
+     *
+     * baseUrl is the starting path of http or https
+     * when vite.base is
+     */
+    basename?: string
+    /**
      * Path to blog pages relative to project root.
      * Used to extract posts from the filesystem.
      *

--- a/src/vite/build.ts
+++ b/src/vite/build.ts
@@ -87,6 +87,8 @@ export async function build({
     hooks?.onPrerenderEnd?.({ error: error as Error })
   }
 
+  // remove .vocs dir from user's workspace
+  fs.removeSync(resolve(publicDir_resolved, '.vocs'))
   // copy public folder
   fs.copySync(resolve(__dirname, '../app/public'), outDir_resolved)
 

--- a/src/vite/build.ts
+++ b/src/vite/build.ts
@@ -47,6 +47,9 @@ export async function build({
   fs.rmSync(outDir_resolved, { recursive: true, force: true })
 
   hooks?.onBundleStart?.()
+
+  fs.copySync(resolve(__dirname, '../app/public'), publicDir_resolved)
+
   try {
     await vite.build({
       build: {

--- a/src/vite/plugins/search.ts
+++ b/src/vite/plugins/search.ts
@@ -99,7 +99,9 @@ export async function search(): Promise<Plugin> {
         fs.ensureDirSync(dir)
         fs.writeJSONSync(join(dir, `search-index-${hash}.json`), json)
       }
-      return `export const getSearchIndex = async () => JSON.stringify(await ((await fetch("/.vocs/search-index-${hash}.json")).json()))`
+      return `export const getSearchIndex = async () => JSON.stringify(await ((await fetch("${`${
+        config.baseUrl || ''
+      }/.vocs/search-index-${hash}.json`}")).json()))`
     },
     async handleHotUpdate({ file }) {
       if (!file.endsWith('.md') && !file.endsWith('.mdx')) return

--- a/src/vite/plugins/search.ts
+++ b/src/vite/plugins/search.ts
@@ -8,6 +8,7 @@ import { hash as hash_ } from '../utils/hash.js'
 import { resolveVocsConfig } from '../utils/resolveVocsConfig.js'
 import { buildIndex, debug, getDocId, processMdx, splitPageIntoSections } from '../utils/search.js'
 import { slash } from '../utils/slash.js'
+import { getAssetsPrefix } from '../utils/rewriteConfig.js'
 
 const virtualModuleId = 'virtual:searchIndex'
 const resolvedVirtualModuleId = `\0${virtualModuleId}`
@@ -90,6 +91,8 @@ export async function search(): Promise<Plugin> {
       if (dev)
         return `export const getSearchIndex = async () => ${JSON.stringify(JSON.stringify(index))}`
 
+      const assetPrefix = getAssetsPrefix(config)
+
       if (searchPromise) {
         index = await searchPromise
         searchPromise = undefined
@@ -99,9 +102,7 @@ export async function search(): Promise<Plugin> {
         fs.ensureDirSync(dir)
         fs.writeJSONSync(join(dir, `search-index-${hash}.json`), json)
       }
-      return `export const getSearchIndex = async () => JSON.stringify(await ((await fetch("${`${
-        config.baseUrl || ''
-      }/.vocs/search-index-${hash}.json`}")).json()))`
+      return `export const getSearchIndex = async () => JSON.stringify(await ((await fetch("${`${assetPrefix}/.vocs/search-index-${hash}.json`}")).json()))`
     },
     async handleHotUpdate({ file }) {
       if (!file.endsWith('.md') && !file.endsWith('.mdx')) return

--- a/src/vite/prerender.ts
+++ b/src/vite/prerender.ts
@@ -12,7 +12,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export async function prerender({ logger, outDir }: PrerenderParameters) {
   const { config } = await resolveVocsConfig()
-  const { rootDir } = config
+  const { rootDir, baseUrl } = config
 
   const outDir_resolved = resolveOutDir(rootDir, outDir)
 
@@ -28,7 +28,7 @@ export async function prerender({ logger, outDir }: PrerenderParameters) {
     const html = template
       .replace('<!--body-->', body)
       .replace('<!--head-->', head)
-      .replace('../app/utils/initializeTheme.ts', '/initializeTheme.iife.js')
+      .replace('../app/utils/initializeTheme.ts', `${baseUrl || ''}/initializeTheme.iife.js`)
     const isIndex = route.endsWith('/')
     const filePath = `${isIndex ? `${route}index` : route}.html`.replace(/^\//, '')
     const path = resolve(outDir_resolved, filePath)

--- a/src/vite/prerender.ts
+++ b/src/vite/prerender.ts
@@ -5,6 +5,7 @@ import pc from 'picocolors'
 import type { Logger } from 'vite'
 import { resolveOutDir } from './utils/resolveOutDir.js'
 import { resolveVocsConfig } from './utils/resolveVocsConfig.js'
+import { getAssetsPrefix } from './utils/rewriteConfig.js'
 
 type PrerenderParameters = { logger?: Logger; outDir?: string }
 
@@ -12,7 +13,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export async function prerender({ logger, outDir }: PrerenderParameters) {
   const { config } = await resolveVocsConfig()
-  const { rootDir, baseUrl } = config
+  const { rootDir } = config
+  const assetPrefix = getAssetsPrefix(config)
 
   const outDir_resolved = resolveOutDir(rootDir, outDir)
 
@@ -28,7 +30,7 @@ export async function prerender({ logger, outDir }: PrerenderParameters) {
     const html = template
       .replace('<!--body-->', body)
       .replace('<!--head-->', head)
-      .replace('../app/utils/initializeTheme.ts', `${baseUrl || ''}/initializeTheme.iife.js`)
+      .replace('../app/utils/initializeTheme.ts', `${assetPrefix}/initializeTheme.iife.js`)
     const isIndex = route.endsWith('/')
     const filePath = `${isIndex ? `${route}index` : route}.html`.replace(/^\//, '')
     const path = resolve(outDir_resolved, filePath)

--- a/src/vite/preview.ts
+++ b/src/vite/preview.ts
@@ -12,11 +12,19 @@ type PreviewParameters = {
 
 export async function preview({ outDir = 'dist' }: PreviewParameters = {}) {
   const { config } = await resolveVocsConfig()
-  const { rootDir } = config
+  const { rootDir, basename } = config
 
   const app = new Hono()
   app.use('*', compress())
-  app.use('/*', serveStatic({ root: resolve(rootDir, outDir) }))
+  app.use(
+    '/*',
+    serveStatic({
+      root: resolve(rootDir, outDir),
+      rewriteRequestPath(path) {
+        return basename ? path.replace(basename!, '') : path
+      },
+    }),
+  )
 
   return new Promise<ReturnType<typeof serve> & { port: number }>((res) => {
     async function createServer(port = 4173) {

--- a/src/vite/utils/resolveVocsConfig.ts
+++ b/src/vite/utils/resolveVocsConfig.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path'
 import toml from 'toml'
 import { type ConfigEnv, loadConfigFromFile } from 'vite'
 import { type ParsedConfig, defineConfig, getDefaultConfig } from '../../config.js'
+import { rewriteConfig } from './rewriteConfig.js'
 
 const moduleExtensions = ['js', 'jsx', 'ts', 'tsx', 'mjs', 'mts']
 const staticExtensions = ['toml', 'json']
@@ -50,6 +51,8 @@ export async function resolveVocsConfig(parameters: ResolveVocsConfigParameters 
   })()
 
   const config = (result ? result.config : await getDefaultConfig()) as ParsedConfig
+
+  rewriteConfig(config)
 
   return {
     config,

--- a/src/vite/utils/rewriteConfig.ts
+++ b/src/vite/utils/rewriteConfig.ts
@@ -2,33 +2,60 @@ import type { IconUrl, ParsedConfig } from '../../config.js'
 
 const IS_PROD = process.env.NODE_ENV === 'production'
 
+/**
+ * The "baseUrl" refers to the public URL associated with the assets.
+ * The "basename" is the prefix of the page routes.
+ * If the vite.base starts with "http" or "https" and "baseUrl" is not provided. then it represents the baseUrl.
+ * If it starts with "/" add "basename" is not provided. then it represents the basename.
+ * The "baseUrl" takes precedence with higher priority, if vite.base starts with "http" or "https",
+  The baseUrl will override vite.base.
+*/
+
 export function rewriteConfig(config: ParsedConfig) {
   const { baseUrl, vite, logoUrl, iconUrl } = config
-  let basename = baseUrl || vite?.base
-  if (!basename) {
-    return
-  }
-
-  basename = basename?.replace(/\/*$/, '')
-  basename = basename.replace(/^\/*/, '/')
-
-  if (basename === '/') {
-    return
-  }
 
   if (!config.vite) {
     config.vite = {}
   }
 
-  config.baseUrl = config.vite.base = basename
+  if (baseUrl) {
+    const viteBase = config.vite.base
+    if (viteBase && !isHttpLink(viteBase)) {
+      if (!config.basename) {
+        config.basename = viteBase
+      }
+    }
+    config.vite.base = baseUrl
+  } else {
+    if (isHttpLink(vite?.base)) {
+      config.baseUrl = vite!.base
+    } else if (vite?.base) {
+      // relative path
+      if (!config.basename) {
+        config.basename = vite.base
+      }
+    }
+  }
+
+  if (config.baseUrl) {
+    config.baseUrl = trimRight(config.baseUrl)
+  }
+
+  if (config.vite?.base) {
+    config.vite.base = trimRight(config.vite?.base)
+  }
 
   if (IS_PROD) {
+    const assetsPrefix = getAssetsPrefix(config)
+    if (!assetsPrefix) {
+      return
+    }
     if (iconUrl) {
-      config.iconUrl = getImgUrlWithBase(iconUrl, basename)
+      config.iconUrl = getImgUrlWithBase(iconUrl, assetsPrefix)
     }
 
     if (logoUrl) {
-      config.logoUrl = getImgUrlWithBase(logoUrl, basename)
+      config.logoUrl = getImgUrlWithBase(logoUrl, assetsPrefix)
     }
   }
 }
@@ -58,4 +85,25 @@ export function getImgUrlWithBase(url: IconUrl | string, basename: string) {
   }
 
   return finalUrl!
+}
+
+function isHttpLink(url?: string) {
+  if (!url) {
+    return false
+  }
+  return /^http(s?):\/\//.test(url)
+}
+
+export function getRouteBasename(config: ParsedConfig): string | undefined {
+  const { basename } = config
+  return basename || ''
+}
+
+export function getAssetsPrefix(config: ParsedConfig) {
+  const { baseUrl } = config
+  return baseUrl || ''
+}
+
+export function trimRight(str: string) {
+  return str.replace(/\/*$/, '')
 }

--- a/src/vite/utils/rewriteConfig.ts
+++ b/src/vite/utils/rewriteConfig.ts
@@ -1,0 +1,61 @@
+import type { IconUrl, ParsedConfig } from '../../config.js'
+
+const IS_PROD = process.env.NODE_ENV === 'production'
+
+export function rewriteConfig(config: ParsedConfig) {
+  const { baseUrl, vite, logoUrl, iconUrl } = config
+  let basename = baseUrl || vite?.base
+  if (!basename) {
+    return
+  }
+
+  basename = basename?.replace(/\/*$/, '')
+  basename = basename.replace(/^\/*/, '/')
+
+  if (basename === '/') {
+    return
+  }
+
+  if (!config.vite) {
+    config.vite = {}
+  }
+
+  config.baseUrl = config.vite.base = basename
+
+  if (IS_PROD) {
+    if (iconUrl) {
+      config.iconUrl = getImgUrlWithBase(iconUrl, basename)
+    }
+
+    if (logoUrl) {
+      config.logoUrl = getImgUrlWithBase(logoUrl, basename)
+    }
+  }
+}
+
+export function getImgUrlWithBase(url: IconUrl | string, basename: string) {
+  if (!url) {
+    return url
+  }
+
+  if (typeof url === 'string') {
+    return basename + url
+  }
+  let finalUrl: IconUrl
+  const keys = Object.keys(url)
+  for (let i = 0, len = keys.length; i < len; i++) {
+    const k = keys[i]
+    const urlWithBase = basename + url[k as keyof IconUrl]
+    if (urlWithBase) {
+      if (!finalUrl!) {
+        finalUrl = {
+          [k]: urlWithBase,
+        } as IconUrl
+      } else {
+        ;(finalUrl[k as keyof IconUrl] as IconUrl) = urlWithBase
+      }
+    }
+  }
+
+  return finalUrl!
+}

--- a/src/vite/utils/rewriteConfig.ts
+++ b/src/vite/utils/rewriteConfig.ts
@@ -19,20 +19,32 @@ export function rewriteConfig(config: ParsedConfig) {
   }
 
   if (baseUrl) {
-    const viteBase = config.vite.base
-    if (viteBase && !isHttpLink(viteBase)) {
+    const originalViteBase = config.vite.base
+    if (originalViteBase && !isHttpLink(originalViteBase)) {
       if (!config.basename) {
-        config.basename = viteBase
+        config.basename = originalViteBase
       }
     }
+
+    if (!vite?.base) {
+      if (config.basename) {
+        config.vite.base = config.basename
+      }
+    }
+
     config.vite.base = baseUrl
   } else {
     if (isHttpLink(vite?.base)) {
       config.baseUrl = vite!.base
     } else if (vite?.base) {
-      // relative path
       if (!config.basename) {
         config.basename = vite.base
+      } else {
+        config.vite.base = config.basename
+      }
+    } else {
+      if (config.basename) {
+        config.vite.base = config.basename
       }
     }
   }
@@ -100,8 +112,8 @@ export function getRouteBasename(config: ParsedConfig): string | undefined {
 }
 
 export function getAssetsPrefix(config: ParsedConfig) {
-  const { baseUrl } = config
-  return baseUrl || ''
+  const { baseUrl, vite } = config
+  return baseUrl || vite?.base || ''
 }
 
 export function trimRight(str: string) {


### PR DESCRIPTION
#67 

After adding the basename to the router, I encountered no issues in the development environment due to the presence of serveStatic('vocs/src/app/public'). However, upon packaging, I discovered that certain CSS URLs located under vocs/src/app did not automatically incorporate the basename. Through debugging, I identified that Vite failed to process the CSS URLs during the build phase. This decision was based on whether the files existed within the public directory of the user's vocs project, which they did not. Consequently, I resorted to a plugin to manually process the CSS URLs. Later, I realized a more elegant solution: before packaging, I duplicated the src/app/public directory from the vocs project to the user's publicDir within the vocs project.