### PR TITLE
fix: remove duplicate sitemap blocks in llms-full.txt   

### DIFF
--- a/site/src/pages.gen.ts
+++ b/site/src/pages.gen.ts
@@ -1,39 +1,38 @@
 // deno-fmt-ignore-file
 // biome-ignore format: generated types do not need formatting
 // prettier-ignore
-import type { PathsForPages, GetConfigResponse } from 'waku/router';
-
+import type { PathsForPages } from 'waku/router';
 
 // prettier-ignore
 type Page =
-| { path: '/'; render: 'static' }
-| { path: '/reference/site-config'; render: 'static' }
-| { path: '/guide/ai-support'; render: 'static' }
-| { path: '/guide/asset-handling'; render: 'static' }
-| { path: '/guide/changelog-generation'; render: 'static' }
-| { path: '/guide/changelog'; render: 'static' }
-| { path: '/guide/deploy'; render: 'static' }
-| { path: '/guide/dynamic-og-images'; render: 'static' }
-| { path: '/guide/feedback'; render: 'static' }
-| { path: '/guide/frontmatter'; render: 'static' }
-| { path: '/guide/getting-started'; render: 'static' }
-| { path: '/guide/layouts'; render: 'static' }
-| { path: '/guide/markdown-extensions'; render: 'static' }
-| { path: '/guide/mcp-server'; render: 'static' }
-| { path: '/guide/navigation'; render: 'static' }
-| { path: '/guide/project-structure'; render: 'static' }
-| { path: '/guide/react'; render: 'static' }
-| { path: '/guide/syntax-highlighting'; render: 'static' }
-| { path: '/guide/theming'; render: 'static' }
-| { path: '/guide/twoslash'; render: 'static' }
-| { path: '/guide/what-is-vocs'; render: 'static' };
+  | { path: '/'; render: 'static' }
+  | { path: '/reference/site-config'; render: 'static' }
+  | { path: '/guide/ai-support'; render: 'static' }
+  | { path: '/guide/asset-handling'; render: 'static' }
+  | { path: '/guide/changelog-generation'; render: 'static' }
+  | { path: '/guide/changelog'; render: 'static' }
+  | { path: '/guide/deploy'; render: 'static' }
+  | { path: '/guide/dynamic-og-images'; render: 'static' }
+  | { path: '/guide/feedback'; render: 'static' }
+  | { path: '/guide/frontmatter'; render: 'static' }
+  | { path: '/guide/getting-started'; render: 'static' }
+  | { path: '/guide/layouts'; render: 'static' }
+  | { path: '/guide/markdown-extensions'; render: 'static' }
+  | { path: '/guide/mcp-server'; render: 'static' }
+  | { path: '/guide/navigation'; render: 'static' }
+  | { path: '/guide/project-structure'; render: 'static' }
+  | { path: '/guide/react'; render: 'static' }
+  | { path: '/guide/syntax-highlighting'; render: 'static' }
+  | { path: '/guide/theming'; render: 'static' }
+  | { path: '/guide/twoslash'; render: 'static' }
+  | { path: '/guide/what-is-vocs'; render: 'static' }
 
 // prettier-ignore
 declare module 'waku/router' {
   interface RouteConfig {
-    paths: PathsForPages<Page>;
+    paths: PathsForPages<Page>
   }
   interface CreatePagesConfig {
-    pages: Page;
+    pages: Page
   }
 }

