### PR TITLE
fix: key badge sizing

### DIFF
--- a/src/react/internal/AskAi.tsx
+++ b/src/react/internal/AskAi.tsx
@@ -106,10 +106,10 @@ export function AskAi(props: AskAi.Props) {
       >
         <div className="vocs:flex vocs:items-center vocs:gap-2">Ask AI...</div>
         <div className="vocs:flex vocs:items-center vocs:gap-0.5">
-          <div className="vocs:bg-primary vocs:text-xs vocs:flex vocs:items-center vocs:justify-center vocs:size-5 vocs:border vocs:border-primary vocs:rounded-sm">
+          <div className="vocs:bg-primary vocs:text-xs vocs:flex vocs:items-center vocs:justify-center vocs:h-5 vocs:w-auto vocs:px-0.75 vocs:border vocs:border-primary vocs:rounded-sm">
             {modifierKey}
           </div>
-          <div className="vocs:bg-primary vocs:text-xs vocs:flex vocs:items-center vocs:justify-center vocs:size-5 vocs:border vocs:border-primary vocs:rounded-sm">
+          <div className="vocs:bg-primary vocs:text-xs vocs:flex vocs:items-center vocs:justify-center vocs:h-5 vocs:w-auto vocs:px-0.75 vocs:border vocs:border-primary vocs:rounded-sm">
             I
           </div>
         </div>

--- a/src/react/internal/DialogTrigger.tsx
+++ b/src/react/internal/DialogTrigger.tsx
@@ -29,10 +29,10 @@ export const DialogTrigger = React.forwardRef<HTMLButtonElement, DialogTrigger.P
           {children}
         </div>
         <div className="vocs:flex vocs:items-center vocs:gap-0.5">
-          <div className="vocs:bg-primary vocs:text-xs vocs:flex vocs:items-center vocs:justify-center vocs:size-5 vocs:border vocs:border-primary vocs:rounded-sm">
+          <div className="vocs:bg-primary vocs:text-xs vocs:flex vocs:items-center vocs:justify-center vocs:h-5 vocs:w-auto vocs:px-0.75 vocs:border vocs:border-primary vocs:rounded-sm">
             {modifierKey}
           </div>{' '}
-          <div className="vocs:bg-primary vocs:text-xs vocs:flex vocs:items-center vocs:justify-center vocs:size-5 vocs:border vocs:border-primary vocs:rounded-sm">
+          <div className="vocs:bg-primary vocs:text-xs vocs:flex vocs:items-center vocs:justify-center vocs:h-5 vocs:w-auto vocs:px-0.75 vocs:border vocs:border-primary vocs:rounded-sm">
             {triggerKey}
           </div>
         </div>


### PR DESCRIPTION
Allow badges to accommodate different key labels (e.g. ⌘ or Ctrl).

before:
<img width="400"  src="https://github.com/user-attachments/assets/fb13c3a5-dc71-4596-855b-761d79e0c280" />

after:
<img width="400"  src="https://github.com/user-attachments/assets/9ad78516-0ee2-4277-b4ac-a11a5b4a09f1" />
