### PR TITLE
Fix to make chevron icon clickable in Sidebar

### DIFF
--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -142,10 +142,6 @@ function SidebarItem(props: {
     if ('key' in event && event.key !== 'Enter') return
     setCollapsed((x) => !x)
   }, [])
-  const onCollapseTriggerInteraction = useCallback((event: KeyboardEvent | MouseEvent) => {
-    if ('key' in event && event.key !== 'Enter') return
-    setCollapsed((x) => !x)
-  }, [])
 
   const active = useRef(true)
   useEffect(() => {
@@ -208,12 +204,7 @@ function SidebarItem(props: {
               ))}
 
             {isCollapsable && (
-              <div
-                role="button"
-                tabIndex={0}
-                onClick={onCollapseTriggerInteraction}
-                onKeyDown={onCollapseTriggerInteraction}
-              >
+              <div role="button" tabIndex={0}>
                 <Icon
                   className={clsx(
                     styles.sectionCollapse,


### PR DESCRIPTION
Two events were competing resulting in nothing happening when you clicked the actual chevron icon in the menu bar