### PR TITLE
Fix outline urls, remove path from outline links

### DIFF
--- a/src/app/components/Outline.tsx
+++ b/src/app/components/Outline.tsx
@@ -201,8 +201,6 @@ function Items({
   onClickItem?: () => void
   setActiveId: (id: string) => void
 }) {
-  const { pathname } = useLocation()
-
   return (
     <ul className={styles.items}>
       {levelItems.map(({ id, level, text }) => {
@@ -229,7 +227,7 @@ function Items({
             <li className={styles.item}>
               <Link
                 data-active={isActive}
-                to={`${pathname}${hash}`}
+                to={hash}
                 onClick={() => {
                   onClickItem?.()
                   setActiveId(id)


### PR DESCRIPTION
In my current setup the outline section contains links with incorrect path.

Outline section always contains link to headers of current page, so `#fragment` is enough for href and path is not needed.

Fixes #149 