### PR TITLE
fix: crash on windows

### DIFF
--- a/src/vite/plugins/dev.ts
+++ b/src/vite/plugins/dev.ts
@@ -6,6 +6,7 @@ import type { PluginOption } from 'vite'
 
 import type { ParsedConfig } from '../../config.js'
 import { resolveVocsConfig } from '../utils/resolveVocsConfig.js'
+import { getFsPath } from '../utils/paths.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -50,7 +51,7 @@ export function dev(): PluginOption {
             const indexHtml = readFileSync(resolve(__dirname, '../index.html'), 'utf-8')
             const template = await server.transformIndexHtml(
               url!,
-              indexHtml.replace(/\.\.\/app/g, `/@fs${resolve(__dirname, '../../app')}`),
+              indexHtml.replace(/\.\.\/app/g, getFsPath(resolve(__dirname, '../../app'))),
             )
             const module = await server.ssrLoadModule(
               resolve(__dirname, '../../app/index.server.tsx'),

--- a/src/vite/plugins/resolve-vocs-modules.ts
+++ b/src/vite/plugins/resolve-vocs-modules.ts
@@ -1,11 +1,30 @@
-import { dirname, extname, resolve } from 'node:path'
+import { basename, dirname, extname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { type PluginOption } from 'vite'
 
 import type { ParsedConfig } from '../../config.js'
 import { resolveVocsConfig } from '../utils/resolveVocsConfig.js'
+import { slash } from '../utils/slash.js'
+import { isWin32 } from '../utils/paths.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
+
+// Get the result of `/node_modules/vocs/_lib`
+const libDir = slash(resolve(__dirname, '../..').replace(process.cwd(), ''))
+
+function getRelativeLibDir(path: string) {
+  // Default level: when the file is located in `docs/pages`
+  let level = 2
+
+  const name = basename(path)
+  const middle = path.replace('/pages/', '').replace(name, '')
+  const middles = middle.split('/').filter((i) => !!i)
+  if (middles.length > 0) level += middles.length
+
+  // e.g. `../../node_modules/vocs/_lib`
+  const levels = new Array(level).fill('..').join('/')
+  return `${levels}${libDir}`
+}
 
 export function resolveVocsModules(): PluginOption {
   let config: ParsedConfig
@@ -15,16 +34,29 @@ export function resolveVocsModules(): PluginOption {
       config = (await resolveVocsConfig()).config
     },
     transform(code_, id) {
+      const resolvedRootDir = resolve(config.rootDir)
+      const resolvedId = resolve(id)
+
       let code = code_
-      if (id.startsWith(resolve(config.rootDir))) {
+      if (resolvedId.startsWith(resolvedRootDir)) {
         if (['.js', '.jsx', '.ts', '.tsx', '.md', '.mdx'].includes(extname(id))) {
+          // The relative path with file name
+          const relative = slash(resolvedId.replace(resolvedRootDir, ''))
+
           code = code.replace(
             /import (.*) from ("|')vocs("|')/g,
-            `import $1 from $2${resolve(__dirname, '../..')}$3`,
+            `import $1 from $2${
+              isWin32 ? getRelativeLibDir(relative) : resolve(__dirname, '../..')
+            }$3`,
           )
+
           code = code.replace(
             /import (.*) from ("|')vocs\/components("|')/g,
-            `import $1 from $2${resolve(__dirname, '../../components')}$3`,
+            `import $1 from $2${
+              isWin32
+                ? `${getRelativeLibDir(relative)}/components`
+                : resolve(__dirname, '../../components')
+            }$3`,
           )
         }
       }

--- a/src/vite/plugins/virtual-routes.ts
+++ b/src/vite/plugins/virtual-routes.ts
@@ -1,4 +1,3 @@
-import { platform } from 'node:os'
 import { extname, resolve } from 'node:path'
 import { globby } from 'globby'
 import type { PluginOption } from 'vite'
@@ -6,6 +5,7 @@ import type { PluginOption } from 'vite'
 import { resolveVocsConfig } from '../utils/resolveVocsConfig.js'
 import { getGitTimestamp } from '../utils/getGitTimestamp.js'
 import { padStartSlash } from '../utils/slash.js'
+import { isWin32 } from '../utils/paths.js'
 
 export function virtualRoutes(): PluginOption {
   const virtualModuleId = 'virtual:routes'
@@ -43,7 +43,7 @@ export function virtualRoutes(): PluginOption {
 
           // On Windows, unable to use full path to file for dynamic import
           // will always prompt that the file cannot be found
-          const componentPath = platform() === 'win32' ? `./${rootDir}/${_path}` : path
+          const componentPath = isWin32 ? `./${rootDir}/${_path}` : path
 
           const type = extname(path).match(/(mdx|md)/) ? 'mdx' : 'jsx'
           const filePath = path.replace(`${pagesPath}/`, '')

--- a/src/vite/plugins/virtual-routes.ts
+++ b/src/vite/plugins/virtual-routes.ts
@@ -4,7 +4,7 @@ import type { PluginOption } from 'vite'
 
 import { resolveVocsConfig } from '../utils/resolveVocsConfig.js'
 import { getGitTimestamp } from '../utils/getGitTimestamp.js'
-import { padStartSlash } from '../utils/slash.js'
+import { padStartSlash, slash } from '../utils/slash.js'
 import { isWin32 } from '../utils/paths.js'
 
 export function virtualRoutes(): PluginOption {
@@ -53,7 +53,7 @@ export function virtualRoutes(): PluginOption {
           let lastUpdatedAt: number | undefined
           if (fileGitTimestamp) lastUpdatedAt = fileGitTimestamp
 
-          let pagePath = path.replace(pagesPath, '').replace(/\.(.*)/, '')
+          let pagePath = slash(path.replace(pagesPath, '').replace(/\.(.*)/, ''))
 
           if (pagePath.endsWith('index'))
             pagePath = pagePath.replace('index', '').replace(/\/$/, '')
@@ -61,7 +61,7 @@ export function virtualRoutes(): PluginOption {
             pagePath,
           )}", type: "${type}", filePath: "${filePath}", lastUpdatedAt: ${lastUpdatedAt} },`
 
-          if (pagePath && !['/', '\\'].includes(pagePath))
+          if (pagePath)
             code += `  { lazy: () => import("${componentPath}"), path: "${padStartSlash(
               pagePath,
             )}.html", type: "${type}", filePath: "${filePath}", lastUpdatedAt: ${lastUpdatedAt} },`

--- a/src/vite/plugins/virtual-styles.ts
+++ b/src/vite/plugins/virtual-styles.ts
@@ -6,6 +6,7 @@ import { type PluginOption } from 'vite'
 
 import type { ParsedConfig, Theme } from '../../config.js'
 import { resolveVocsConfig } from '../utils/resolveVocsConfig.js'
+import { getFsPath } from '../utils/paths.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -41,8 +42,8 @@ export function virtualStyles(): PluginOption {
 
       const { config } = await resolveVocsConfig()
       const { rootDir } = config
-      const themeStyles = resolve(__dirname, '../.vocs/theme.css')
-      const rootStyles = resolve(rootDir, 'styles.css')
+      const themeStyles = getFsPath(resolve(__dirname, '../.vocs/theme.css'))
+      const rootStyles = getFsPath(resolve(rootDir, 'styles.css'))
       let code = ''
       if (existsSync(themeStyles)) code += `import "${themeStyles}";`
       if (existsSync(rootStyles)) code += `import "${rootStyles}";`

--- a/src/vite/utils/paths.ts
+++ b/src/vite/utils/paths.ts
@@ -7,7 +7,7 @@ export function getFsPath(path: string) {
   return `/@fs${padStartSlash(path, false)}`
 }
 
-// Only file and data URLs are supported by the default ESM loader. 
+// Only file and data URLs are supported by the default ESM loader.
 // On Windows, absolute paths must be valid `file://` URLs.
 export function compatibleAbsolutePath(path: string) {
   return isWin32 ? `file://${path}` : path

--- a/src/vite/utils/paths.ts
+++ b/src/vite/utils/paths.ts
@@ -1,4 +1,7 @@
+import { platform } from 'node:os'
 import { padStartSlash } from './slash.js'
+
+export const isWin32 = platform() === 'win32'
 
 export function getFsPath(path: string) {
   return `/@fs${padStartSlash(path, false)}`

--- a/src/vite/utils/paths.ts
+++ b/src/vite/utils/paths.ts
@@ -6,3 +6,9 @@ export const isWin32 = platform() === 'win32'
 export function getFsPath(path: string) {
   return `/@fs${padStartSlash(path, false)}`
 }
+
+// Only file and data URLs are supported by the default ESM loader. 
+// On Windows, absolute paths must be valid `file://` URLs.
+export function compatibleAbsolutePath(path: string) {
+  return isWin32 ? `file://${path}` : path
+}

--- a/src/vite/utils/paths.ts
+++ b/src/vite/utils/paths.ts
@@ -1,0 +1,5 @@
+import { padStartSlash } from './slash.js'
+
+export function getFsPath(path: string) {
+  return `/@fs${padStartSlash(path, false)}`
+}

--- a/src/vite/utils/slash.ts
+++ b/src/vite/utils/slash.ts
@@ -1,3 +1,8 @@
 export function slash(p: string): string {
   return p.replace(/\\/g, '/')
 }
+
+export function padStartSlash(path: string, replaceSlash = true) {
+  const p = replaceSlash ? slash(path) : path
+  return p.startsWith('/') ? p : `/${p}`
+}


### PR DESCRIPTION
Hi, I raised an issue more than a month ago about the program crashes on Windows.

Related issues and this PR will close it #52 .

---

The following is a record of my solution process.

Initially, based on the error log and running normally on my MacBook, I got some key information: This was mainly caused by the inability to read the target files correctly on the Windows platform.

In the past month or so, I have tried to solve this problem several times, but because Bun does not support Windows and the problem only occurs on Windows, there was no effective debugging solution for a long time.

This weekend, I also turned on a Windows machine at home, built the _lib related files on my MacBook, and shared them with Windows via SMB , and overwrote its files in `node_modules` directory. At this point, I finally have a relatively simple and effective solution to debug program running problems.

### Solution process

According to the crash process of the program, I found that there are mainly the following problems:

#### dev service failed to start

In `src/vite/plugins/dev.ts`, `/@fs` —> `/@fs/` is missing a slash, causing the dev service to start crashing. In order to prevent too many or too few slashes, I added a `getFsPath` to supplement the prefix (this method was also used later when solving other crash problems)

#### `virtualStyles` plugin cannot load style files

In `src/vite/plugins/virtual-styles.ts`, the path prefix of `/@fs/` is also missing.

The above two steps solve the crash problem on Windows and also ensure that it can run normally on Mac.

#### Routes data is missing

As of this point, `run dev` works fine on Mac, but `run dev` on Windows only gets a Not Found route.

Printing the `routes` array correctly gets 6 initial routes on Mac, but only 1 on Windows.

To do this, start troubleshooting the routes data provider: `routes_virtual`, located in `src/vite/plugins/virtual-routes.ts`.

The problem here is that in `buildStart`, the Glob pattern matching condition is the complete file path, which will cause Windows to include the backslash `\`, which is not supported.

See: https:/ /github.com/sindresorhus/globby?tab=readme-ov-file#api 

```markdown
Note that glob patterns can only contain forward-slashes, not backward-slashes, so if you want to construct a glob pattern from path components, you need to use path.posix.join() instead of path.join().
```

Therefore, I narrowed the matching scope to only match within the `rootDir` range, and appropriately excluded the `node_modules` and `dist` directories, and successfully obtained the same routing file as the data source on Mac.

#### Component of Route is invalid

The next problem comes. On Windows, an invalid routing component will be prompted because the file path obtained does not support loading through dynamic import.

Therefore, in `src/vite/plugins/virtual-routes.ts`, a componentPath variable is declared for the target of dynamic import. For Windows, a relative path is used to introduce it.

#### The homepage cannot import React components

When we get here, the dev service and routing are normal, but when other routing is normal, an error will be reported on the homepage and components from `vocs/components` cannot be introduced.

The parsing and replacement process of the import path is found in `src/vite/plugins/resolve-vocs-modules.ts`. The relative path is also used to solve the import problem on Windows. See the comment of `getRelativeLibDir`.

At this point, the dev problem has been solved.

#### Pre-rendering failed

When I run `run build`, I get an error saying `on windows, absolute paths must be valid file:// URLs. Received protocol d:`. This problem is solved by using `compatibleAbsolutePath` in `src/vite/prerender.ts`.

At the same time, I have also fixed the problem that after the build is successful, but there will be only empty HTML files under Windows. Pre-rendering is also successful now.

### Remaining problem

Windows currently cannot preview normally under `run preview` under the project, but by copying the build products to an independent Express service, it can be accessed normally. So there should be no big problem with the build product. It may be that there are still problems with the preview service program that need to be fixed.

In addition, there is still a problem with searching on Windows, and the target index cannot be searched.

But for these two problems, I plan to solve them through other PRs to prevent one PR from carrying too many code changes.

### Some previews

Start the dev service on Windows Terminal and it can be used normally.

<img width="1005" alt="image" src="https://github.com/wevm/vocs/assets/24845958/e2f40d60-89c1-4222-8ac6-c7ff251196be">

<img width="1005" alt="image" src="https://github.com/wevm/vocs/assets/24845958/b6701aef-94f2-4610-9328-1f6bde6057ea">

After building, it can get correct pre-rendered results.

<img width="1279" alt="image" src="https://github.com/wevm/vocs/assets/24845958/1ec11f89-6c55-4f9c-bd31-c9aa3d2ab774">

Although it is not possible to directly preview the built product, normal access and routing switching can be achieved through the Express service.

<img width="1172" alt="image" src="https://github.com/wevm/vocs/assets/24845958/6abf6b1e-e8e7-4496-b582-fcc4cad286ef">




