### PR TITLE
Encode uri for description and title

### DIFF
--- a/src/app/root.tsx
+++ b/src/app/root.tsx
@@ -139,8 +139,8 @@ function Head({ frontmatter }: { frontmatter: Module['frontmatter'] }) {
                 typeof logoUrl === 'string' ? logoUrl : logoUrl?.dark || ''
               }`,
             )
-            .replace('%title', title || '')
-            .replace('%description', (description !== 'undefined' ? description : '') || '')}
+            .replace('%title', encodeURIComponent(title) || '')
+            .replace('%description', (description !== 'undefined' ? encodeURIComponent(description) : '') || '')}
         />
       )}
     </Helmet>


### PR DESCRIPTION
Any special characters break URI encoding for the %title and %description og image replacements.

This `encodeURIComponents` the parameters, and due to the way the parameters are read in the example vocs helper with next.js this should work as expected.