### PR TITLE
feat: add block annotation support for [!code hl] and [!code focus]

### DIFF
--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -454,6 +454,7 @@ export function rehypeShiki(
         ShikiTransformers.notationFocus(),
         ShikiTransformers.notationHighlight(),
         ShikiTransformers.notationWordHighlight(),
+        ...ShikiTransformers.notationBlock(),
         ...ShikiTransformers.notationCollapse(),
         ...ShikiTransformers.notationFold(),
         ShikiTransformers.removeNotationEscape(),

--- a/src/internal/shiki-transformers.test.ts
+++ b/src/internal/shiki-transformers.test.ts
@@ -1,17 +1,17 @@
 import { createHighlighter } from 'shiki'
 import { describe, expect, test } from 'vitest'
-import { notationCollapse, notationFold } from './shiki-transformers.js'
+import { notationBlock, notationCollapse, notationFold } from './shiki-transformers.js'
 
 const highlighter = await createHighlighter({
   themes: ['github-dark'],
-  langs: ['javascript', 'jsx', 'typescript'],
+  langs: ['javascript', 'jsx', 'typescript', 'bash'],
 })
 
 function highlight(code: string, lang = 'javascript') {
   return highlighter.codeToHtml(code, {
     lang,
     theme: 'github-dark',
-    transformers: [...notationCollapse(), ...notationFold()],
+    transformers: [...notationBlock(), ...notationCollapse(), ...notationFold()],
   })
 }
 
@@ -128,5 +128,144 @@ foo bar baz`,
     expect(html).toContain('data-v-fold')
     const foldMatch = html.match(/<span data-v-fold[^>]*>[^<]*<\/span>/g)
     expect(foldMatch?.length).toBe(1)
+  })
+})
+
+function highlightBlockOnly(code: string, lang = 'javascript') {
+  return highlighter.codeToHtml(code, {
+    lang,
+    theme: 'github-dark',
+    transformers: [...notationBlock()],
+  })
+}
+
+describe('notationBlock', () => {
+  test('highlight block annotation', () => {
+    const html = highlightBlockOnly(`function foo() {
+  // [!code hl:start]
+  const a = 1
+  const b = 2
+  // [!code hl:end]
+  const c = 3
+}`)
+    expect(html).toContain('highlighted')
+    expect(html.match(/class="[^"]*highlighted[^"]*"/g)?.length).toBe(2)
+    expect(html).not.toContain('[!code hl:start]')
+    expect(html).not.toContain('[!code hl:end]')
+  })
+
+  test('focus block annotation', () => {
+    const html = highlightBlockOnly(`function foo() {
+  // [!code focus:start]
+  const a = 1
+  const b = 2
+  // [!code focus:end]
+  const c = 3
+}`)
+    expect(html).toContain('focused')
+    expect(html).toContain('has-focused')
+    expect(html.match(/class="line focused"/g)?.length).toBe(2)
+    expect(html).not.toContain('[!code focus:start]')
+    expect(html).not.toContain('[!code focus:end]')
+  })
+
+  test('sequential blocks', () => {
+    const html = highlightBlockOnly(`// [!code hl:start]
+const a = 1
+// [!code hl:end]
+// [!code focus:start]
+const b = 2
+// [!code focus:end]`)
+    expect(html).toContain('highlighted')
+    expect(html).toContain('focused')
+  })
+
+  test('no annotation produces no block classes', () => {
+    const html = highlightBlockOnly(`function foo() {
+  return 1
+}`)
+    expect(html).not.toContain('highlighted')
+    expect(html).not.toContain('focused')
+  })
+
+  test('unclosed block highlights to end of code', () => {
+    const html = highlightBlockOnly(`const a = 1
+// [!code hl:start]
+const b = 2
+const c = 3`)
+    expect(html.match(/class="[^"]*highlighted[^"]*"/g)?.length).toBe(2)
+    expect(html).not.toContain('[!code hl:start]')
+  })
+
+  test('stray end marker is removed but has no effect', () => {
+    const html = highlightBlockOnly(`const a = 1
+// [!code hl:end]
+const b = 2`)
+    expect(html).not.toContain('highlighted')
+    expect(html).not.toContain('[!code hl:end]')
+  })
+
+  test('nested same-type blocks', () => {
+    const html = highlightBlockOnly(`// [!code hl:start]
+const a = 1
+// [!code hl:start]
+const b = 2
+// [!code hl:end]
+const c = 3
+// [!code hl:end]
+const d = 4`)
+    expect(html.match(/class="[^"]*highlighted[^"]*"/g)?.length).toBe(3)
+    expect(html).not.toContain('[!code')
+  })
+
+  test('overlapping different-type blocks', () => {
+    const html = highlightBlockOnly(`// [!code hl:start]
+const a = 1
+// [!code focus:start]
+const b = 2
+// [!code hl:end]
+const c = 3
+// [!code focus:end]
+const d = 4`)
+    const highlightedCount = html.match(/class="line[^"]*highlighted[^"]*"/g)?.length ?? 0
+    const focusedCount = html.match(/class="line[^"]*focused[^"]*"/g)?.length ?? 0
+    expect(highlightedCount).toBe(2)
+    expect(focusedCount).toBe(2)
+    const bothClasses = html.match(
+      /class="line[^"]*highlighted[^"]*focused[^"]*"|class="line[^"]*focused[^"]*highlighted[^"]*"/g,
+    )
+    expect(bothClasses?.length).toBe(1)
+  })
+
+  test('marker inside string literal is NOT detected', () => {
+    const html = highlightBlockOnly(`const s = "[!code hl:start]"
+const t = "[!code hl:end]"`)
+    expect(html).not.toContain('highlighted')
+    expect(html).toContain('[!code hl:start]')
+    expect(html).toContain('[!code hl:end]')
+  })
+
+  test('line count matches content minus markers', () => {
+    const html = highlightBlockOnly(`line1
+// [!code hl:start]
+line2
+line3
+// [!code hl:end]
+line4`)
+    const lineCount = html.match(/class="line[^"]*"/g)?.length ?? 0
+    expect(lineCount).toBe(4)
+  })
+
+  test('different comment styles (bash)', () => {
+    const bashHtml = highlightBlockOnly(
+      `x=1
+# [!code hl:start]
+y=2
+# [!code hl:end]
+z=3`,
+      'bash',
+    )
+    expect(bashHtml.match(/class="[^"]*highlighted[^"]*"/g)?.length).toBe(1)
+    expect(bashHtml).not.toContain('[!code')
   })
 })

