### PR TITLE
fix: Support the use of the [!code focus] in jsx syntax #295

### DIFF
--- a/site/pages/docs/api/config.mdx
+++ b/site/pages/docs/api/config.mdx
@@ -288,12 +288,12 @@ import { defineConfig } from 'vocs'
 
 export default defineConfig({
   head: ( // [!code focus]
-    <> // [!code focus]
-      <meta property="og:type" content="website" /> // [!code focus]
-      <meta property="og:title" content="viem · TypeScript Interface for Ethereum" /> // [!code focus]
-      <meta property="og:image" content="https://viem.sh/og-image.png" /> // [!code focus]
-      <meta property="og:url" content="https://viem.sh" /> // [!code focus]
-      <meta property="og:description" content="Build reliable Ethereum apps & libraries with lightweight, composable, & type-safe modules from viem." /> // [!code focus]
+    <> {/* [!code focus] */}
+      <meta property="og:type" content="website" /> {/* [!code focus] */}
+      <meta property="og:title" content="viem · TypeScript Interface for Ethereum" /> {/* [!code focus] */}
+      <meta property="og:image" content="https://viem.sh/og-image.png" /> {/* [!code focus] */}
+      <meta property="og:url" content="https://viem.sh" /> {/* [!code focus] */}
+      <meta property="og:description" content="Build reliable Ethereum apps & libraries with lightweight, composable, & type-safe modules from viem." /> {/* [!code focus] */}
     </> // [!code focus]
   ), // [!code focus]
   title: 'Viem'

--- a/src/vite/plugins/shiki/transformerSplitIdentifiers.ts
+++ b/src/vite/plugins/shiki/transformerSplitIdentifiers.ts
@@ -9,7 +9,7 @@ export const transformerSplitIdentifiers = (): ShikiTransformer => ({
     const child = hast.children[0]
     if (child.type !== 'text') return
     if (child.value.trim().length === 0) return
-    if (child.value.match(/\/\/ \[!/)) return
+    if ([/\/\/ \[!/,/\/\* \[!/].some(reg => child.value.match(reg))) return
 
     let identifier = false
     let item = ''


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/da80216f-4ab9-4e2c-b47a-de6cb71e86bb)

Support the use of the [!code focus] in jsx syntax