### PR TITLE
fix: sponsors layout in smaller screen

### DIFF
--- a/src/app/components/Sponsors.css.ts
+++ b/src/app/components/Sponsors.css.ts
@@ -47,8 +47,15 @@ export const column = style(
     border: `1px solid ${primitiveColorVars.border}`,
     display: 'flex',
     justifyContent: 'center',
-    padding: spaceVars['32'],
+    paddingBottom: spaceVars['18'],
+    paddingTop: spaceVars['18'],
     width: `calc(${columnsVar} * 100%)`,
+    '@media': {
+      'screen and (max-width: 768px)': {
+        paddingBottom: spaceVars['8'],
+        paddingTop: spaceVars['8'],
+      },
+    },
   },
   'column',
 )
@@ -68,7 +75,13 @@ export const sponsor = style(
 export const image = style(
   {
     filter: 'grayscale(1)',
-    height: heightVar,
+    height: `calc(${heightVar} * 1.2)`,
+    width: '75%',
+    '@media': {
+      'screen and (min-width: 768px)': {
+        padding: spaceVars['8'],
+      },
+    },
     transition: 'filter 0.1s',
     selectors: {
       '.dark &': {


### PR DESCRIPTION
right is before left is after
![image](https://github.com/user-attachments/assets/e3c0d273-bc8d-45fd-9bd3-d212fe005c47)


https://github.com/user-attachments/assets/caf14819-d8fb-4609-831b-81024758ac4d

