### PR TITLE
feat: expose mdx components for imports

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -7,3 +7,5 @@ export { Raw } from './app/components/Raw.js'
 export { Sponsors } from './app/components/Sponsors.js'
 export { Steps, type StepsProps } from './app/components/Steps.js'
 export { Step, type StepProps } from './app/components/Step.js'
+
+export { components as MDXComponents } from './app/components/mdx/index.js'


### PR DESCRIPTION
# Feat: Expose MDX Components to be consumed in react components

When authoring React components in mdx files, this allows the components to be imported into other components using external libraries such as `react-markdown`.
