### PR TITLE
fix the BUG Missing Git Ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,21 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# production
+/docs/dist
+
+# misc
 .DS_Store
-dist
-node_modules
-_lib
-tsconfig.tsbuildinfo
-tsconfig.*.tsbuildinfo
-vocs.config.ts.timestamp-*
-.vercel
-.vocs
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# typescript
+*.tsbuildinfo


### PR DESCRIPTION
The Missing `.gitignore` when creating a new project has been fixed