### PR TITLE
fix: recognize language aliases for syntax highlighting

### DIFF
--- a/playground/src/pages/kitchen-sink.mdx
+++ b/playground/src/pages/kitchen-sink.mdx
@@ -323,9 +323,9 @@ wowee plain text!
 npm i vocs
 ```
 
-```ts [example.ts]
-type Example = string // [!code hl]
-const example: Example = 'example' 
+```rs [example.rs]
+type Example = &'static str; // [!code hl]
+const EXAMPLE: Example = "example";
 ```
  
 ```ts [Line Highlight & Numbers]

--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -45,6 +45,15 @@ const defaultLanguages = {
   solidity,
 } as const
 
+/** Set of all valid language names including aliases from explicitly imported languages */
+const validLanguageNames = new Set([
+  ...Object.keys(bundledLanguages),
+  // Extract names and aliases from explicitly imported language modules (non-function values)
+  ...Object.values(defaultLanguages).flatMap((lang) =>
+    typeof lang === 'function' ? [] : lang.flatMap((l) => [l.name, ...(l.aliases ?? [])]),
+  ),
+])
+
 /**
  * Remark plugin that transforms mermaid code blocks into Mermaid components.
  * Replaces ```mermaid code blocks with a paragraph that has hName/hProperties
@@ -568,15 +577,15 @@ export function remarkLangCommaAttrs() {
  * may be parsed as the lang. This moves it to meta instead.
  */
 export function remarkCodeTitle(options: remarkCodeTitle.Options = {}) {
-  const specialLanguages = ['ansi', 'text', 'txt', 'plain', 'plaintext']
-  const additionalLanguages = options.additionalLanguages ?? []
+  const specialLanguages = new Set(['ansi', 'text', 'txt', 'plain', 'plaintext'])
+  const additionalLanguages = new Set(options.additionalLanguages ?? [])
   return (tree: MdAst.Root) => {
     UnistUtil.visit(tree, 'code', (node) => {
       if (!node.lang) return
       const match =
-        Object.keys(defaultLanguages).includes(node.lang) ||
-        specialLanguages.includes(node.lang) ||
-        additionalLanguages.includes(node.lang)
+        validLanguageNames.has(node.lang) ||
+        specialLanguages.has(node.lang) ||
+        additionalLanguages.has(node.lang)
       if (match) return
       node.meta = node.lang
       node.lang = 'plaintext'


### PR DESCRIPTION
code blocks using language aliases (e.g., `rs` instead of `rust`) weren't getting syntax highlighting because `remarkCodeTitle` only checked primary language names, not aliases.

added `validLanguageNames` Set that includes both primary names and aliases from imported language modules.