### PR TITLE
fix: bump version in CLI

### DIFF
--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -1,1 +1,1 @@
-export const version = '1.0.0-alpha.57'
+export const version = '1.0.0-alpha.62'


### PR DESCRIPTION
Hey all - just making this PR as it was a bit confusing seeing a stale version in the CLI when we run builds. Thanks!