### PR TITLE
Allow navigable header sections in sidebar w/ link param

### DIFF
--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -181,12 +181,12 @@ function flattenSidebar(sidebar: SidebarItem[]) {
   const items: SidebarItem[] = []
 
   for (const item of sidebar) {
+    if (item.navigable || !item.items) {
+      items.push(item)
+    }
     if (item.items) {
       items.push(...flattenSidebar(item.items))
-      continue
     }
-
-    items.push(item)
   }
 
   return items

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -181,7 +181,7 @@ function flattenSidebar(sidebar: SidebarItem[]) {
   const items: SidebarItem[] = []
 
   for (const item of sidebar) {
-    if (item.navigable || !item.items) {
+    if (item.link) {
       items.push(item)
     }
     if (item.items) {

--- a/src/app/components/Sidebar.css.ts
+++ b/src/app/components/Sidebar.css.ts
@@ -195,6 +195,20 @@ export const sectionTitle = style(
   'sectionTitle',
 )
 
+export const sectionTitleLink = style(
+  {
+    selectors: {
+      '&:hover': {
+        color: primitiveColorVars.text,
+      },
+      '&[data-active="true"]': {
+        color: primitiveColorVars.textAccent,
+      },
+    },
+  },
+  'sectionTitleLink',
+)
+
 export const sectionCollapse = style(
   {
     color: primitiveColorVars.text3,

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -198,8 +198,9 @@ function SidebarItem(props: {
                   data-active={Boolean(match)}
                   onClick={onClick}
                   className={clsx(
-                    depth === 0 ? styles.sectionTitle : styles.item,
-                    depth === 0 && styles.sectionTitleLink,
+                    depth === 0
+                      ? [styles.sectionTitle, styles.sectionTitleLink]
+                      : styles.item,
                     hasActiveChildItem && styles.sectionHeaderActive,
                   )}
                   to={item.link}

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -199,6 +199,7 @@ function SidebarItem(props: {
                   onClick={onClick}
                   className={clsx(
                     depth === 0 ? styles.sectionTitle : styles.item,
+                    depth === 0 && styles.sectionTitleLink,
                     hasActiveChildItem && styles.sectionHeaderActive,
                   )}
                   to={item.link}

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -198,9 +198,7 @@ function SidebarItem(props: {
                   data-active={Boolean(match)}
                   onClick={onClick}
                   className={clsx(
-                    depth === 0
-                      ? [styles.sectionTitle, styles.sectionTitleLink]
-                      : styles.item,
+                    depth === 0 ? [styles.sectionTitle, styles.sectionTitleLink] : styles.item,
                     hasActiveChildItem && styles.sectionHeaderActive,
                   )}
                   to={item.link}

--- a/src/config.ts
+++ b/src/config.ts
@@ -465,6 +465,8 @@ export type SidebarItem = {
   /** Optional pathname to the target documentation page. */
   // TODO: support external links
   link?: string
+  /** Force the item to work with standard page navigation */
+  navigable?: boolean
   /** Optional children to nest under this item. */
   items?: SidebarItem[]
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -465,8 +465,6 @@ export type SidebarItem = {
   /** Optional pathname to the target documentation page. */
   // TODO: support external links
   link?: string
-  /** Force the item to work with standard page navigation */
-  navigable?: boolean
   /** Optional children to nest under this item. */
   items?: SidebarItem[]
 }


### PR DESCRIPTION
Hi, we would like to be able to show the navigation Footer on all section headers, to use those as summary sections. Would it be possible to add a param that makes these pages usable as documentation pages with bottom-of-page navigation? Great docs framework!