### PR TITLE
fix: sidebar footer cause horizontal scrollbar to appear

### DIFF
--- a/src/app/components/Sidebar.css.ts
+++ b/src/app/components/Sidebar.css.ts
@@ -141,9 +141,7 @@ export const footer = style(
     bottom: 0,
     backgroundColor: primitiveColorVars.backgroundDark,
     display: 'flex',
-    padding: `${spaceVars['8']} ${sidebarVars.horizontalPadding} ${spaceVars['16']}`,
-    marginLeft: `calc(-1 * ${sidebarVars.horizontalPadding})`,
-    marginRight: `calc(-1 * ${sidebarVars.horizontalPadding})`,
+    padding: `${spaceVars['8']} 0 ${spaceVars['16']}`,
     position: 'sticky',
     '@media': {
       'screen and (max-width: 1080px)': {


### PR DESCRIPTION
it seems the sidebar footer works perfectly fine without the `margin` and `padding`, what was the reason for it to offset negatively using margin and then pull it back to the right position using pading?

see pics:

#### desktop 

![localhost_5173_](https://github.com/user-attachments/assets/aeef7f94-ea08-427c-a620-b50bad67ebb8)

#### mobile

![localhost_5173_ (1)](https://github.com/user-attachments/assets/f7799b28-bb73-41c7-ae6f-00d8543a59be)

https://github.com/wevm/vocs/issues/262