### PR TITLE
fix: include codeHighlight.langs in rehypeShiki options

### DIFF
--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -430,7 +430,7 @@ export { remarkVocsScope } from './remark-vocs-scope.js'
 export function rehypeShiki(
   options: ExactPartial<rehypeShiki.Options> = {},
 ): [typeof shiki, RehypeShikiOptions] {
-  const { cacheDir, srcDir, rootDir, themes, twoslash = true } = options
+  const { cacheDir, langs, srcDir, rootDir, themes, twoslash = true } = options
 
   // Process twoslash transformers - inject cacheDir if they're factory functions
   const rawTransformers =
@@ -452,7 +452,7 @@ export function rehypeShiki(
       inline: 'tailing-curly-colon',
       rootStyle: false,
       themes,
-      langs: [...Object.values(defaultLanguages), ...transformerLangs],
+      langs: [...Object.values(defaultLanguages), ...transformerLangs, ...(langs ?? [])],
       // TODO: infer `langs` for faster cold start.
       transformers: [
         rootDir && srcDir ? ShikiTransformers.notationInclude({ srcDir, rootDir }) : undefined,


### PR DESCRIPTION
The `codeHighlight.langs` config option was being set in config.ts but ignored in mdx.ts where rehypeShiki is configured. This meant users could not add additional Shiki languages beyond the default bundle.

This fix merges the user-provided langs with the default languages and transformer langs, allowing configuration like:

```ts
import lua from 'shiki/langs/lua.mjs'

export default defineConfig({
  codeHighlight: {
    langs: [lua],
  },
})
```

## Problem

In `config.ts` line 455, `codeHighlight.langs` is properly extracted:
```ts
langs: codeHighlight?.langs ?? (Langs.infer({ rootDir, srcDir, pagesDir }) as never),
```

But in `mdx.ts` line 455, it was being overwritten:
```ts
langs: [...Object.values(defaultLanguages), ...transformerLangs],
```

The config `langs` never reached the actual shiki plugin.

## Fix

Now the user-provided `langs` are merged:
```ts
langs: [...Object.values(defaultLanguages), ...transformerLangs, ...(langs ?? [])],
```