--- a/src/internal/llms.test.ts
+++ b/src/internal/llms.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, test } from 'vitest'
+import { buildLlmsContent } from './llms.js'
+import {
+  remarkDefaultFrontmatter,
+  remarkExtractFrontmatter,
+  remarkFrontmatter,
+  remarkStripFrontmatter,
+  remarkStripJs,
+} from './mdx.js'
+
+const plugins = {
+  rehypePlugins: [],
+  remarkPlugins: [
+    remarkFrontmatter,
+    remarkDefaultFrontmatter,
+    remarkExtractFrontmatter,
+    remarkStripFrontmatter,
+    remarkStripJs,
+  ],
+}
+
+describe('buildLlmsContent', () => {
+  test('empty pages', async () => {
+    const result = await buildLlmsContent({
+      pages: [],
+      title: 'My Docs',
+      ...plugins,
+    })
+
+    expect(result.short).toMatchInlineSnapshot(`
+      "# My Docs
+      "
+    `)
+    expect(result.full).toMatchInlineSnapshot(`
+      "# My Docs
+
+      <!--
+      Sitemap:
+      -->
+      "
+    `)
+  })
+
+  test('single page with frontmatter', async () => {
+    const result = await buildLlmsContent({
+      pages: [
+        {
+          path: '/',
+          content: `---
+title: Home
+description: Welcome to the docs
+---
+
+# Welcome
+
+This is the home page.`,
+        },
+      ],
+      title: 'My Docs',
+      ...plugins,
+    })
+
+    expect(result.short).toMatchInlineSnapshot(`
+      "# My Docs
+
+      - [Home](/index): Welcome to the docs"
+    `)
+    expect(result.full).toMatchInlineSnapshot(`
+      "# My Docs
+
+      <!--
+      Sitemap:
+      - [Home](/index): Welcome to the docs
+      -->
+
+      # Welcome
+
+      This is the home page.
+      "
+    `)
+  })
+
+  test('pages without title are excluded', async () => {
+    const result = await buildLlmsContent({
+      pages: [
+        { path: '/no-title', content: 'No heading, no frontmatter.' },
+        { path: '/with-title', content: '---\ntitle: With Title\n---\n\nContent here.' },
+      ],
+      title: 'My Docs',
+      ...plugins,
+    })
+
+    expect(result.short).toMatchInlineSnapshot(`
+      "# My Docs
+
+      - [With Title](/with-title)"
+    `)
+    expect(result.full).toMatchInlineSnapshot(`
+      "# My Docs
+
+      <!--
+      Sitemap:
+      - [With Title](/with-title)
+      -->
+
+      Content here.
+      "
+    `)
+  })
+
+  test('h1 is used as title when no frontmatter', async () => {
+    const result = await buildLlmsContent({
+      pages: [{ path: '/page', content: '# My Page Title\n\nContent here.' }],
+      title: 'My Docs',
+      ...plugins,
+    })
+
+    expect(result.short).toMatchInlineSnapshot(`
+      "# My Docs
+
+      - [My Page Title](/page)"
+    `)
+    expect(result.full).toMatchInlineSnapshot(`
+      "# My Docs
+
+      <!--
+      Sitemap:
+      - [My Page Title](/page)
+      -->
+
+      # My Page Title
+
+      Content here.
+      "
+    `)
+  })
+
+  test('pages are sorted by depth then alphabetically', async () => {
+    const result = await buildLlmsContent({
+      pages: [
+        {
+          path: '/guide/getting-started',
+          content: '---\ntitle: Getting Started\n---\n\nLearn the basics.',
+        },
+        { path: '/api/', content: '---\ntitle: API\n---\n\nAPI reference docs.' },
+        { path: '/about', content: '---\ntitle: About\n---\n\nAbout this project.' },
+        { path: '/', content: '---\ntitle: Home\n---\n\nWelcome home.' },
+      ],
+      title: 'My Docs',
+      ...plugins,
+    })
+
+    expect(result.short).toMatchInlineSnapshot(`
+      "# My Docs
+
+      - [Home](/index)
+      - [About](/about)
+      - [API](/api/)
+      - [Getting Started](/guide/getting-started)"
+    `)
+    expect(result.full).toMatchInlineSnapshot(`
+      "# My Docs
+
+      <!--
+      Sitemap:
+      - [Home](/index)
+      - [About](/about)
+      - [API](/api/)
+      - [Getting Started](/guide/getting-started)
+      -->
+
+      Welcome home.
+
+      About this project.
+
+      API reference docs.
+
+      Learn the basics.
+      "
+    `)
+  })
+
+  test('index path uses /index in nav links', async () => {
+    const result = await buildLlmsContent({
+      pages: [{ path: '/', content: '---\ntitle: Home\n---\n\nThis is the homepage.' }],
+      title: 'My Docs',
+      ...plugins,
+    })
+
+    expect(result.short).toMatchInlineSnapshot(`
+      "# My Docs
+
+      - [Home](/index)"
+    `)
+    expect(result.full).toMatchInlineSnapshot(`
+      "# My Docs
+
+      <!--
+      Sitemap:
+      - [Home](/index)
+      -->
+
+      This is the homepage.
+      "
+    `)
+  })
+
+  test('includes sitemap in page content', async () => {
+    const result = await buildLlmsContent({
+      pages: [{ path: '/page', content: '---\ntitle: Page\n---\n\nContent.' }],
+      title: 'My Docs',
+      ...plugins,
+    })
+
+    expect(result.short).toMatchInlineSnapshot(`
+      "# My Docs
+
+      - [Page](/page)"
+    `)
+    expect(result.full).toMatchInlineSnapshot(`
+      "# My Docs
+
+      <!--
+      Sitemap:
+      - [Page](/page)
+      -->
+
+      Content.
+      "
+    `)
+  })
+
+  test('description is included in output when provided', async () => {
+    const result = await buildLlmsContent({
+      pages: [{ path: '/', content: '---\ntitle: Home\n---\n\nWelcome to the docs.' }],
+      title: 'My Docs',
+      description: 'A great documentation site',
+      ...plugins,
+    })
+
+    expect(result.short).toMatchInlineSnapshot(`
+      "# My Docs
+
+      A great documentation site
+
+      - [Home](/index)"
+    `)
+    expect(result.full).toMatchInlineSnapshot(`
+      "# My Docs
+
+      A great documentation site
+
+      <!--
+      Sitemap:
+      - [Home](/index)
+      -->
+
+      Welcome to the docs.
+      "
+    `)
+  })
+
+  test('handles mdx content', async () => {
+    const result = await buildLlmsContent({
+      pages: [
+        {
+          path: '/component',
+          content: `---
+title: Component
+---
+
+<Component />`,
+        },
+      ],
+      title: 'My Docs',
+      ...plugins,
+    })
+
+    expect(result.short).toMatchInlineSnapshot(`
+      "# My Docs
+
+      - [Component](/component)"
+    `)
+    expect(result.full).toMatchInlineSnapshot(`
+      "# My Docs
+
+      <!--
+      Sitemap:
+      - [Component](/component)
+      -->
+
+      <Component />
+      "
+    `)
+  })
+})

