### PR TITLE
fix: Modified postbuild.ts to handle tsx files

### DIFF
--- a/scripts/postbuild.ts
+++ b/scripts/postbuild.ts
@@ -39,7 +39,8 @@ function rewriteExtensions(dir: string) {
     if (path.endsWith('root.js')) continue
     if (path.endsWith('vocs-config.js')) continue
     const fileContent = fs.readFileSync(path, 'utf-8')
-    fs.writeFileSync(path, fileContent.replace(/\.(tsx|ts)/g, '.js'))
+    fs.writeFileSync(path, fileContent.replace(/\.(tsx)/g, '.jsx'))
+    fs.writeFileSync(path, fileContent.replace(/\.(ts)/g, '.js'))
   }
 }
 


### PR DESCRIPTION
# Fix

Noticed that after the build in `virtual-consumer-components.js` it resolved to being false all the time because `layout.js` didn't exist.

# Before (when built):

**File:** `./vocs/_lib/vite/plugins/virtual-consumer-components.js`

```js
        ${exportComponent(resolve(rootDir, 'layout.js'), 'Layout')}
        ${exportComponent(resolve(rootDir, 'footer.js'), 'Footer')}
      `;
        },
    };
}
function exportComponent(path, name) {
    if (existsSync(path)) // Would always result in false
        return `export { default as ${name} } from "${path}";`;
    return `export const ${name} = ({ children }) => children;`;
}
```

# After (with change):

```js
        ${exportComponent(resolve(rootDir, 'layout.jsx'), 'Layout')}
        ${exportComponent(resolve(rootDir, 'footer.jsx'), 'Footer')}
      `;
        },
    };
}
function exportComponent(path, name) {
    if (existsSync(path)) // Accounts for correct jsx file being loaded
        return `export { default as ${name} } from "${path}";`;
    return `export const ${name} = ({ children }) => children;`;
}
```

BREAKING CHANGE: No

Closes: #90