--- a/src/internal/shiki-transformers.ts
+++ b/src/internal/shiki-transformers.ts
@@ -18,6 +18,99 @@ export {
 } from '@shikijs/transformers'
 
 /**
+ * Shiki transformer that enables block-based highlight and focus annotations.
+ *
+ * Detects `// [!code hl:start]` / `// [!code hl:end]` and
+ * `// [!code focus:start]` / `// [!code focus:end]` annotations,
+ * applying the appropriate class to all lines within the block.
+ *
+ * - `// [!code hl:start]` ... `// [!code hl:end]` - Highlights all lines in block
+ * - `// [!code focus:start]` ... `// [!code focus:end]` - Focuses all lines in block
+ *
+ * Marker lines are removed from output. Blocks can overlap and nest.
+ * Only pure marker lines (where the marker is the only meaningful content) are detected.
+ */
+export function notationBlock(): ShikiTransformer[] {
+  type Element = import('hast').Element
+  type Text = import('hast').Text
+  type ElementContent = import('hast').ElementContent
+
+  type BlockType = 'highlighted' | 'focused'
+  type BlockMarker = { type: BlockType; action: 'start' | 'end' }
+
+  const markerPattern =
+    /^\s*(?:\/\/|\/\*|#|;|--|<!--)\s*\[!code (hl|focus):(start|end)\]\s*(?:\*\/|-->)?\s*$/
+
+  function getTextContent(element: Element): string {
+    let text = ''
+    for (const child of element.children) {
+      if (child.type === 'text') text += (child as Text).value
+      else if (child.type === 'element') text += getTextContent(child as Element)
+    }
+    return text
+  }
+
+  function isMarkerLine(line: Element): BlockMarker | null {
+    const text = getTextContent(line)
+    const match = text.match(markerPattern)
+    if (!match) return null
+    const [, type, action] = match as [string, 'hl' | 'focus', 'start' | 'end']
+    const blockType: BlockType = type === 'hl' ? 'highlighted' : 'focused'
+    return { type: blockType, action }
+  }
+
+  return [
+    {
+      name: 'vocs:notation-block',
+      code(code) {
+        const activeBlocks: Map<BlockType, number> = new Map()
+        const newChildren: ElementContent[] = []
+        let hasFocus = false
+        let skipNextNewline = false
+
+        for (const child of code.children) {
+          if (skipNextNewline && child.type === 'text' && child.value === '\n') {
+            skipNextNewline = false
+            continue
+          }
+          skipNextNewline = false
+
+          if (child.type !== 'element') {
+            newChildren.push(child)
+            continue
+          }
+
+          const line = child as Element
+          const marker = isMarkerLine(line)
+
+          if (marker) {
+            if (marker.action === 'start') {
+              activeBlocks.set(marker.type, (activeBlocks.get(marker.type) ?? 0) + 1)
+            } else {
+              const count = activeBlocks.get(marker.type) ?? 0
+              if (count > 0) activeBlocks.set(marker.type, count - 1)
+            }
+            skipNextNewline = true
+            continue
+          }
+
+          for (const [blockType, count] of activeBlocks) {
+            if (count > 0) {
+              this.addClassToHast(line, blockType)
+              if (blockType === 'focused') hasFocus = true
+            }
+          }
+          newChildren.push(child)
+        }
+
+        code.children = newChildren
+        if (hasFocus) this.addClassToHast(code, 'has-focused')
+      },
+    },
+  ]
+}
+
+/**
  * Shiki transformer that enables collapsible code regions.
  *
  * Detects `// [!code collapse]` or `// [!code collapse:N]` annotations and marks


### PR DESCRIPTION
## Summary

Adds start/end block markers for highlight and focus annotations, allowing multiple consecutive lines to be annotated without repeating the marker on each line.

## Usage

```ts
// [!code hl:start]
const a = 1
const b = 2
const c = 3
// [!code hl:end]

// [!code focus:start]
const focused = true
// [!code focus:end]
```

## Features

- Supports `// [!code hl:start]` / `// [!code hl:end]` for highlight blocks
- Supports `// [!code focus:start]` / `// [!code focus:end]` for focus blocks
- Blocks can be used sequentially
- Marker lines are removed from output

---

_Closes #390 (superseded by this PR based on the `next` branch)_