### PR TITLE
Fix  frontmatter parse issue with Colon in  `H1` 

### DIFF
--- a/src/vite/plugins/remark/inferred-frontmatter.ts
+++ b/src/vite/plugins/remark/inferred-frontmatter.ts
@@ -18,7 +18,7 @@ export function remarkInferFrontmatter() {
         const value = child.value
         const [, title, description] = value.includes('[')
           ? value.match(/(.*) \[(.*)\]/) || []
-          : [undefined, value]
+          : [undefined, JSON.stringify(value)]
 
         const frontmatterIndex = parent.children.findIndex((child) => child.type === 'yaml')
         const index = frontmatterIndex > 0 ? frontmatterIndex : 0


### PR DESCRIPTION
Something like this  will throws YAML parse Error, [Here](https://github.com/wevm/vocs/blob/74703506f5d0cfa77f39419c82519f9b984fe608/src/vite/plugins/remark/inferred-frontmatter.ts#L32)
```mdx
---
layout : "landing"
---
# Foo: bar
```

Close  #131  #135 