### PR TITLE
feat: add block annotation support for [!code hl] and [!code focus]

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "changeset:publish": "tsx scripts/prepublish.ts && pnpm build && changeset publish",
     "changeset:version": "changeset version && pnpm install --lockfile-only",
     "check": "biome check . --write --unsafe",
+    "test": "vitest",
     "check:deps": "pnpx taze -r",
     "check:types": "tsc --noEmit",
     "docs:dev": "node --import tsx/esm ./src/cli/index.ts dev",
@@ -40,6 +41,7 @@
     "typescript": "catalog:",
     "vercel": "^32.7.2",
     "viem": "^2.38.3",
+    "vitest": "^4.0.18",
     "vocs": "workspace:*"
   },
   "simple-git-hooks": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       viem:
         specifier: ^2.38.3
         version: 2.38.3(typescript@5.9.3)
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@edge-runtime/vm@3.1.7)(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1)
       vocs:
         specifier: workspace:*
         version: link:src
@@ -988,9 +991,6 @@ packages:
   '@jridgewell/set-array@1.2.1':
     resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
-
-  '@jridgewell/sourcemap-codec@1.4.15':
-    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -2021,6 +2021,9 @@ packages:
   '@types/body-parser@1.19.4':
     resolution: {integrity: sha512-N7UDG0/xiPQa2D/XrVJXjkWbpqHCd2sBaB32ggRF2l83RhPfamgKGF8gwwqyksS95qUS5ZYF9aF+lLPRlwI2UA==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/chroma-js@3.1.1':
     resolution: {integrity: sha512-SFCr4edNkZ1bGaLzGz7rgR1bRzVX4MmMxwsIa3/Bh6ose8v+hRpneoizHv0KChdjxaXyjRtaMq7sCuZSzPomQA==}
 
@@ -2128,6 +2131,9 @@ packages:
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.2':
     resolution: {integrity: sha512-GNBWlGBMjiiiL5TSkvPtOteuXsiVitw5MYGY1UYlrAq0SKyczsls6sCD7TZ8fsjRsvCVxml7EbyjJezPb3DrSA==}
@@ -2342,6 +2348,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@4.0.18':
+    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+
+  '@vitest/mocker@4.0.18':
+    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.0.18':
+    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+
+  '@vitest/runner@4.0.18':
+    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+
+  '@vitest/snapshot@4.0.18':
+    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+
+  '@vitest/spy@4.0.18':
+    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+
+  '@vitest/utils@4.0.18':
+    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
 
@@ -2445,6 +2480,10 @@ packages:
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
@@ -2553,6 +2592,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@5.3.0:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
@@ -3271,6 +3314,10 @@ packages:
     resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
     engines: {node: '>=6'}
 
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
   exsolve@1.0.5:
     resolution: {integrity: sha512-pz5dvkYYKQ1AHVrgOzBKWeP4u4FRb3a6DNK2ucr0OoNwYIU4QWsJ+NM36LLzORT+z845MzKHHhpXiUF5nvQoJg==}
 
@@ -3838,6 +3885,9 @@ packages:
   magic-string@0.30.19:
     resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
@@ -4289,6 +4339,9 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -4790,6 +4843,9 @@ packages:
   shiki@1.29.2:
     resolution: {integrity: sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -4829,6 +4885,9 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stat-mode@0.3.0:
     resolution: {integrity: sha512-QjMLR0A3WwFY2aZdV0okfFEJB5TRjkggXZjxP3A1RsWsNHNu3YPv8btmtc6iCFZ0Rul3FE93OYogvhOUClU+ng==}
 
@@ -4839,6 +4898,9 @@ packages:
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stdin-discarder@0.1.0:
     resolution: {integrity: sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==}
@@ -4913,10 +4975,12 @@ packages:
   tar@4.4.18:
     resolution: {integrity: sha512-ZuOtqqmkV9RE1+4odd+MhBpibmCxNP6PJhH/h2OqNuotTX7/XHPZQJv2pKvWMplFH9SIZZhitehh6vBH6LO8Pg==}
     engines: {node: '>=4.5'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   tar@6.2.0:
     resolution: {integrity: sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -4929,12 +4993,23 @@ packages:
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.0.1:
     resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
+
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -5212,6 +5287,40 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.0.18:
+    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.18
+      '@vitest/browser-preview': 4.0.18
+      '@vitest/browser-webdriverio': 4.0.18
+      '@vitest/ui': 4.0.18
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
@@ -5247,6 +5356,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wide-align@1.1.5:
@@ -5969,7 +6083,7 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.5':
     dependencies:
       '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.25
 
   '@jridgewell/remapping@2.3.5':
@@ -5981,24 +6095,22 @@ snapshots:
 
   '@jridgewell/set-array@1.2.1': {}
 
-  '@jridgewell/sourcemap-codec@1.4.15': {}
-
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -7081,6 +7193,11 @@ snapshots:
       '@types/connect': 3.4.37
       '@types/node': 24.9.1
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/chroma-js@3.1.1': {}
 
   '@types/compression@1.8.1':
@@ -7216,6 +7333,8 @@ snapshots:
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 0.7.33
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.2':
     dependencies:
@@ -7600,6 +7719,45 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@4.0.18':
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.18(vite@7.1.11(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.1.11(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1)
+
+  '@vitest/pretty-format@4.0.18':
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  '@vitest/runner@4.0.18':
+    dependencies:
+      '@vitest/utils': 4.0.18
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.0.18': {}
+
+  '@vitest/utils@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      tinyrainbow: 3.0.3
+
   abbrev@1.1.1: {}
 
   abitype@1.1.0(typescript@5.9.3):
@@ -7680,6 +7838,8 @@ snapshots:
       tslib: 2.7.0
 
   array-union@2.1.0: {}
+
+  assertion-error@2.0.1: {}
 
   astring@1.9.0: {}
 
@@ -7774,6 +7934,8 @@ snapshots:
   caniuse-lite@1.0.30001751: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chalk@5.3.0: {}
 
@@ -8452,6 +8614,8 @@ snapshots:
 
   exit-hook@2.2.1: {}
 
+  expect-type@1.3.0: {}
+
   exsolve@1.0.5: {}
 
   extend@3.0.2: {}
@@ -9085,6 +9249,10 @@ snapshots:
       yallist: 4.0.0
 
   magic-string@0.30.19:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
@@ -9853,6 +10021,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  obug@2.1.1: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -10515,6 +10685,8 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.0.2: {}
@@ -10540,11 +10712,15 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  stackback@0.0.2: {}
+
   stat-mode@0.3.0: {}
 
   statuses@1.5.0: {}
 
   statuses@2.0.1: {}
+
+  std-env@3.10.0: {}
 
   stdin-discarder@0.1.0:
     dependencies:
@@ -10648,12 +10824,18 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.0.1: {}
+
+  tinyexec@1.0.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.0.3: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -10955,6 +11137,44 @@ snapshots:
       tsx: 4.20.6
       yaml: 2.8.1
 
+  vitest@4.0.18(@edge-runtime/vm@3.1.7)(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(vite@7.1.11(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.1.11(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@edge-runtime/vm': 3.1.7
+      '@types/node': 24.9.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
   vscode-jsonrpc@8.2.0: {}
 
   vscode-languageserver-protocol@3.17.5:
@@ -10986,6 +11206,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wide-align@1.1.5:
     dependencies:

--- a/src/vite/plugins/mdx.ts
+++ b/src/vite/plugins/mdx.ts
@@ -43,6 +43,7 @@ import { remarkTwoslash } from './remark/twoslash.js'
 import { transformerCustomTags } from './shiki/transformerCustomTags.js'
 import { transformerEmptyLine } from './shiki/transformerEmptyLine.js'
 import { transformerLineNumbers } from './shiki/transformerLineNumbers.js'
+import { transformerNotationBlock } from './shiki/transformerNotationBlock.js'
 import { transformerNotationInclude } from './shiki/transformerNotationInclude.js'
 import { transformerSplitIdentifiers } from './shiki/transformerSplitIdentifiers.js'
 import { transformerTagLine } from './shiki/transformerTagLine.js'
@@ -110,6 +111,7 @@ export const getRehypePlugins = ({
           transformerNotationFocus(),
           transformerNotationHighlight(),
           transformerNotationWordHighlight(),
+          transformerNotationBlock(),
           transformerNotationInclude({ rootDir }),
           transformerEmptyLine(),
           transformerCustomTags(),

--- a/src/vite/plugins/shiki/transformerNotationBlock.test.ts
+++ b/src/vite/plugins/shiki/transformerNotationBlock.test.ts
@@ -247,6 +247,222 @@ const a = 1
     })
   })
 
+  describe('regex patterns', () => {
+    describe('comment style variations', () => {
+      it('should match // style comments', async () => {
+        const code = `// [!code hl:start]
+const a = 1
+// [!code hl:end]`
+        const html = await highlight(code)
+        expect(html).toContain('highlighted')
+        expect(html).not.toContain('[!code')
+      })
+
+      it('should match # style comments', async () => {
+        const code = `# [!code hl:start]
+x = 1
+# [!code hl:end]`
+        const html = await highlight(code, 'python')
+        expect(html).toContain('highlighted')
+        expect(html).not.toContain('[!code')
+      })
+
+      it('should match /* */ style comments', async () => {
+        const code = `/* [!code hl:start] */
+const a = 1
+/* [!code hl:end] */`
+        const html = await highlight(code)
+        expect(html).toContain('highlighted')
+        expect(html).not.toContain('[!code')
+      })
+
+      it('should match <!-- --> style comments', async () => {
+        const code = `<!-- [!code hl:start] -->
+<div>test</div>
+<!-- [!code hl:end] -->`
+        const html = await highlight(code, 'html')
+        expect(html).toContain('highlighted')
+        expect(html).not.toContain('[!code')
+      })
+
+      it('should match -- style comments (SQL)', async () => {
+        const code = `-- [!code hl:start]
+SELECT * FROM users
+-- [!code hl:end]`
+        const html = await highlight(code, 'sql')
+        expect(html).toContain('highlighted')
+        expect(html).not.toContain('[!code')
+      })
+    })
+
+    describe('whitespace handling', () => {
+      it('should match with no leading whitespace', async () => {
+        const code = `// [!code hl:start]
+const a = 1
+// [!code hl:end]`
+        const html = await highlight(code)
+        expect(html).toContain('highlighted')
+      })
+
+      it('should match with leading spaces', async () => {
+        const code = `  // [!code hl:start]
+const a = 1
+  // [!code hl:end]`
+        const html = await highlight(code)
+        expect(html).toContain('highlighted')
+      })
+
+      it('should match with leading tabs', async () => {
+        const code = `\t// [!code hl:start]
+const a = 1
+\t// [!code hl:end]`
+        const html = await highlight(code)
+        expect(html).toContain('highlighted')
+      })
+
+      it('should match with extra space after comment token', async () => {
+        const code = `//  [!code hl:start]
+const a = 1
+//  [!code hl:end]`
+        const html = await highlight(code)
+        expect(html).toContain('highlighted')
+      })
+
+      it('should match with multiple spaces inside marker', async () => {
+        const code = `// [!code  hl:start]
+const a = 1
+// [!code  hl:end]`
+        const html = await highlight(code)
+        expect(html).toContain('highlighted')
+      })
+
+      it('should match with trailing whitespace before closing', async () => {
+        const code = `/* [!code hl:start]  */
+const a = 1
+/* [!code hl:end]  */`
+        const html = await highlight(code)
+        expect(html).toContain('highlighted')
+      })
+    })
+
+    describe('non-matching patterns', () => {
+      it('should NOT match marker with trailing text', async () => {
+        const code = `// [!code hl:start] some note
+const a = 1
+// [!code hl:end]`
+        const html = await highlight(code)
+        expect(html).toContain('[!code hl:start] some note')
+      })
+
+      it('should NOT match marker mid-line', async () => {
+        const code = `const x = 1 // [!code hl:start]
+const a = 1
+// [!code hl:end]`
+        const html = await highlight(code)
+        expect(html).not.toContain('highlighted')
+      })
+
+      it('should NOT match typo hl:stat', async () => {
+        const code = `// [!code hl:stat]
+const a = 1
+// [!code hl:end]`
+        const html = await highlight(code)
+        expect(html).not.toContain('highlighted')
+        expect(html).toContain('[!code hl:stat]')
+      })
+
+      it('should NOT match typo focus:star', async () => {
+        const code = `// [!code focus:star]
+const a = 1
+// [!code focus:end]`
+        const html = await highlight(code)
+        expect(html).not.toContain('focused')
+      })
+
+      it('should NOT match missing space after comment token', async () => {
+        const code = `//[!code hl:start]
+const a = 1
+//[!code hl:end]`
+        const html = await highlight(code)
+        expect(html).not.toContain('highlighted')
+      })
+
+      it('should NOT match wrong bracket style', async () => {
+        const code = `// (!code hl:start)
+const a = 1
+// (!code hl:end)`
+        const html = await highlight(code)
+        expect(html).not.toContain('highlighted')
+      })
+
+      it('should NOT match missing exclamation mark', async () => {
+        const code = `// [code hl:start]
+const a = 1
+// [code hl:end]`
+        const html = await highlight(code)
+        expect(html).not.toContain('highlighted')
+      })
+
+      it('should NOT match case variations', async () => {
+        const code = `// [!CODE HL:START]
+const a = 1
+// [!CODE HL:END]`
+        const html = await highlight(code)
+        expect(html).not.toContain('highlighted')
+      })
+
+      it('should match block comments without closing (optional closing)', async () => {
+        const code = `/* [!code hl:start]
+const a = 1
+/* [!code hl:end]`
+        const html = await highlight(code)
+        expect(html).toContain('highlighted')
+      })
+    })
+
+    describe('block type matching', () => {
+      it('should only match hl type for hl markers', async () => {
+        const code = `// [!code hl:start]
+const a = 1
+// [!code hl:end]`
+        const html = await highlight(code)
+        expect(html).toContain('highlighted')
+        expect(html).not.toContain('focused')
+      })
+
+      it('should only match focus type for focus markers', async () => {
+        const code = `// [!code focus:start]
+const a = 1
+// [!code focus:end]`
+        const html = await highlight(code)
+        expect(html).toContain('focused')
+        expect(html).not.toContain('highlighted')
+      })
+
+      it('should NOT match unknown block types', async () => {
+        const code = `// [!code diff:start]
+const a = 1
+// [!code diff:end]`
+        const html = await highlight(code)
+        expect(html).not.toContain('highlighted')
+        expect(html).not.toContain('focused')
+        expect(html).toContain('[!code diff:start]')
+      })
+
+      it('should leave hl block open when end type does not match', async () => {
+        const code = `// [!code hl:start]
+const a = 1
+// [!code focus:end]
+const b = 2`
+        const html = await highlight(code)
+        const highlightedCount = (html.match(/class="line highlighted"/g) || []).length
+        expect(highlightedCount).toBe(2)
+        expect(html).not.toContain('[!code hl:start]')
+        expect(html).not.toContain('[!code focus:end]')
+      })
+    })
+  })
+
   describe('custom options', () => {
     it('should use custom highlight class', async () => {
       const highlighter = await createHighlighter({

--- a/src/vite/plugins/shiki/transformerNotationBlock.test.ts
+++ b/src/vite/plugins/shiki/transformerNotationBlock.test.ts
@@ -1,0 +1,316 @@
+import { type BundledLanguage, createHighlighter } from 'shiki'
+import { describe, expect, it } from 'vitest'
+import { transformerNotationBlock } from './transformerNotationBlock.js'
+
+async function highlight(code: string, lang: BundledLanguage = 'typescript') {
+  const highlighter = await createHighlighter({
+    themes: ['github-dark'],
+    langs: [lang],
+  })
+
+  const html = highlighter.codeToHtml(code, {
+    lang,
+    theme: 'github-dark',
+    transformers: [transformerNotationBlock()],
+  })
+
+  highlighter.dispose()
+  return html
+}
+
+describe('transformerNotationBlock', () => {
+  describe('highlight blocks', () => {
+    it('should highlight lines between hl:start and hl:end markers', async () => {
+      const code = `const a = 1
+// [!code hl:start]
+const b = 2
+const c = 3
+// [!code hl:end]
+const d = 4`
+
+      const html = await highlight(code)
+
+      expect(html).toContain('class="line highlighted"')
+      expect(html).not.toContain('[!code hl:start]')
+      expect(html).not.toContain('[!code hl:end]')
+      expect(html).toMatch(/line highlighted[^>]*>.*\bb\b/)
+      expect(html).toMatch(/line highlighted[^>]*>.*\bc\b/)
+      expect(html).not.toMatch(/line highlighted[^>]*>.*\ba\b.*=.*1/)
+      expect(html).not.toMatch(/line highlighted[^>]*>.*\bd\b.*=.*4/)
+    })
+
+    it('should handle multiple separate highlight blocks', async () => {
+      const code = `// [!code hl:start]
+const a = 1
+// [!code hl:end]
+const b = 2
+// [!code hl:start]
+const c = 3
+// [!code hl:end]`
+
+      const html = await highlight(code)
+
+      const highlightedCount = (html.match(/class="line highlighted"/g) || []).length
+      expect(highlightedCount).toBe(2)
+    })
+
+    it('should handle hash comments for Python/Ruby', async () => {
+      const code = `x = 1
+# [!code hl:start]
+y = 2
+z = 3
+# [!code hl:end]
+w = 4`
+
+      const html = await highlight(code, 'python')
+
+      expect(html).toContain('class="line highlighted"')
+      expect(html).not.toContain('[!code hl:start]')
+      expect(html).not.toContain('[!code hl:end]')
+    })
+
+    it('should handle HTML comments', async () => {
+      const code = `<div>
+<!-- [!code hl:start] -->
+<span>highlighted</span>
+<!-- [!code hl:end] -->
+</div>`
+
+      const html = await highlight(code, 'html')
+
+      expect(html).toContain('class="line highlighted"')
+      expect(html).not.toContain('[!code hl:start]')
+      expect(html).not.toContain('[!code hl:end]')
+    })
+
+    it('should handle block comments /* */', async () => {
+      const code = `const a = 1
+/* [!code hl:start] */
+const b = 2
+/* [!code hl:end] */
+const c = 3`
+
+      const html = await highlight(code)
+
+      expect(html).toContain('class="line highlighted"')
+      expect(html).not.toContain('[!code hl:start]')
+    })
+  })
+
+  describe('focus blocks', () => {
+    it('should focus lines between focus:start and focus:end markers', async () => {
+      const code = `const a = 1
+// [!code focus:start]
+const b = 2
+const c = 3
+// [!code focus:end]
+const d = 4`
+
+      const html = await highlight(code)
+
+      expect(html).toContain('class="line focused"')
+      expect(html).toContain('has-focused')
+      expect(html).not.toContain('[!code focus:start]')
+      expect(html).not.toContain('[!code focus:end]')
+    })
+
+    it('should add has-focused class to pre element', async () => {
+      const code = `// [!code focus:start]
+const x = 1
+// [!code focus:end]`
+
+      const html = await highlight(code)
+
+      expect(html).toMatch(/<pre[^>]*class="[^"]*has-focused[^"]*"/)
+    })
+  })
+
+  describe('mixed blocks', () => {
+    it('should handle both hl and focus blocks in same code', async () => {
+      const code = `const a = 1
+// [!code hl:start]
+const b = 2
+// [!code hl:end]
+// [!code focus:start]
+const c = 3
+// [!code focus:end]
+const d = 4`
+
+      const html = await highlight(code)
+
+      expect(html).toContain('class="line highlighted"')
+      expect(html).toContain('class="line focused"')
+    })
+
+    it('should handle overlapping hl and focus blocks', async () => {
+      const code = `// [!code hl:start]
+// [!code focus:start]
+const a = 1
+// [!code focus:end]
+const b = 2
+// [!code hl:end]`
+
+      const html = await highlight(code)
+
+      expect(html).toContain('highlighted')
+      expect(html).toContain('focused')
+    })
+
+    it('should apply both classes to overlapping lines', async () => {
+      const code = `// [!code hl:start]
+// [!code focus:start]
+const a = 1
+// [!code hl:end]
+// [!code focus:end]`
+
+      const html = await highlight(code)
+
+      expect(html).toMatch(/class="line (highlighted focused|focused highlighted)"/)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle empty blocks', async () => {
+      const code = `const a = 1
+// [!code hl:start]
+// [!code hl:end]
+const b = 2`
+
+      const html = await highlight(code)
+
+      expect(html).not.toContain('[!code hl:start]')
+      expect(html).not.toContain('[!code hl:end]')
+    })
+
+    it('should handle unclosed blocks (apply to end of file)', async () => {
+      const code = `const a = 1
+// [!code hl:start]
+const b = 2
+const c = 3`
+
+      const html = await highlight(code)
+
+      const highlightedCount = (html.match(/class="line highlighted"/g) || []).length
+      expect(highlightedCount).toBe(2)
+    })
+
+    it('should handle nested blocks of same type gracefully', async () => {
+      const code = `// [!code hl:start]
+const a = 1
+// [!code hl:start]
+const b = 2
+// [!code hl:end]
+const c = 3
+// [!code hl:end]`
+
+      const html = await highlight(code)
+
+      expect(html).toContain('highlighted')
+      expect(html).not.toContain('[!code hl:start]')
+    })
+
+    it('should handle markers with extra whitespace', async () => {
+      const code = `const a = 1
+//   [!code hl:start]
+const b = 2
+//   [!code hl:end]
+const c = 3`
+
+      const html = await highlight(code)
+
+      expect(html).toContain('class="line highlighted"')
+    })
+
+    it('should preserve code without any markers', async () => {
+      const code = `const a = 1
+const b = 2
+const c = 3`
+
+      const html = await highlight(code)
+
+      expect(html).not.toContain('highlighted')
+      expect(html).not.toContain('focused')
+      expect(html).toContain('a')
+      expect(html).toContain('b')
+      expect(html).toContain('c')
+    })
+
+    it('should not match partial markers', async () => {
+      const code = `// [!code hl:star]
+const a = 1
+// [!code hl:ending]`
+
+      const html = await highlight(code)
+
+      expect(html).not.toContain('highlighted')
+      expect(html).toContain('[!code hl:star]')
+    })
+  })
+
+  describe('custom options', () => {
+    it('should use custom highlight class', async () => {
+      const highlighter = await createHighlighter({
+        themes: ['github-dark'],
+        langs: ['typescript'],
+      })
+
+      const code = `// [!code hl:start]
+const a = 1
+// [!code hl:end]`
+
+      const html = highlighter.codeToHtml(code, {
+        lang: 'typescript',
+        theme: 'github-dark',
+        transformers: [transformerNotationBlock({ highlightClass: 'my-highlight' })],
+      })
+
+      highlighter.dispose()
+
+      expect(html).toContain('my-highlight')
+      expect(html).not.toContain('highlighted')
+    })
+
+    it('should use custom focus class', async () => {
+      const highlighter = await createHighlighter({
+        themes: ['github-dark'],
+        langs: ['typescript'],
+      })
+
+      const code = `// [!code focus:start]
+const a = 1
+// [!code focus:end]`
+
+      const html = highlighter.codeToHtml(code, {
+        lang: 'typescript',
+        theme: 'github-dark',
+        transformers: [transformerNotationBlock({ focusClass: 'my-focus' })],
+      })
+
+      highlighter.dispose()
+
+      expect(html).toContain('my-focus')
+    })
+
+    it('should use custom focus active pre class', async () => {
+      const highlighter = await createHighlighter({
+        themes: ['github-dark'],
+        langs: ['typescript'],
+      })
+
+      const code = `// [!code focus:start]
+const a = 1
+// [!code focus:end]`
+
+      const html = highlighter.codeToHtml(code, {
+        lang: 'typescript',
+        theme: 'github-dark',
+        transformers: [transformerNotationBlock({ focusActivePreClass: 'custom-has-focus' })],
+      })
+
+      highlighter.dispose()
+
+      expect(html).toContain('custom-has-focus')
+      expect(html).not.toContain('has-focused')
+    })
+  })
+})

--- a/src/vite/plugins/shiki/transformerNotationBlock.ts
+++ b/src/vite/plugins/shiki/transformerNotationBlock.ts
@@ -19,8 +19,8 @@ export interface TransformerNotationBlockOptions {
   focusActivePreClass?: string
 }
 
-const startRegex = /^\s*(?:\/\/|\/\*|<!--|#|--)\s*\[!code\s+(hl|focus):start\]\s*(?:\*\/|-->)?$/
-const endRegex = /^\s*(?:\/\/|\/\*|<!--|#|--)\s*\[!code\s+(hl|focus):end\]\s*(?:\*\/|-->)?$/
+const startRegex = /^\s*(?:\/\/|\/\*|<!--|#|--)\s+\[!code\s+(hl|focus):start\]\s*(?:\*\/|-->)?\s*$/
+const endRegex = /^\s*(?:\/\/|\/\*|<!--|#|--)\s+\[!code\s+(hl|focus):end\]\s*(?:\*\/|-->)?\s*$/
 
 /**
  * Transformer that handles block-level code annotations for highlight and focus.

--- a/src/vite/plugins/shiki/transformerNotationBlock.ts
+++ b/src/vite/plugins/shiki/transformerNotationBlock.ts
@@ -1,4 +1,4 @@
-import type { Element, Text } from 'hast'
+import type { Element, ElementContent } from 'hast'
 import { addClassToHast, type ShikiTransformer } from 'shiki'
 
 export interface TransformerNotationBlockOptions {
@@ -17,13 +17,6 @@ export interface TransformerNotationBlockOptions {
    * @default 'has-focused'
    */
   focusActivePreClass?: string
-}
-
-type BlockType = 'hl' | 'focus'
-
-interface BlockState {
-  type: BlockType
-  startIndex: number
 }
 
 const startRegex = /^\s*(?:\/\/|\/\*|<!--|#|--)\s*\[!code\s+(hl|focus):start\]\s*(?:\*\/|-->)?$/
@@ -50,61 +43,55 @@ export function transformerNotationBlock(
   return {
     name: 'vocs:notation-block',
     code(code) {
-      const lines = code.children.filter((i) => i.type === 'element') as Element[]
-      const linesToRemove: (Element | Text)[] = []
-      const activeBlocks: BlockState[] = []
-      const lineAnnotations: Map<number, BlockType[]> = new Map()
+      const children = code.children
+      const lines = children.filter((i) => i.type === 'element') as Element[]
+      const removeSet = new Set<ElementContent>()
+
+      let hlDepth = 0
+      let focusDepth = 0
       let hasFocus = false
 
-      lines.forEach((line, idx) => {
+      for (const line of lines) {
         const lineText = getLineText(line)
 
         const startMatch = lineText.match(startRegex)
         if (startMatch) {
-          const blockType = startMatch[1] as BlockType
-          activeBlocks.push({ type: blockType, startIndex: idx })
-          markLineForRemoval(line, code, linesToRemove)
-          return
+          const blockType = startMatch[1]
+          if (blockType === 'hl') {
+            hlDepth++
+          } else {
+            focusDepth++
+          }
+          markLineForRemoval(line, code, removeSet)
+          continue
         }
 
         const endMatch = lineText.match(endRegex)
         if (endMatch) {
-          const blockType = endMatch[1] as BlockType
-          const blockIndex = activeBlocks.findIndex((b) => b.type === blockType)
-          if (blockIndex !== -1) {
-            activeBlocks.splice(blockIndex, 1)
+          const blockType = endMatch[1]
+          if (blockType === 'hl') {
+            hlDepth = Math.max(0, hlDepth - 1)
+          } else {
+            focusDepth = Math.max(0, focusDepth - 1)
           }
-          markLineForRemoval(line, code, linesToRemove)
-          return
+          markLineForRemoval(line, code, removeSet)
+          continue
         }
 
-        for (const block of activeBlocks) {
-          const annotations = lineAnnotations.get(idx) || []
-          annotations.push(block.type)
-          lineAnnotations.set(idx, annotations)
-          if (block.type === 'focus') hasFocus = true
+        if (hlDepth > 0) {
+          addClassToHast(line, highlightClass)
         }
-      })
-
-      for (const [idx, annotations] of lineAnnotations) {
-        const line = lines[idx]
-        if (!line) continue
-        for (const annotation of annotations) {
-          const className = annotation === 'hl' ? highlightClass : focusClass
-          addClassToHast(line, className)
+        if (focusDepth > 0) {
+          addClassToHast(line, focusClass)
+          hasFocus = true
         }
       }
 
-      if (hasFocus) {
+      if (hasFocus && this.pre) {
         addClassToHast(this.pre, focusActivePreClass)
       }
 
-      for (const node of linesToRemove) {
-        const index = code.children.indexOf(node)
-        if (index !== -1) {
-          code.children.splice(index, 1)
-        }
-      }
+      code.children = children.filter((n) => !removeSet.has(n))
     },
   }
 }
@@ -121,11 +108,15 @@ function getLineText(line: Element): string {
   return text
 }
 
-function markLineForRemoval(line: Element, code: Element, linesToRemove: (Element | Text)[]): void {
-  linesToRemove.push(line)
+function markLineForRemoval(line: Element, code: Element, removeSet: Set<ElementContent>): void {
+  removeSet.add(line)
   const lineIndex = code.children.indexOf(line)
   const nextNode = code.children[lineIndex + 1]
-  if (nextNode && nextNode.type === 'text' && nextNode.value === '\n') {
-    linesToRemove.push(nextNode)
+  if (
+    nextNode &&
+    nextNode.type === 'text' &&
+    (nextNode.value === '\n' || nextNode.value === '\r\n')
+  ) {
+    removeSet.add(nextNode)
   }
 }

--- a/src/vite/plugins/shiki/transformerNotationBlock.ts
+++ b/src/vite/plugins/shiki/transformerNotationBlock.ts
@@ -1,0 +1,131 @@
+import type { Element, Text } from 'hast'
+import { addClassToHast, type ShikiTransformer } from 'shiki'
+
+export interface TransformerNotationBlockOptions {
+  /**
+   * Class to apply to highlighted lines
+   * @default 'highlighted'
+   */
+  highlightClass?: string
+  /**
+   * Class to apply to focused lines
+   * @default 'focused'
+   */
+  focusClass?: string
+  /**
+   * Class added to the <pre> element when focus blocks are present
+   * @default 'has-focused'
+   */
+  focusActivePreClass?: string
+}
+
+type BlockType = 'hl' | 'focus'
+
+interface BlockState {
+  type: BlockType
+  startIndex: number
+}
+
+const startRegex = /^\s*(?:\/\/|\/\*|<!--|#|--)\s*\[!code\s+(hl|focus):start\]\s*(?:\*\/|-->)?$/
+const endRegex = /^\s*(?:\/\/|\/\*|<!--|#|--)\s*\[!code\s+(hl|focus):end\]\s*(?:\*\/|-->)?$/
+
+/**
+ * Transformer that handles block-level code annotations for highlight and focus.
+ *
+ * Supports start/end markers:
+ * - // [!code hl:start] ... // [!code hl:end]
+ * - // [!code focus:start] ... // [!code focus:end]
+ *
+ * Works with various comment styles: //, /* *\/, <!--  -->, #, --
+ */
+export function transformerNotationBlock(
+  options: TransformerNotationBlockOptions = {},
+): ShikiTransformer {
+  const {
+    highlightClass = 'highlighted',
+    focusClass = 'focused',
+    focusActivePreClass = 'has-focused',
+  } = options
+
+  return {
+    name: 'vocs:notation-block',
+    code(code) {
+      const lines = code.children.filter((i) => i.type === 'element') as Element[]
+      const linesToRemove: (Element | Text)[] = []
+      const activeBlocks: BlockState[] = []
+      const lineAnnotations: Map<number, BlockType[]> = new Map()
+      let hasFocus = false
+
+      lines.forEach((line, idx) => {
+        const lineText = getLineText(line)
+
+        const startMatch = lineText.match(startRegex)
+        if (startMatch) {
+          const blockType = startMatch[1] as BlockType
+          activeBlocks.push({ type: blockType, startIndex: idx })
+          markLineForRemoval(line, code, linesToRemove)
+          return
+        }
+
+        const endMatch = lineText.match(endRegex)
+        if (endMatch) {
+          const blockType = endMatch[1] as BlockType
+          const blockIndex = activeBlocks.findIndex((b) => b.type === blockType)
+          if (blockIndex !== -1) {
+            activeBlocks.splice(blockIndex, 1)
+          }
+          markLineForRemoval(line, code, linesToRemove)
+          return
+        }
+
+        for (const block of activeBlocks) {
+          const annotations = lineAnnotations.get(idx) || []
+          annotations.push(block.type)
+          lineAnnotations.set(idx, annotations)
+          if (block.type === 'focus') hasFocus = true
+        }
+      })
+
+      for (const [idx, annotations] of lineAnnotations) {
+        const line = lines[idx]
+        if (!line) continue
+        for (const annotation of annotations) {
+          const className = annotation === 'hl' ? highlightClass : focusClass
+          addClassToHast(line, className)
+        }
+      }
+
+      if (hasFocus) {
+        addClassToHast(this.pre, focusActivePreClass)
+      }
+
+      for (const node of linesToRemove) {
+        const index = code.children.indexOf(node)
+        if (index !== -1) {
+          code.children.splice(index, 1)
+        }
+      }
+    },
+  }
+}
+
+function getLineText(line: Element): string {
+  let text = ''
+  for (const child of line.children) {
+    if (child.type === 'text') {
+      text += child.value
+    } else if (child.type === 'element') {
+      text += getLineText(child as Element)
+    }
+  }
+  return text
+}
+
+function markLineForRemoval(line: Element, code: Element, linesToRemove: (Element | Text)[]): void {
+  linesToRemove.push(line)
+  const lineIndex = code.children.indexOf(line)
+  const nextNode = code.children[lineIndex + 1]
+  if (nextNode && nextNode.type === 'text' && nextNode.value === '\n') {
+    linesToRemove.push(nextNode)
+  }
+}


### PR DESCRIPTION
## Summary

Adds start/end block markers for highlight and focus annotations, allowing multiple consecutive lines to be annotated without repeating the marker on each line.

## Usage

```ts
// [!code hl:start]
const a = 1
const b = 2
const c = 3
// [!code hl:end]

// [!code focus:start]
const focused = true
// [!code focus:end]
```

## Features

- Supports `// [!code hl:start]` / `// [!code hl:end]` for highlight blocks
- Supports `// [!code focus:start]` / `// [!code focus:end]` for focus blocks
- Works with multiple comment styles: `//`, `/* */`, `<!-- -->`, `#`, `--`
- Blocks can overlap (a line can be both highlighted and focused)
- Marker lines are removed from output