### PR TITLE
Fix search input clearing on refresh (#120)

### DIFF
--- a/src/app/components/SearchDialog.tsx
+++ b/src/app/components/SearchDialog.tsx
@@ -15,6 +15,7 @@ import { Link, useNavigate } from 'react-router-dom'
 
 import { useDebounce } from '../hooks/useDebounce.js'
 import { useLocalStorage } from '../hooks/useLocalStorage.js'
+import { useSessionStorage } from '../hooks/useSessionStorage.js'
 import { type Result, useSearchIndex } from '../hooks/useSearchIndex.js'
 import { visuallyHidden } from '../styles/utils.css.js'
 import { Content } from './Content.js'
@@ -26,7 +27,7 @@ export function SearchDialog(props: { open: boolean; onClose(): void }) {
   const inputRef = useRef<HTMLInputElement>(null)
   const listRef = useRef<HTMLUListElement>(null)
 
-  const [filterText, setFilterText] = useLocalStorage('filterText', '')
+  const [filterText, setFilterText] = useSessionStorage('filterText', '')
   const searchTerm = useDebounce(filterText, 200)
   const searchIndex = useSearchIndex()
 

--- a/src/app/hooks/useSessionStorage.ts
+++ b/src/app/hooks/useSessionStorage.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect, useCallback } from 'react'
+
+type SetValue<type> = (newVal: type | ((prevVal: type) => type)) => void
+
+export function useSessionStorage<type>(
+  key: string,
+  defaultValue: type | undefined,
+): [type | undefined, SetValue<type>] {
+  const [value, setValue] = useState<type>()
+
+  useEffect(() => {
+    const initialValue = getItem(key) as type | undefined
+
+    if (typeof initialValue === 'undefined' || initialValue === null) {
+      setValue(typeof defaultValue === 'function' ? defaultValue() : defaultValue)
+    } else {
+      setValue(initialValue)
+    }
+  }, [defaultValue, key])
+
+  const setter = useCallback(
+    (updater: type | ((prevVal: type) => type)) => {
+      setValue((old) => {
+        let newVal: type
+        if (typeof updater === 'function') newVal = (updater as any)(old)
+        else newVal = updater
+
+        try {
+          sessionStorage.setItem(key, JSON.stringify(newVal))
+        } catch {}
+
+        return newVal
+      })
+    },
+    [key],
+  )
+
+  return [value, setter]
+}
+
+function getItem(key: string): unknown {
+  try {
+    const itemValue = sessionStorage.getItem(key)
+    if (typeof itemValue === 'string') {
+      return JSON.parse(itemValue)
+    }
+    return undefined
+  } catch {
+    return undefined
+  }
+}


### PR DESCRIPTION
### **Description**:
This PR addresses issue #120, where the search input field was persisting its value after a browser tab refresh. It implements the following changes:

### **Modification**: 
1. Created a custom hook (`useSessionStorage`) to manage data to session storage.
2. Integrated `useSessionStorage `into the `SearchDialog `component.