### PR TITLE
fix: update 404 link run-a-node.md

### DIFF
--- a/playgrounds/reth/docs/pages/run/run-a-node.md
+++ b/playgrounds/reth/docs/pages/run/run-a-node.md
@@ -12,4 +12,4 @@ In this chapter we'll go through a few different topics you'll encounter when ru
 1. [Ports](./ports.md)
 1. [Troubleshooting](./troubleshooting.md)
 
-In the future, we also intend to support the [OP Stack](https://stack.optimism.io/docs/understand/explainer/), which will allow you to run Reth as a Layer 2 client. More there soon!
+In the future, we also intend to support the [OP Stack](https://docs.optimism.io/superchain/superchain-explainer), which will allow you to run Reth as a Layer 2 client. More there soon!


### PR DESCRIPTION
Hi! I updated an outdated link in `run-a-node.md`:
  - **Old link:** `https://stack.optimism.io/docs/understand/explainer/`  
  - **New link:** `https://docs.optimism.io/superchain/superchain-explainer`  
