### PR TITLE
Do not add React plugin if it was already provided by the user.

### DIFF
--- a/playgrounds/viem/vocs.config.ts
+++ b/playgrounds/viem/vocs.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from '../../src/index.js'
+import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   sidebar: [
@@ -12,4 +13,10 @@ export default defineConfig({
     },
   ],
   title: 'Viem',
+  vite: {
+    plugins: [
+      // You can customize Vite plugins such as the React plugin here.
+      react(),
+    ]
+  }
 })


### PR DESCRIPTION
I have a number of custom babel plugins that I need to provide to Vite's `react` plugin. Because of how Vocs is set up, I end up with two copies of the React babel plugin (making compilation slower), and two copies of the fast-refresh plugin, which is attempting to define the same global variables.

This PR fixes it by checking if the user provided the React plugin and avoids adding it in those situations.

I added a "test" to one of the playground examples. That example would fail before, and does not fail now.