### PR TITLE
Fix HomePage logo image

### DIFF
--- a/src/app/components/HomePage.tsx
+++ b/src/app/components/HomePage.tsx
@@ -19,9 +19,7 @@ export function Root({ children, className }: { children: ReactNode; className?:
 export function Logo({ className }: { className?: string }) {
   const { logoUrl, title } = useConfig()
   return logoUrl ? (
-    <div className={clsx(className, styles.logo)}>
-      <Logo_ />
-    </div>
+    <Logo_ className={clsx(className, styles.logo)} />
   ) : (
     <h1 className={clsx(className, styles.title)}>{title}</h1>
   )


### PR DESCRIPTION
- Current issue:
The `HomePage.Logo` component is not rendering the SVG image `https://aptosfoundation.org/brandbook/logotype/SVG/Aptos_Primary_BLK.svg` correctly and displays as zero width.

- Proposed solution:
This PR proposes adopting the approach used in the `NavLogo` component https://github.com/wevm/vocs/blob/deb697a8ad48baa5096f5cb1872cb15a05664107/src/app/components/NavLogo.tsx#L8 which successfully renders the SVG logo.