### PR TITLE
106 fix/bug missing git ignore

### DIFF
--- a/create-vocs/.npmignore
+++ b/create-vocs/.npmignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/create-vocs/.npmignore
+++ b/create-vocs/.npmignore
@@ -1,1 +1,0 @@
-!.gitignore

--- a/create-vocs/package.json
+++ b/create-vocs/package.json
@@ -2,6 +2,10 @@
   "name": "create-vocs",
   "version": "1.0.0-alpha.5",
   "type": "module",
+  "scripts": {
+    "prepack": "mv templates/default/.gitignore templates/default/_gitignore",
+    "postpack": "mv templates/default/_gitignore templates/default/.gitignore"
+  },
   "bin": {
     "create-vocs": "./_lib/bin.js"
   },


### PR DESCRIPTION
# Context

Fixes the issue of when running `npm pack` which excludes `.gitignore`.

BREAKING CHANGE: No

Closes: #106

# Issue (Before)

Assuming that `npm pack` is used to bundle the `create-vocs`. When running that command, it results in a `tgz` file.

```bash
# FROM ./create-vocs

mkdir tmp;
npm pack; # Results in 'create-vocs-1.0.0-alpha.5.tgz'
tar zxvf create-vocs-1.0.0-alpha.5.tgz -C tmp;
tree tmp/package/templates -a;

# NOTE: `.gitignore` is not present
# [Expected Output]:
# tmp/package/templates
# └── default
#     ├── README.md
#     ├── docs
#     │   └── pages
#     │       ├── example.mdx
#     │       ├── getting-started.mdx
#     │       └── index.mdx
#     ├── package.json
#     ├── tsconfig.json
#     └── vocs.config.ts
```

# Fix (After)

```bash
# FROM ./create-vocs

mkdir tmp;
npm pack; # Results in 'create-vocs-1.0.0-alpha.5.tgz'
tar zxvf create-vocs-1.0.0-alpha.5.tgz -C tmp;
tree tmp/package/templates -a;

# NOTE: `_gitignore` is now present
# [Expected Output]:
# tmp/package/templates
# └── default
#     ├── README.md
#     ├── _gitignore <------ Hello there!
#     ├── docs
#     │   └── pages
#     │       ├── example.mdx
#     │       ├── getting-started.mdx
#     │       └── index.mdx
#     ├── package.json
#     ├── tsconfig.json
#     └── vocs.config.ts
```

Now when running this library with the new template, we do the following:

```bash
# FROM ./create-vocs/tmp/package

# modify permissions to use
chmod +x ./_lib/bin.js;
./_lib/bin.js;

# [Expected Prompts]:
# ┌  Welcome to Vocs!
# │
# ◇  Enter the name of your project
# │  cmaaaaaan-work
# │
# ◆  Project successfully scaffolded in /path/to/wevm--vocs/create-vocs/tmp/package/cmaaaaaan-work!
# │
# │  Next steps:
# │
# ◇  1. cd ./cmaaaaaan-work - Navigate to project
# │
# ◇  2. npm install - Install dependencies
# │
# ◇  3. npm run dev - Start dev server
# │
# ◇  4. Head to http://localhost:5173
# │
```

Then when we `tree` into that directory, we should see the following result:

```bash
# FROM ./create-vocs/tmp/package

tree cmaaaaaan-work -a;

# [Expected Output]:
# cmaaaaaan-work
# ├── .gitignore <------- LET'S GOOOOO!!
# ├── README.md
# ├── docs
# │   └── pages
# │       ├── example.mdx
# │       ├── getting-started.mdx
# │       └── index.mdx
# ├── package.json
# ├── tsconfig.json
# └── vocs.config.ts
```

This also follows some of the same conventions as seen in `create-t3-app`, see this repo for reference: https://github.com/t3-oss/create-t3-app/tree/main/cli/template/base
