### PR TITLE
feat: support config as callback with env context

### DIFF
--- a/.changeset/deep-stars-wonder.md
+++ b/.changeset/deep-stars-wonder.md
@@ -1,0 +1,5 @@
+---
+"vocs": minor
+---
+
+feat: support config as callback with env context

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import type { PluggableList } from 'unified'
 import type { ConfigEnv, UserConfig } from 'vite'
 
 export type VocsConfigEnv = Pick<ConfigEnv, 'mode' | 'command' | 'isPreview'>
+
 import type { PageData } from './app/hooks/usePageData.js'
 import type {
   borderRadiusVars,

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,9 @@ import type { SearchOptions } from 'minisearch'
 import type { ReactElement } from 'react'
 import type { TwoslashOptions } from 'twoslash'
 import type { PluggableList } from 'unified'
-import type { UserConfig } from 'vite'
+import type { ConfigEnv, UserConfig } from 'vite'
+
+export type VocsConfigEnv = Pick<ConfigEnv, 'mode' | 'command' | 'isPreview'>
 import type { PageData } from './app/hooks/usePageData.js'
 import type {
   borderRadiusVars,
@@ -203,19 +205,53 @@ export type Config<
 >
 
 export type ParsedConfig = Config<true>
+export type VocsConfig = Config<false>
 
-export async function defineConfig<colorScheme extends ColorScheme = undefined>({
-  aiCta = true,
-  blogDir = './pages/blog',
-  cacheDir,
-  checkDeadlinks = true,
-  head,
-  ogImageUrl,
-  rootDir = 'docs',
-  title = 'Docs',
-  titleTemplate = `%s – ${title}`,
-  ...config
-}: Config<false, colorScheme>): Promise<ParsedConfig> {
+export type VocsConfigFnObject = (env: VocsConfigEnv) => VocsConfig
+export type VocsConfigFnPromise = (env: VocsConfigEnv) => Promise<VocsConfig>
+export type VocsConfigFn = (env: VocsConfigEnv) => VocsConfig | Promise<VocsConfig>
+
+export type VocsConfigExport<colorScheme extends ColorScheme = ColorScheme> =
+  | Config<false, colorScheme>
+  | Promise<Config<false, colorScheme>>
+  | VocsConfigFn
+
+// Callback overloads first (no generic, better env inference)
+export function defineConfig(config: VocsConfigFnObject): VocsConfigFnObject
+export function defineConfig(config: VocsConfigFnPromise): VocsConfigFnPromise
+// Object overloads (with generic for colorScheme type safety)
+export function defineConfig<colorScheme extends ColorScheme = undefined>(
+  config: Config<false, colorScheme>,
+): Config<false, colorScheme>
+export function defineConfig<colorScheme extends ColorScheme = undefined>(
+  config: Promise<Config<false, colorScheme>>,
+): Promise<Config<false, colorScheme>>
+// Catch-all
+export function defineConfig(config: VocsConfigExport): VocsConfigExport
+export function defineConfig(config: VocsConfigExport): VocsConfigExport {
+  return config
+}
+
+export async function resolveConfig(
+  configExport: VocsConfigExport,
+  env: VocsConfigEnv = { command: 'serve', mode: 'development' },
+): Promise<ParsedConfig> {
+  const rawConfig =
+    typeof configExport === 'function' ? await configExport(env) : await configExport
+
+  const {
+    aiCta = true,
+    blogDir = './pages/blog',
+    cacheDir,
+    checkDeadlinks = true,
+    head,
+    ogImageUrl,
+    rootDir = 'docs',
+    title = 'Docs',
+    titleTemplate = `%s – ${title}`,
+    ...config
+  } = rawConfig
+
   const basePath = parseBasePath(config.basePath)
   return {
     aiCta,
@@ -241,13 +277,11 @@ export async function defineConfig<colorScheme extends ColorScheme = undefined>(
     socials: parseSocials(config.socials ?? []),
     topNav: parseTopNav(config.topNav ?? []),
     theme: await parseTheme(config.theme ?? ({} as Theme)),
-    vite: parseViteConfig(config.vite, {
-      basePath,
-    }),
+    vite: parseViteConfig(config.vite, { basePath }),
   }
 }
 
-export const getDefaultConfig = async () => await defineConfig({})
+export const getDefaultConfig = async (env?: VocsConfigEnv) => await resolveConfig({}, env)
 
 //////////////////////////////////////////////////////
 // Parsers

--- a/src/vite/build.ts
+++ b/src/vite/build.ts
@@ -36,7 +36,7 @@ export async function build({
   publicDir = 'public',
   searchIndex = true,
 }: BuildParameters = {}) {
-  const { config } = await resolveVocsConfig()
+  const { config } = await resolveVocsConfig({ command: 'build', mode: 'production' })
   const { rootDir, cacheDir } = config
 
   const outDir_resolved = resolveOutDir(rootDir, outDir)

--- a/src/vite/preview.ts
+++ b/src/vite/preview.ts
@@ -11,7 +11,7 @@ type PreviewParameters = {
 }
 
 export async function preview({ outDir = 'dist' }: PreviewParameters = {}) {
-  const { config } = await resolveVocsConfig()
+  const { config } = await resolveVocsConfig({ mode: 'production', isPreview: true })
   const { basePath, rootDir } = config
 
   const app = new Hono()

--- a/src/vite/utils/resolveVocsConfig.ts
+++ b/src/vite/utils/resolveVocsConfig.ts
@@ -35,8 +35,7 @@ export async function resolveVocsConfig(parameters: ResolveVocsConfigParameters 
   const result = await (async () => {
     if (!ext) return
 
-    if (moduleExtensions.includes(ext)) 
-      return await loadConfigFromFile(env, configPath)
+    if (moduleExtensions.includes(ext)) return await loadConfigFromFile(env, configPath)
 
     if (staticExtensions.includes(ext)) {
       const file = readFileSync(configPath, 'utf8')

--- a/src/vite/utils/resolveVocsConfig.ts
+++ b/src/vite/utils/resolveVocsConfig.ts
@@ -45,14 +45,15 @@ export async function resolveVocsConfig(parameters: ResolveVocsConfigParameters 
         return
       })()
 
-      const config = await resolveConfig(rawConfig, env)
-      return config ? { config } : undefined
+      return rawConfig ? { config: rawConfig } : undefined
     }
 
     return
   })()
 
-  const config = (result ? result.config : await getDefaultConfig(env)) as ParsedConfig
+  const config = (
+    result ? await resolveConfig(result.config, env) : await getDefaultConfig(env)
+  ) as ParsedConfig
 
   return {
     config,

--- a/src/vite/utils/resolveVocsConfig.ts
+++ b/src/vite/utils/resolveVocsConfig.ts
@@ -1,22 +1,26 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import toml from 'toml'
-import { type ConfigEnv, loadConfigFromFile } from 'vite'
-import { defineConfig, getDefaultConfig, type ParsedConfig } from '../../config.js'
+import { loadConfigFromFile } from 'vite'
+import {
+  getDefaultConfig,
+  type ParsedConfig,
+  resolveConfig,
+  type VocsConfigEnv,
+} from '../../config.js'
 
 const moduleExtensions = ['js', 'jsx', 'ts', 'tsx', 'mjs', 'mts']
 const staticExtensions = ['toml', 'json']
 const extensions = [...moduleExtensions, ...staticExtensions]
 const defaultConfigPaths = ['.vocs/config', 'vocs.config', 'Vocs']
 
-type ResolveVocsConfigParameters = {
-  command?: ConfigEnv['command']
+type ResolveVocsConfigParameters = Partial<VocsConfigEnv> & {
   configPath?: string
-  mode?: ConfigEnv['mode']
 }
 
 export async function resolveVocsConfig(parameters: ResolveVocsConfigParameters = {}) {
-  const { command = 'serve', mode = 'development' } = parameters
+  const { command = 'serve', mode = 'development', isPreview = false } = parameters
+  const env: VocsConfigEnv = { command, mode, isPreview }
 
   const [configPath, ext] = (() => {
     for (const ext of extensions) {
@@ -31,8 +35,8 @@ export async function resolveVocsConfig(parameters: ResolveVocsConfigParameters 
   const result = await (async () => {
     if (!ext) return
 
-    if (moduleExtensions.includes(ext))
-      return await loadConfigFromFile({ command, mode }, configPath)
+    if (moduleExtensions.includes(ext)) 
+      return await loadConfigFromFile(env, configPath)
 
     if (staticExtensions.includes(ext)) {
       const file = readFileSync(configPath, 'utf8')
@@ -42,14 +46,14 @@ export async function resolveVocsConfig(parameters: ResolveVocsConfigParameters 
         return
       })()
 
-      const config = await defineConfig(rawConfig)
+      const config = await resolveConfig(rawConfig, env)
       return config ? { config } : undefined
     }
 
     return
   })()
 
-  const config = (result ? result.config : await getDefaultConfig()) as ParsedConfig
+  const config = (result ? result.config : await getDefaultConfig(env)) as ParsedConfig
 
   return {
     config,

--- a/src/vite/vite.config.ts
+++ b/src/vite/vite.config.ts
@@ -18,8 +18,8 @@ import { virtualRoutes } from './plugins/virtual-routes.js'
 import { virtualStyles } from './plugins/virtual-styles.js'
 import { resolveVocsConfig } from './utils/resolveVocsConfig.js'
 
-export default defineConfig(async () => {
-  const { config } = await resolveVocsConfig()
+export default defineConfig(async (env) => {
+  const { config } = await resolveVocsConfig(env)
   const viteConfig = config.vite ?? {}
   const hasReact = await hasReactPlugin(viteConfig.plugins ?? [])
 


### PR DESCRIPTION
## Description 

Add callback-style config support.

## Changes

### 1. Pass env from `vite.config.ts` to `resolveVocsConfig()`
Before: env was not passed, always defaulted to `{ command: 'serve', mode: 'development' }`

After: Vite's `ConfigEnv` is forwarded properly (except `isSsrBuild` - I guess it's not needed for `vocs`?)

### 2.  Separate `defineConfig` / `resolveConfig`
`defineConfig`: Type helper passthrough:
- Supports env inference for callback usage
- Trade-off: callback overloads take priority, so `colorScheme` generic only works for object form
   
`resolveConfig`: Resolves callback/object and parses config:
- Called by `resolveVocsConfig` when loading user config
- Referenced Vite's approach: [`defineConfig`](https://github.com/vitejs/vite/blob/964c718a382ff46ec1f906d7d6bc3f135a6dcd3f/packages/vite/src/node/config.ts#L170), [`resolveConfig`](https://github.com/vitejs/vite/blob/964c718a382ff46ec1f906d7d6bc3f135a6dcd3f/packages/vite/src/node/config.ts#L1316)


Since `defineConfig` is now a passthrough (lazy), parsing happens in `resolveVocsConfig` via `resolveConfig`.

## Usage


Better support monorepo with tsconfig `customConditions` resolving exports.source  in dev mode:

```ts
export default defineConfig(({ mode }) => ({
  vite: {
    resolve: {
      ...(mode === 'development' && {
        conditions: ['source', 'module', 'browser', 'default'],
      }),
    },
  },
}))
```
(This is actually why I opened this PR)