### PR TITLE
fix: broken outline links with basePath config

### DIFF
--- a/.changeset/wild-poems-film.md
+++ b/.changeset/wild-poems-film.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed outline with basePath config

--- a/src/app/components/Outline.tsx
+++ b/src/app/components/Outline.tsx
@@ -1,5 +1,5 @@
-import { Fragment, type ReactElement, useEffect, useMemo, useRef, useState } from 'react'
-import { useLocation } from 'react-router-dom'
+import { Fragment, useEffect, useMemo, useRef, useState, type ReactElement } from 'react'
+import { Link, useLocation } from 'react-router-dom'
 
 import { useConfig } from '../hooks/useConfig.js'
 import { useLayout } from '../hooks/useLayout.js'
@@ -227,10 +227,9 @@ function Items({
         return (
           <Fragment key={id}>
             <li className={styles.item}>
-              {/* biome-ignore lint/a11y/useValidAnchor: */}
-              <a
+              <Link
                 data-active={isActive}
-                href={`${pathname}${hash}`}
+                to={`${pathname}${hash}`}
                 onClick={() => {
                   onClickItem?.()
                   setActiveId(id)
@@ -238,7 +237,7 @@ function Items({
                 className={styles.link}
               >
                 {text}
-              </a>
+              </Link>
             </li>
             {nextLevelItems && (
               <Items


### PR DESCRIPTION
Addresses #143 

The problem was that the link was created with `useLocation` from `react-router`, but that was used into a `<a>` link.

I think In this case the best possible fix is to use `react-router`'s `<Link />` element, as that is aware of the actual base path.