### PR TITLE
Fix: Vanilla Extract TS Identifiers

### DIFF
--- a/src/vite/vite.config.ts
+++ b/src/vite/vite.config.ts
@@ -49,7 +49,7 @@ export default defineConfig(async () => {
 
       vanillaExtractPlugin({
         identifiers({ filePath, debugId }) {
-          const scope = basename(filePath).replace('.css.ts', '')
+          const scope = basename(filePath).replace(/\.css\.(js|ts)$/, '')
           const prefix = scope === 'base' ? '' : 'vocs_'
           return `${prefix}${scope}${debugId ? `_${debugId}` : ''}`
         },


### PR DESCRIPTION
I am using my own React component library built with Vanilla Extract in a local, untranspiled TypeScript package, and although it is straightforward to configure the vite config to transpile my local package (using `vite.optimizeDeps.exclude` and `vite.ssr.noExternal`), the vanilla extract plugin still receives the original `*.css.ts` file paths, so I believe those need to be taken into account in the custom identifiers function.