--- a/src/internal/llms.test.ts
+++ b/src/internal/llms.test.ts
@@ -228,6 +228,15 @@ This is the home page.`,
       Content.
       "
     `)
+    expect(result.results[0]?.content).toMatchInlineSnapshot(`
+      "<!--
+      Sitemap:
+      - [Page](/page)
+      -->
+
+      Content.
+      "
+    `)
   })
 
   test('description is included in output when provided', async () => {

--- a/src/internal/llms.ts
+++ b/src/internal/llms.ts
@@ -58,7 +58,7 @@ export async function buildLlmsContent(options: buildLlmsContent.Options) {
   const short = [...llmsTxtContent, ...nav]
   const full = [...llmsTxtContent, sitemap, ...results.map((r) => r.content)]
 
-  const resultsWithSitemap = results.map((r) => ({ ...r, content: sitemap + r.content }))
+  const resultsWithSitemap = results.map((r) => ({ ...r, content: `${sitemap}\n${r.content}` }))
 
   return { full: full.join('\n'), results: resultsWithSitemap, short: short.join('\n') }
 }

--- a/src/internal/llms.ts
+++ b/src/internal/llms.ts
@@ -1,0 +1,91 @@
+import fs from 'node:fs/promises'
+import remarkMdx from 'remark-mdx'
+import remarkParse from 'remark-parse'
+import remarkStringify from 'remark-stringify'
+import type { PluggableList } from 'unified'
+import { unified } from 'unified'
+import type * as Config from './config.js'
+
+export async function buildLlmsContent(options: buildLlmsContent.Options) {
+  const { pages, title, description, rehypePlugins, remarkPlugins } = options
+
+  const results = await Promise.all(
+    pages.map(async (page) => {
+      const content =
+        typeof page.content === 'string'
+          ? page.content
+          : await fs.readFile(page.content.path, 'utf-8')
+      const file = await unified()
+        .use(remarkParse)
+        .use(remarkMdx)
+        .use(remarkStringify)
+        .use(remarkPlugins)
+        .use(rehypePlugins)
+        .process(content)
+
+      const { title, description } = (file?.data?.['frontmatter'] ?? {}) as Config.Frontmatter
+      if (!title) return null
+
+      return {
+        content: String(file),
+        file,
+        title,
+        description,
+        path: page.path,
+      }
+    }),
+  )
+    .then((data) => data.filter((data): data is NonNullable<typeof data> => data !== null))
+    .then((data) =>
+      data.sort((a, b) => {
+        const depthA = a.path.split('/').filter(Boolean).length
+        const depthB = b.path.split('/').filter(Boolean).length
+        if (depthA !== depthB) return depthA - depthB
+        return a.path.localeCompare(b.path)
+      }),
+    )
+
+  const llmsTxtContent: string[] = [`# ${title}`, '']
+  if (description) llmsTxtContent.push(description, '')
+
+  const nav = []
+  for (const { title, description, path } of results)
+    nav.push(
+      `- [${title}](${path === '/' ? '/index' : path})${description ? `: ${description}` : ''}`,
+    )
+
+  const sitemap = ['<!--', 'Sitemap:', ...nav, '-->', ''].join('\n')
+  const short = [...llmsTxtContent, ...nav]
+  const full = [...llmsTxtContent, sitemap, ...results.map((r) => r.content)]
+
+  const resultsWithSitemap = results.map((r) => ({ ...r, content: sitemap + r.content }))
+
+  return { full: full.join('\n'), results: resultsWithSitemap, short: short.join('\n') }
+}
+
+export declare namespace buildLlmsContent {
+  type Options = {
+    pages: Page[]
+    title: string
+    description?: string | undefined
+    rehypePlugins: PluggableList
+    remarkPlugins: PluggableList
+  }
+
+  type Page = {
+    path: string
+    content: string | { path: string }
+  }
+}
+
+export async function getPagesFromDir(pagesDir: string): Promise<buildLlmsContent.Page[]> {
+  const files = await Array.fromAsync(fs.glob(`${pagesDir}/**/*.{md,mdx}`))
+  return files.map((file) => ({
+    path: file
+      .replace(pagesDir, '')
+      .replace(/\.mdx?$/, '')
+      .replace(/\/$/, '')
+      .replace(/index$/, ''),
+    content: { path: file },
+  }))
+}

--- a/src/internal/vite-plugins.ts
+++ b/src/internal/vite-plugins.ts
@@ -214,12 +214,17 @@ export function llms(config: Config.Config): PluginOption {
       )
 
     const sitemap = ['<!--', 'Sitemap:', ...nav, '-->', '', ''].join('\n')
+
+
+    const originalContents = results.map((r) => r.content)
+
+    // Add sitemap to each page for individual MD serving (/assets/md/*.md)
     for (const result of results) result.content = sitemap + result.content
 
     const short = [...llmsTxtContent, ...nav]
 
-    const full = [...llmsTxtContent]
-    for (const { content } of results) full.push(content)
+    // For full: add sitemap ONCE at top, then original contents (without per-page sitemap)
+    const full = [...llmsTxtContent, sitemap, ...originalContents]
 
     return { full: full.join('\n'), results, short: short.join('\n') }
   }

--- a/src/internal/vite-plugins.ts
+++ b/src/internal/vite-plugins.ts
@@ -215,15 +215,12 @@ export function llms(config: Config.Config): PluginOption {
 
     const sitemap = ['<!--', 'Sitemap:', ...nav, '-->', '', ''].join('\n')
 
-
     const originalContents = results.map((r) => r.content)
 
-    // Add sitemap to each page for individual MD serving (/assets/md/*.md)
     for (const result of results) result.content = sitemap + result.content
 
     const short = [...llmsTxtContent, ...nav]
 
-    // For full: add sitemap ONCE at top, then original contents (without per-page sitemap)
     const full = [...llmsTxtContent, sitemap, ...originalContents]
 
     return { full: full.join('\n'), results, short: short.join('\n') }

--- a/src/internal/vite-plugins.ts
+++ b/src/internal/vite-plugins.ts
@@ -2,16 +2,13 @@ import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import mdxPlugin from '@mdx-js/rollup'
 import tailwindcss, { type PluginOptions as TailwindOptions } from '@tailwindcss/vite'
-import remarkMdx from 'remark-mdx'
-import remarkParse from 'remark-parse'
-import remarkStringify from 'remark-stringify'
-import { unified } from 'unified'
 import type { PluginOption, ResolvedConfig, ViteDevServer } from 'vite'
 import { createLogger } from 'vite'
 import * as Config from './config.js'
 import * as ConfigSerializer from './config-serializer.js'
 import * as Icons from './icons.js'
 import * as Langs from './langs.js'
+import * as Llms from './llms.js'
 import * as Mdx from './mdx.js'
 import { SearchDocuments, SearchIndex } from './search.js'
 import * as ShikiTransformers from './shiki-transformers.js'
@@ -164,66 +161,8 @@ export function llms(config: Config.Config): PluginOption {
 
   async function buildLlmsContent() {
     const pagesDir = path.resolve(viteConfig.root, config.srcDir, config.pagesDir)
-    const pages = await Array.fromAsync(fs.glob(`${pagesDir}/**/*.{md,mdx}`))
-
-    const results = await Promise.all(
-      pages.map(async (page) => {
-        const content = await fs.readFile(page, 'utf-8')
-        const file = await unified()
-          .use(remarkParse)
-          .use(remarkMdx)
-          .use(remarkStringify)
-          .use(remarkPlugins)
-          .use(rehypePlugins)
-          .process(content)
-
-        const { title, description } = (file?.data?.['frontmatter'] ?? {}) as Config.Frontmatter
-        if (!title) return null
-
-        const path = page
-          .replace(pagesDir, '')
-          .replace(/\.mdx?$/, '')
-          .replace(/\/$/, '')
-          .replace(/index$/, '')
-        return {
-          content: String(file),
-          file,
-          title,
-          description,
-          path,
-        }
-      }),
-    )
-      .then((data) => data.filter((data): data is NonNullable<typeof data> => data !== null))
-      .then((data) =>
-        data.sort((a, b) => {
-          const depthA = a.path.split('/').filter(Boolean).length
-          const depthB = b.path.split('/').filter(Boolean).length
-          if (depthA !== depthB) return depthA - depthB
-          return a.path.localeCompare(b.path)
-        }),
-      )
-
-    const llmsTxtContent: string[] = [`# ${title}`, '']
-    if (description) llmsTxtContent.push(description, '')
-
-    const nav = []
-    for (const { title, description, path } of results)
-      nav.push(
-        `- [${title}](${path === '/' ? '/index' : path})${description ? `: ${description}` : ''}`,
-      )
-
-    const sitemap = ['<!--', 'Sitemap:', ...nav, '-->', '', ''].join('\n')
-
-    const originalContents = results.map((r) => r.content)
-
-    for (const result of results) result.content = sitemap + result.content
-
-    const short = [...llmsTxtContent, ...nav]
-
-    const full = [...llmsTxtContent, sitemap, ...originalContents]
-
-    return { full: full.join('\n'), results, short: short.join('\n') }
+    const pages = await Llms.getPagesFromDir(pagesDir)
+    return Llms.buildLlmsContent({ pages, title, description, rehypePlugins, remarkPlugins })
   }
 
   return {


### PR DESCRIPTION
- Fixed bug where sitemap block was duplicated once per page in llms-full.txt (20 times in vocs) 
In Viem 498 times:
<img width="1248" height="895" alt="Screenshot 1" src="https://github.com/user-attachments/assets/e4508fac-b23b-43d6-abd2-5dd3583fdade" />

In Tempo 107 times:
<img width="1251" height="850" alt="Screenshot 2" src="https://github.com/user-attachments/assets/66986dbd-af01-40b2-aa94-ee6d1554b480" />

                                                                                     
- Now sitemap appears only once at the top of llms-full.txt                                                                                                                  
- Individual page markdown files still include sitemap for context