### PR TITLE
fix: prevent dev server crashes during HMR updates

### DIFF
--- a/src/vite/plugins/virtual-config.ts
+++ b/src/vite/plugins/virtual-config.ts
@@ -1,24 +1,73 @@
-import type { PluginOption } from 'vite'
+import { createLogger, type PluginOption } from 'vite'
 
 import { deserializeFunctionsStringified, serializeConfig } from '../../config.js'
-import { resolveVocsConfig } from '../utils/resolveVocsConfig.js'
+import { clearConfigCache, resolveVocsConfig } from '../utils/resolveVocsConfig.js'
+
+const logger = createLogger()
 
 export function virtualConfig(): PluginOption {
   const virtualModuleId = 'virtual:config'
   const resolvedVirtualModuleId = `\0${virtualModuleId}`
 
+  let configPath: string | undefined
+  let debounceTimer: NodeJS.Timeout | undefined
+  let cleanupHandlers: Array<() => void> = []
+
   return {
     name: 'vocs-config',
     async configureServer(server) {
-      const { configPath } = await resolveVocsConfig()
+      const resolved = await resolveVocsConfig()
+      configPath = resolved.configPath
+
       if (configPath) {
         server.watcher.add(configPath)
-        server.watcher.on('change', async (path) => {
+
+        const changeHandler = async (path: string) => {
           if (path !== configPath) return
-          try {
-            const { config } = await resolveVocsConfig()
-            server.ws.send('vocs:config', config)
-          } catch {}
+
+          if (debounceTimer) clearTimeout(debounceTimer)
+
+          // debounce config changes to handle rapid edits
+          debounceTimer = setTimeout(async () => {
+            try {
+              clearConfigCache()
+
+              const { config } = await resolveVocsConfig()
+              const mod = server.moduleGraph.getModuleById(resolvedVirtualModuleId)
+              if (mod) {
+                server.moduleGraph.invalidateModule(mod)
+              }
+
+              server.ws.send('vocs:config', config)
+
+              logger.info('Config updated successfully', { timestamp: true })
+            } catch (error) {
+              const err = error instanceof Error ? error : new Error(String(error))
+
+              server.ws.send({
+                type: 'error',
+                err: {
+                  message: `Vocs config error: ${err.message}`,
+                  stack: err.stack || '',
+                  plugin: 'vocs-config',
+                },
+              })
+            }
+          }, 100)
+        }
+
+        server.watcher.on('change', changeHandler)
+
+        cleanupHandlers.push(() => {
+          server.watcher.off('change', changeHandler)
+          if (debounceTimer) clearTimeout(debounceTimer)
+        })
+
+        server.httpServer?.on('close', () => {
+          cleanupHandlers.forEach((cleanup) => {
+            cleanup()
+          })
+          cleanupHandlers = []
         })
       }
     },
@@ -36,9 +85,26 @@ export function virtualConfig(): PluginOption {
       }
       return
     },
-    handleHotUpdate() {
-      // TODO: handle changes
+    async handleHotUpdate({ server, file }) {
+      if (file !== configPath) return
+
+      clearConfigCache()
+
+      // invalidate virtual mod
+      const mod = server.moduleGraph.getModuleById(resolvedVirtualModuleId)
+      if (mod) {
+        server.moduleGraph.invalidateModule(mod)
+        return [mod]
+      }
+
       return
+    },
+    buildEnd() {
+      cleanupHandlers.forEach((cleanup) => {
+        cleanup()
+      })
+      cleanupHandlers = []
+      if (debounceTimer) clearTimeout(debounceTimer)
     },
   }
 }

--- a/src/vite/utils/resolveVocsConfig.ts
+++ b/src/vite/utils/resolveVocsConfig.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import toml from 'toml'
-import { type ConfigEnv, loadConfigFromFile } from 'vite'
+import { type ConfigEnv, createLogger, loadConfigFromFile } from 'vite'
 import { defineConfig, getDefaultConfig, type ParsedConfig } from '../../config.js'
 
 const moduleExtensions = ['js', 'jsx', 'ts', 'tsx', 'mjs', 'mts']
@@ -9,10 +9,28 @@ const staticExtensions = ['toml', 'json']
 const extensions = [...moduleExtensions, ...staticExtensions]
 const defaultConfigPaths = ['.vocs/config', 'vocs.config', 'Vocs']
 
+const logger = createLogger()
+
 type ResolveVocsConfigParameters = {
   command?: ConfigEnv['command']
   configPath?: string
   mode?: ConfigEnv['mode']
+}
+
+let configCache: {
+  config: ParsedConfig
+  configPath: string | undefined
+  timestamp: number
+} | null = null
+
+let errorCache: {
+  message: string
+  timestamp: number
+} | null = null
+
+export function clearConfigCache() {
+  configCache = null
+  errorCache = null
 }
 
 export async function resolveVocsConfig(parameters: ResolveVocsConfigParameters = {}) {
@@ -20,7 +38,7 @@ export async function resolveVocsConfig(parameters: ResolveVocsConfigParameters 
 
   const [configPath, ext] = (() => {
     for (const ext of extensions) {
-      if (parameters.configPath) return parameters.configPath
+      if (parameters.configPath) return [parameters.configPath, ext]
       for (const filePath of defaultConfigPaths)
         if (existsSync(resolve(process.cwd(), `${filePath}.${ext}`)))
           return [`${filePath}.${ext}`, ext]
@@ -28,32 +46,92 @@ export async function resolveVocsConfig(parameters: ResolveVocsConfigParameters 
     return [undefined, undefined]
   })()
 
-  const result = await (async () => {
-    if (!ext) return
+  // if we recently failed to load this config, return cached result immediately
+  // to avoid spamming the console with repeated errors from multiple plugins
+  const now = Date.now()
+  if (errorCache && errorCache.timestamp > now - 500) {
+    if (configCache) {
+      return {
+        config: configCache.config,
+        configPath: configCache.configPath,
+      }
+    }
+    // return default config without logging again
+    const config = await getDefaultConfig()
+    return {
+      config,
+      configPath,
+    }
+  }
 
-    if (moduleExtensions.includes(ext))
-      return await loadConfigFromFile({ command, mode }, configPath)
+  try {
+    const result = await (async () => {
+      if (!ext) return
 
-    if (staticExtensions.includes(ext)) {
-      const file = readFileSync(configPath, 'utf8')
-      const rawConfig = (() => {
-        if (ext === 'toml') return camelCaseKeys(toml.parse(file))
-        if (ext === 'json') return JSON.parse(file)
-        return
-      })()
+      if (moduleExtensions.includes(ext))
+        return await loadConfigFromFile({ command, mode }, configPath)
 
-      const config = await defineConfig(rawConfig)
-      return config ? { config } : undefined
+      if (staticExtensions.includes(ext)) {
+        if (!existsSync(configPath)) throw new Error(`Config file not found: ${configPath}`)
+
+        const file = readFileSync(configPath, 'utf8')
+        const rawConfig = (() => {
+          if (ext === 'toml') return camelCaseKeys(toml.parse(file))
+          if (ext === 'json') return JSON.parse(file)
+          return
+        })()
+
+        const config = await defineConfig(rawConfig)
+        return config ? { config } : undefined
+      }
+
+      return
+    })()
+
+    const config = (result ? result.config : await getDefaultConfig()) as ParsedConfig
+
+    configCache = {
+      config,
+      configPath,
+      timestamp: Date.now(),
     }
 
-    return
-  })()
+    return {
+      config,
+      configPath,
+    }
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error))
+    const now = Date.now()
 
-  const config = (result ? result.config : await getDefaultConfig()) as ParsedConfig
+    const shouldLog =
+      !errorCache || errorCache.message !== err.message || errorCache.timestamp < now - 1_000
 
-  return {
-    config,
-    configPath,
+    if (shouldLog) {
+      logger.error(`Failed to load Vocs config${configPath ? ` from ${configPath}` : ''}:`, {
+        error: err,
+        timestamp: true,
+      })
+      errorCache = {
+        message: err.message,
+        timestamp: now,
+      }
+    }
+
+    // if we have a cached config, return it to keep the server running
+    if (configCache) {
+      return {
+        config: configCache.config,
+        configPath: configCache.configPath,
+      }
+    }
+
+    // fall back to default config if no cache available
+    const config = await getDefaultConfig()
+    return {
+      config,
+      configPath,
+    }
   }
 }
 


### PR DESCRIPTION
ensures the dev server always continues running with cached config when file edits errors occur, without crashing and killing the process. This handles live edits to config files too.

changes:
- implement `handleHotUpdate` in `virtual-config`, `virtual-routes`, `virtual-blog`
- add error boundaries to all HMR handlers
- replace `server.restart()` with `moduleGraph.invalidateModule()`
- add config caching with fallback to last-known-good config
- add debouncing and error deduplication
- add event handler cleanup