### PR TITLE
feat: Log filename when llms.txt

### DIFF
--- a/src/vite/plugins/llms.ts
+++ b/src/vite/plugins/llms.ts
@@ -73,7 +73,7 @@ export async function llms(): Promise<PluginOption> {
               try {
                 description = toMarkdown(n, { extensions: [mdxJsxToMarkdown()] }).trim()
               } catch(e) {
-                console.error(`Failed to parse markdown file while generating LLM.txt in file ${file}`)
+                console.error(`Failed to parse markdown while generating llms.txt for file ${file}`)
                 throw e
               }
               return

--- a/src/vite/plugins/llms.ts
+++ b/src/vite/plugins/llms.ts
@@ -70,7 +70,12 @@ export async function llms(): Promise<PluginOption> {
               if (found) return
               if (j && i && j <= i) return
               found = true
-              description = toMarkdown(n, { extensions: [mdxJsxToMarkdown()] }).trim()
+              try {
+                description = toMarkdown(n, { extensions: [mdxJsxToMarkdown()] }).trim()
+              } catch(e) {
+                console.error(`Failed to parse markdown file while generating LLM.txt in file ${file}`)
+                throw e
+              }
               return
             })
 


### PR DESCRIPTION
This makes it easier to fix errors when generating llms.txt file by logging filename

```bash
✖ bundles failed to build: [llms] Cannot handle unknown node `mdxTextExpression`
error: script "build:app" exited with code 1
error: script "build" exited with code 1
```