### PR TITLE
fix: tab list overflow

### DIFF
--- a/src/app/components/Tabs.css.ts
+++ b/src/app/components/Tabs.css.ts
@@ -23,6 +23,7 @@ export const list = style(
     borderTopRightRadius: borderRadiusVars['4'],
     display: 'flex',
     padding: `${spaceVars['0']} ${spaceVars['14']}`,
+    overflowX: 'auto',
     '@media': {
       [viewportVars['max-720px']]: {
         borderRadius: 0,


### PR DESCRIPTION
Fixes tab list horizontal overflow.
This happens quickly when you have multiple tabs and are viewing the page from mobile.