### PR TITLE
feat: add showSearch frontmatter option to hide search on specific pages

### DIFF
--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -372,6 +372,11 @@ export type Frontmatter = {
    */
   showAskAi?: boolean | undefined
   /**
+   * Whether to show the search box.
+   * @default true
+   */
+  showSearch?: boolean | undefined
+  /**
    * Whether to show the feedback widget.
    * @default true
    */

--- a/src/react/Layout.client.tsx
+++ b/src/react/Layout.client.tsx
@@ -24,7 +24,8 @@ import { useTopGutterRef } from './useTopGutterOffset.js'
 export function Main(props: Main.Props) {
   const { children } = props
 
-  const { layout, showAskAi, showSidebar, showTopNav, showLogo, showOutline } = useLayout()
+  const { layout, showAskAi, showSearch, showSidebar, showTopNav, showLogo, showOutline } =
+    useLayout()
   const { Footer, OutlineFooter, SidebarHeader } = useSlots()
 
   const sidebarScrollRef = React.useRef<HTMLDivElement>(null)
@@ -111,26 +112,30 @@ export function Main(props: Main.Props) {
 
             <div className="vocs:w-1" />
 
-            <div className="vocs:max-lg:w-[180px] vocs:w-[240px] vocs:max-md:hidden">
-              <Search.Search />
-            </div>
+            {showSearch && (
+              <div className="vocs:max-lg:w-[180px] vocs:w-[240px] vocs:max-md:hidden">
+                <Search.Search />
+              </div>
+            )}
           </div>
 
           <TopNav.TopNav className="vocs:max-lg:hidden vocs:px-2" />
 
           <div className="vocs:lg:hidden vocs:flex vocs:items-center vocs:px-3 vocs:gap-1">
-            <Search.Search
-              disableKeyboardShortcut
-              trigger={
-                <button
-                  aria-label="Search"
-                  className="vocs:flex vocs:md:hidden vocs:items-center vocs:justify-center vocs:cursor-pointer vocs:size-8"
-                  type="button"
-                >
-                  <LucideSearch />
-                </button>
-              }
-            />
+            {showSearch && (
+              <Search.Search
+                disableKeyboardShortcut
+                trigger={
+                  <button
+                    aria-label="Search"
+                    className="vocs:flex vocs:md:hidden vocs:items-center vocs:justify-center vocs:cursor-pointer vocs:size-8"
+                    type="button"
+                  >
+                    <LucideSearch />
+                  </button>
+                }
+              />
+            )}
 
             <MobileNav.MobileNav />
           </div>

--- a/src/react/useLayout.ts
+++ b/src/react/useLayout.ts
@@ -8,6 +8,7 @@ export type LayoutState = {
   showAskAi: boolean
   showLogo: boolean
   showOutline: boolean
+  showSearch: boolean
   showSidebar: boolean
   showTopNav: boolean
   /** Outline depth (number of heading levels to show). `undefined` means show all. */
@@ -37,6 +38,11 @@ export function useLayout(): LayoutState {
     },
     get showAskAi() {
       if (frontmatter?.showAskAi !== undefined) return frontmatter.showAskAi
+      if (layout === 'blank') return false
+      return true
+    },
+    get showSearch() {
+      if (frontmatter?.showSearch !== undefined) return frontmatter.showSearch
       if (layout === 'blank') return false
       return true
     },


### PR DESCRIPTION
Adds `showSearch` frontmatter option (analogous to `showAskAi`) to conditionally hide the search box on specific pages.

## Usage

```yaml
---
showSearch: false
showAskAi: false
---
```

## Changes
- Added `showSearch?: boolean` to frontmatter type in `config.ts`
- Added `showSearch` getter to `useLayout.ts`
- Wrapped Search components in `Layout.client.tsx` with `showSearch` conditional