### PR TITLE
Fix the issue where an MDX file contains snippets.

### DIFF
--- a/.changeset/thirty-poems-cheer.md
+++ b/.changeset/thirty-poems-cheer.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed search indexing for files which had code snippets.

--- a/src/vite/utils/search.ts
+++ b/src/vite/utils/search.ts
@@ -11,6 +11,7 @@ import { Fragment } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import * as runtime from 'react/jsx-runtime'
 
+import type { PluggableList } from 'unified'
 import { getRehypePlugins, getRemarkPlugins } from '../plugins/mdx.js'
 import * as cache from './cache.js'
 import { hash } from './hash.js'
@@ -26,6 +27,7 @@ export async function buildIndex({
   baseDir: string
 }) {
   const pagesPaths = await globby(`${resolve(baseDir, 'pages')}/**/*.{md,mdx}`)
+  const rehypePlugins = getRehypePlugins({ rootDir: baseDir, twoslash: false })
 
   const documents = await Promise.all(
     pagesPaths.map((pagePath) =>
@@ -35,7 +37,7 @@ export async function buildIndex({
         const pageCache = cache.search.get(key) ?? {}
         if (pageCache.mdx === mdx) return pageCache.document
 
-        const html = await processMdx(pagePath, mdx)
+        const html = await processMdx({ filePath: pagePath, file: mdx, rehypePlugins })
 
         const sections = splitPageIntoSections(html)
         if (sections.length === 0) {
@@ -91,9 +93,12 @@ export function saveIndex(outDir: string, index: MiniSearch) {
 }
 
 const remarkPlugins = getRemarkPlugins()
-const rehypePlugins = getRehypePlugins({ twoslash: false })
 
-export async function processMdx(filePath: string, file: string) {
+export async function processMdx({
+  filePath,
+  file,
+  rehypePlugins,
+}: { filePath: string; file: string; rehypePlugins: PluggableList }) {
   try {
     const compiled = await compile(file, {
       baseUrl: pathToFileURL(filePath).href,

--- a/src/vite/utils/search.ts
+++ b/src/vite/utils/search.ts
@@ -94,7 +94,11 @@ export function saveIndex(outDir: string, index: MiniSearch) {
 
 const remarkPlugins = getRemarkPlugins()
 
-export async function processMdx(filePath: string, file: string, options: { rehypePlugins: PluggableList }) {
+export async function processMdx(
+  filePath: string,
+  file: string,
+  options: { rehypePlugins: PluggableList },
+) {
   const { rehypePlugins } = options
   try {
     const compiled = await compile(file, {

--- a/src/vite/utils/search.ts
+++ b/src/vite/utils/search.ts
@@ -10,8 +10,8 @@ import pLimit from 'p-limit'
 import { Fragment } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import * as runtime from 'react/jsx-runtime'
-
 import type { PluggableList } from 'unified'
+
 import { getRehypePlugins, getRemarkPlugins } from '../plugins/mdx.js'
 import * as cache from './cache.js'
 import { hash } from './hash.js'
@@ -37,7 +37,7 @@ export async function buildIndex({
         const pageCache = cache.search.get(key) ?? {}
         if (pageCache.mdx === mdx) return pageCache.document
 
-        const html = await processMdx({ filePath: pagePath, file: mdx, rehypePlugins })
+        const html = await processMdx(pagePath, mdx, { rehypePlugins })
 
         const sections = splitPageIntoSections(html)
         if (sections.length === 0) {
@@ -94,11 +94,8 @@ export function saveIndex(outDir: string, index: MiniSearch) {
 
 const remarkPlugins = getRemarkPlugins()
 
-export async function processMdx({
-  filePath,
-  file,
-  rehypePlugins,
-}: { filePath: string; file: string; rehypePlugins: PluggableList }) {
+export async function processMdx(filePath: string, file: string, options: { rehypePlugins: PluggableList }) {
+  const { rehypePlugins } = options
   try {
     const compiled = await compile(file, {
       baseUrl: pathToFileURL(filePath).href,


### PR DESCRIPTION
The following code will prevent the file from being indexed for search:

  ```ts [publicClient.ts]
  // [!include ~/snippets/publicClient.ts:client]
  ```