### PR TITLE
feat: trigger native app deep links on mobile for Ask AI

### DIFF
--- a/src/react/internal/AskAi.tsx
+++ b/src/react/internal/AskAi.tsx
@@ -125,7 +125,16 @@ export function AskAi(props: AskAi.Props) {
                 <Menu.Item
                   key={provider.name}
                   className="vocs:flex vocs:items-center vocs:gap-2 vocs:px-2 vocs:py-1.5 vocs:text-primary/80 vocs:hover:text-heading vocs:hover:bg-accenta3 vocs:rounded-md vocs:text-sm vocs:cursor-pointer vocs:transition-colors"
-                  onClick={() => window.open(provider.url, '_blank')}
+                  onClick={() => {
+                    // On mobile, use location.href to trigger Universal Links / App Links
+                    // which will open the native app if installed
+                    const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
+                    if (isMobile) {
+                      window.location.href = provider.url
+                    } else {
+                      window.open(provider.url, '_blank')
+                    }
+                  }}
                 >
                   <provider.icon className="vocs:size-4" />
                   {provider.name}


### PR DESCRIPTION
## Problem

On mobile, clicking Claude or ChatGPT in the Ask AI menu opens a new browser tab instead of the native app, even when installed.

## Solution

Use `window.location.href` instead of `window.open(url, '_blank')` on mobile devices. This properly triggers iOS Universal Links and Android App Links, which will open the native Claude/ChatGPT app if installed.

## Notes

Neither Claude nor ChatGPT have custom URL schemes (`claude://`, `chatgpt://`), but both apps register Universal Links / App Links for their web domains. The key is using `location.href` rather than `window.open` with `_blank`, which browsers may treat as a new tab rather than a navigation that triggers app routing.