### PR TITLE
fix: folder returns 404 when it contains word `index`

### DIFF
--- a/src/vite/plugins/virtual-routes.ts
+++ b/src/vite/plugins/virtual-routes.ts
@@ -48,7 +48,7 @@ export function virtualRoutes(): PluginOption {
 
           let pagePath = path.replace(replacer, '').replace(/\.(.*)/, '')
           if (pagePath.endsWith('index'))
-            pagePath = pagePath.replace('index', '').replace(/\/$/, '')
+            pagePath = pagePath.replace(/index$/, '').replace(/\/$/, '')
           code += `  { lazy: () => import("${path}"), path: "/${pagePath}", type: "${type}", filePath: "${filePath}", lastUpdatedAt: ${lastUpdatedAt} },`
           if (pagePath)
             code += `  { lazy: () => import("${path}"), path: "/${pagePath}.html", type: "${type}", filePath: "${filePath}", lastUpdatedAt: ${lastUpdatedAt} },`

--- a/src/vite/prerender.ts
+++ b/src/vite/prerender.ts
@@ -66,7 +66,7 @@ function getRoutes(routesDir: string) {
         continue
       }
       const file = path.replace(routesDir, '').replace(/\..*$/, '')
-      routes.push(file.endsWith('/index') ? file.replace('index', '') : file)
+      routes.push(file.endsWith('/index') ? file.replace(/index$/, '') : file)
     }
   }
   recurseRoutes(routesDir)


### PR DESCRIPTION
fixed https://github.com/wevm/vocs/issues/238

- see inline comment for why the fix.
- not an expert on this repo but i followed the pattern in https://github.com/wevm/vocs/commit/05a953e800f9912fcf55ad381dea062c6accd74b , tested locally it works
