### PR TITLE
fix: merge user-provided codeHighlight.langs with defaults

### DIFF
--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -430,7 +430,7 @@ export { remarkVocsScope } from './remark-vocs-scope.js'
 export function rehypeShiki(
   options: ExactPartial<rehypeShiki.Options> = {},
 ): [typeof shiki, RehypeShikiOptions] {
-  const { cacheDir, srcDir, rootDir, themes, twoslash = true } = options
+  const { cacheDir, langs: userLangs, srcDir, rootDir, themes, twoslash = true } = options
 
   // Process twoslash transformers - inject cacheDir if they're factory functions
   const rawTransformers =
@@ -443,6 +443,13 @@ export function rehypeShiki(
   const transformerLangs =
     rawTransformers?.flatMap((t) => ('langs' in t ? (t.langs as LanguageRegistration[]) : [])) ?? []
 
+  // Merge default languages with user-provided languages and transformer languages
+  const mergedLangs = [
+    ...Object.values(defaultLanguages),
+    ...(userLangs ?? []),
+    ...transformerLangs,
+  ]
+
   return [
     shiki,
     {
@@ -452,7 +459,7 @@ export function rehypeShiki(
       inline: 'tailing-curly-colon',
       rootStyle: false,
       themes,
-      langs: [...Object.values(defaultLanguages), ...transformerLangs],
+      langs: mergedLangs,
       // TODO: infer `langs` for faster cold start.
       transformers: [
         rootDir && srcDir ? ShikiTransformers.notationInclude({ srcDir, rootDir }) : undefined,


### PR DESCRIPTION
## Problem

The `codeHighlight.langs` config option is documented but effectively ignored. In `rehypeShiki()`, user-provided langs are overwritten:

```typescript
// src/internal/mdx.ts:455 (before fix)
langs: [...Object.values(defaultLanguages), ...transformerLangs],
```

This means users cannot add additional shiki language grammars via config.

## Reproduction

1. Create a vocs project with custom language config:
```typescript
// vocs.config.ts
import swift from 'shiki/langs/swift.mjs'

export default defineConfig({
  codeHighlight: {
    langs: [swift]
  }
})
```

2. Add a code block using that language in any MDX file:
````markdown
```swift
let greeting = "Hello, World!"
print(greeting)
```
````

3. **Expected**: Swift code has syntax highlighting
4. **Actual**: No syntax highlighting (falls back to plaintext)

## Solution

Merge user-provided langs with defaults instead of ignoring them:

```typescript
const mergedLangs = [
  ...Object.values(defaultLanguages),
  ...(userLangs ?? []),
  ...transformerLangs,
]
```

This preserves all default languages while allowing users to add additional ones.

## Testing

- Build passes
- Biome check passes