### PR TITLE
fix(vite): resolve tailwind hmr for mdx files

### DIFF
--- a/.changeset/fix-tailwind-hmr.md
+++ b/.changeset/fix-tailwind-hmr.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed Tailwind HMR not working for MDX files by correcting Vite root handling and adding a custom HMR plugin.

--- a/src/vite/devServer.ts
+++ b/src/vite/devServer.ts
@@ -19,10 +19,13 @@ export async function createDevServer(params: CreateDevServerParameters = {}) {
   return createServer({
     configFile: resolve(import.meta.dirname, './vite.config.ts'),
     envDir: cwd(),
-    root: import.meta.dirname,
+    root: cwd(),
     server: {
       host: params.host,
       port: params.port,
+      fs: {
+        allow: [process.cwd(), resolve(import.meta.dirname, '../../')],
+      },
     },
     plugins: [dev()],
   })

--- a/src/vite/plugins/tailwind-hmr.ts
+++ b/src/vite/plugins/tailwind-hmr.ts
@@ -1,0 +1,33 @@
+import type { Plugin } from 'vite'
+
+export function tailwindHmr(): Plugin {
+  return {
+    name: 'vocs-tailwind-hmr',
+    configureServer(server) {
+      server.watcher.on('change', async (file) => {
+        if (!file.endsWith('.mdx')) return
+
+        const keys = [...server.moduleGraph.idToModuleMap.keys()]
+        const relationId = keys.find((id) => id.includes('styles.css'))
+
+        if (relationId) {
+          const relationModule = server.moduleGraph.getModuleById(relationId)
+          if (relationModule) {
+            server.moduleGraph.invalidateModule(relationModule)
+            server.ws.send({
+              type: 'update',
+              updates: [
+                {
+                  type: 'js-update',
+                  timestamp: Date.now(),
+                  path: relationModule.url,
+                  acceptedPath: relationModule.url,
+                },
+              ],
+            })
+          }
+        }
+      })
+    },
+  }
+}

--- a/src/vite/vite.config.ts
+++ b/src/vite/vite.config.ts
@@ -11,6 +11,7 @@ import { mdx } from './plugins/mdx.js'
 import { resolveVocsModules } from './plugins/resolve-vocs-modules.js'
 import { search } from './plugins/search.js'
 import { splitVendorChunkPlugin } from './plugins/splitVendorChunk.js'
+import { tailwindHmr } from './plugins/tailwind-hmr.js'
 import { virtualBlog } from './plugins/virtual-blog.js'
 import { virtualConfig } from './plugins/virtual-config.js'
 import { virtualConsumerComponents } from './plugins/virtual-consumer-components.js'
@@ -57,6 +58,7 @@ export default defineConfig(async () => {
           return `${prefix}${scope}${debugId ? `_${debugId}` : ''}`
         },
       }),
+      tailwindHmr(),
       css(),
       llms(),
       mdx(),


### PR DESCRIPTION
## Description
Fixes #364

Resolves an issue where Tailwind CSS styles didn't update in [.mdx](cci:7://file://open/vocs/playgrounds/tailwind/docs/pages/index.mdx:0:0-0:0) files without a manual refresh.

## Changes
-   **Fixed Root & Scanning**: Pointed Vite to the correct project root so Tailwind detects changes in user files.
-   **Fixed HMR**: Added a plugin that automatically updates CSS when [.mdx](cci:7://file://open/vocs/playgrounds/tailwind/docs/pages/index.mdx:0:0-0:0) files change, giving instant feedback without reloading the page.
-   **Fixed Permissions**: Allowed Vite to serve internal library files to prevent errors.

## Verification
-   Verified that changing Tailwind classes in MDX now updates instantly.
-   Confirmed no page reload is needed.
-   Added changeset.