### PR TITLE
fix: add trailing slash redirect middleware

### DIFF
--- a/src/waku/internal/middleware/index.ts
+++ b/src/waku/internal/middleware/index.ts
@@ -1,2 +1,3 @@
 export { default as mdRouter } from './md-router.js'
 export { default as redirects } from './redirects.js'
+export { default as trailingSlash } from './trailing-slash.js'

--- a/src/waku/internal/middleware/trailing-slash.ts
+++ b/src/waku/internal/middleware/trailing-slash.ts
@@ -1,0 +1,23 @@
+import type { MiddlewareHandler } from 'hono'
+
+export const trailingSlash = (): MiddlewareHandler => {
+  return async (context, next) => {
+    const url = new URL(context.req.url)
+
+    // Skip root path and paths with file extensions
+    if (url.pathname === '/' || /\.\w+$/.test(url.pathname)) return next()
+
+    // Redirect trailing slash to non-trailing slash
+    if (url.pathname.endsWith('/')) {
+      const destination = new URL(url.pathname.slice(0, -1), url.origin)
+      destination.search = url.search
+
+      context.res = context.redirect(destination.toString(), 308)
+      return
+    }
+
+    return next()
+  }
+}
+
+export default trailingSlash


### PR DESCRIPTION
## Summary

Fixes 500 errors when accessing URLs with trailing slashes (e.g. `/protocol/` vs `/protocol`).

## Problem

Waku's router throws an error when receiving paths that end with `/` (except root). This causes 500 errors for users who accidentally or intentionally visit URLs with trailing slashes.

## Solution

Add a new `trailingSlash` middleware that:
1. Skips root path (`/`) and paths with file extensions
2. Redirects trailing slash URLs to their canonical non-slash versions with a 308 permanent redirect

This runs before the request reaches the router, preventing the error.

## Changes

- Added `src/waku/internal/middleware/trailing-slash.ts`
- Exported from `src/waku/internal/middleware/index.ts`