### PR TITLE
feat: Add pointer to llms.txt in outline

### DIFF
--- a/src/app/components/LlmLink.tsx
+++ b/src/app/components/LlmLink.tsx
@@ -1,0 +1,21 @@
+import { useConfig } from '../hooks/useConfig.js'
+import { Link } from './Link.js'
+
+export function LlmLink() {
+  const { baseUrl, llmLink } = useConfig()
+
+  if (!llmLink) return null
+
+  const url = typeof llmLink === 'object' ? (llmLink.url ?? '/llms.txt') : '/llms.txt'
+  const text = typeof llmLink === 'object' ? (llmLink.text ?? 'llms.txt') : 'llms.txt'
+
+  const finalUrl = baseUrl ? `${baseUrl}${url}` : url
+
+  return (
+    <div>
+      <Link href={finalUrl} variant="styleless">
+        {text}
+      </Link>
+    </div>
+  )
+}

--- a/src/app/components/Outline.tsx
+++ b/src/app/components/Outline.tsx
@@ -31,9 +31,9 @@ export function Outline({
   onClickItem?: () => void
   showTitle?: boolean
 } = {}) {
-  const { outlineFooter, llmLink } = useConfig()
+  const { outlineFooter } = useConfig()
 
-  const { showOutline, showAiCta } = useLayout()
+  const { showOutline, showAiCta, showLlmLink } = useLayout()
   const maxLevel = (() => {
     if (typeof showOutline === 'number') return minLevel + showOutline - 1
     return maxLevel_
@@ -167,13 +167,13 @@ export function Outline({
   const hasItems = items.length > 0
 
   // If there are no items and no AI CTA and no LLM link, don't render anything
-  if (!hasItems && !showAiCta && !llmLink) return null
+  if (!hasItems && !showAiCta && !showLlmLink) return null
 
   const levelItems = hasItems ? items.filter((item) => item.level === minLevel) : []
   return (
     <aside className={styles.root}>
       {showAiCta && <AiCtaDropdown />}
-      {llmLink && <LlmLink />}
+      {showLlmLink && <LlmLink />}
       {hasItems && (
         <nav className={styles.nav}>
           {showTitle && <h2 className={styles.heading}>On this page</h2>}

--- a/src/app/components/Outline.tsx
+++ b/src/app/components/Outline.tsx
@@ -6,6 +6,7 @@ import { useLayout } from '../hooks/useLayout.js'
 import { debounce } from '../utils/debounce.js'
 import { deserializeElement } from '../utils/deserializeElement.js'
 import { AiCtaDropdown } from './AiCtaDropdown.js'
+import { LlmLink } from './LlmLink.js'
 import { root as Heading, slugTarget } from './mdx/Heading.css.js'
 import * as styles from './Outline.css.js'
 
@@ -30,7 +31,7 @@ export function Outline({
   onClickItem?: () => void
   showTitle?: boolean
 } = {}) {
-  const { outlineFooter } = useConfig()
+  const { outlineFooter, llmLink } = useConfig()
 
   const { showOutline, showAiCta } = useLayout()
   const maxLevel = (() => {
@@ -165,13 +166,14 @@ export function Outline({
 
   const hasItems = items.length > 0
 
-  // If there are no items and no AI CTA, don't render anything
-  if (!hasItems && !showAiCta) return null
+  // If there are no items and no AI CTA and no LLM link, don't render anything
+  if (!hasItems && !showAiCta && !llmLink) return null
 
   const levelItems = hasItems ? items.filter((item) => item.level === minLevel) : []
   return (
     <aside className={styles.root}>
       {showAiCta && <AiCtaDropdown />}
+      {llmLink && <LlmLink />}
       {hasItems && (
         <nav className={styles.nav}>
           {showTitle && <h2 className={styles.heading}>On this page</h2>}

--- a/src/app/hooks/useLayout.tsx
+++ b/src/app/hooks/useLayout.tsx
@@ -11,6 +11,7 @@ export function useLayout(): Layout {
     layout: layout_,
     showLogo,
     showAiCta,
+    showLlmLink,
     showOutline,
     showSidebar,
     showTopNav,
@@ -27,6 +28,11 @@ export function useLayout(): Layout {
     get showAiCta() {
       if (typeof showAiCta !== 'undefined') return showAiCta
       if (aiCta === false) return false
+      return layout === 'docs'
+    },
+    get showLlmLink() {
+      if (typeof showLlmLink !== 'undefined') return showLlmLink
+      if (showLlmLink === false) return false
       return layout === 'docs'
     },
     get showOutline() {

--- a/src/app/hooks/usePageData.ts
+++ b/src/app/hooks/usePageData.ts
@@ -8,6 +8,7 @@ export type PageData = {
   frontmatter: Module['frontmatter']
   lastUpdatedAt?: number
   previousPath?: string
+  showLlmLink?: boolean
 }
 
 export function usePageData() {

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -24,7 +24,8 @@ export type Frontmatter = {
 
 export type Layout = {
   layout: 'docs' | 'landing' | 'minimal'
-  showAiCta: boolean
+  showAiCta?: boolean
+  showLlmLink?: boolean
   showLogo: boolean
   showOutline: number | boolean
   showSidebar: boolean

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,24 @@ export type Config<
           query: (p: { location: string }) => string
         }
     /**
+     * Whether or not to show the LLM link in the outline (ie. "LLM? Read llms.txt"),
+     * as well as any configuration.
+     */
+    llmLink?:
+      | boolean
+      | {
+          /**
+           * Custom URL for the LLM link.
+           * @default "/llms.txt"
+           */
+          url?: string
+          /**
+           * Custom text for the link.
+           * @default "llms.txt"
+           */
+          text?: string
+        }
+    /**
      * Configuration for the banner fixed to the top of the page.
      *
      * Can be a Markdown string, a React Element, or an object with the following properties:
@@ -203,6 +221,7 @@ export async function defineConfig<colorScheme extends ColorScheme = undefined>(
   cacheDir,
   checkDeadlinks = true,
   head,
+  llmLink = true,
   ogImageUrl,
   rootDir = 'docs',
   title = 'Docs',
@@ -216,6 +235,7 @@ export async function defineConfig<colorScheme extends ColorScheme = undefined>(
     cacheDir,
     checkDeadlinks,
     head,
+    llmLink,
     ogImageUrl,
     rootDir,
     title,


### PR DESCRIPTION
### Motivation
Developers increasingly use LLMs and coding agents to help build projects using documentation sites.

Observation: LLMs and coding agents vary in whether they'll naturally discover an llms.txt file. Some agents only look at page content and don't search for an llms.txt on the site unless prompted. Additionally, the page fetch tools that agents use generally parse HTML → markdown; headers, navigation, and other structural elements are often dropped in this process.

Hypothesis: Models that are aware of an llms.txt file (effectively a sitemap optimized for LLMs) and retrieve it have a higher likelihood of successfully completing tasks. Hence, we should have an explicit pointer to llms.txt for agent discovery. It's also useful for developers to know it exists so they can leverage it when building with LLM assistance.

### Change
Adds a pointer to llms.txt in the outline. Based on a new config variable `llmLink` that defaults to `true`

### Test
Tested with `playgrounds/custom-layout` no changes to the config
<img width="2468" height="1766" alt="CleanShot 2025-12-18 at 19 36 59@2x" src="https://github.com/user-attachments/assets/21b656fc-f80b-4749-b1c9-174554e76255" />
