### PR TITLE
feat(ask-ai): add copied confirmation for copy actions

### DIFF
--- a/src/react/internal/AskAi.tsx
+++ b/src/react/internal/AskAi.tsx
@@ -19,6 +19,7 @@ export function AskAi(props: AskAi.Props) {
 
   const [menuOpen, setMenuOpen] = React.useState(false)
   const [copied, setCopied] = React.useState(false)
+  const [mcpCopied, setMcpCopied] = React.useState(false)
 
   const [modifierKey, setModifierKey] = React.useState('⌘')
   React.useEffect(() => {
@@ -32,6 +33,12 @@ export function AskAi(props: AskAi.Props) {
     const timeout = setTimeout(() => setCopied(false), 1500)
     return () => clearTimeout(timeout)
   }, [copied])
+
+  React.useEffect(() => {
+    if (!mcpCopied) return
+    const timeout = setTimeout(() => setMcpCopied(false), 1500)
+    return () => clearTimeout(timeout)
+  }, [mcpCopied])
 
   React.useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -145,6 +152,7 @@ export function AskAi(props: AskAi.Props) {
             <Menu.Separator className="vocs:my-2 vocs:border-t vocs:border-primary" />
 
             <Menu.Item
+              closeOnClick={false}
               className="vocs:flex vocs:items-center vocs:gap-2 vocs:px-2 vocs:py-1.5 vocs:text-primary/80 vocs:hover:text-heading vocs:hover:bg-accenta3 vocs:rounded-md vocs:text-sm vocs:cursor-pointer vocs:transition-colors"
               onClick={copyPageForAi}
             >
@@ -164,13 +172,15 @@ export function AskAi(props: AskAi.Props) {
               <>
                 <Menu.Separator className="vocs:my-2 vocs:border-t vocs:border-primary" />
                 <Menu.Item
+                  closeOnClick={false}
                   className="vocs:flex vocs:items-center vocs:gap-2 vocs:px-2 vocs:py-1.5 vocs:text-primary/80 vocs:hover:text-heading vocs:hover:bg-accenta3 vocs:rounded-md vocs:text-sm vocs:cursor-pointer vocs:transition-colors"
                   onClick={() => {
                     navigator.clipboard.writeText(mcpUrl)
+                    setMcpCopied(true)
                   }}
                 >
                   <SimpleIconsModelcontextprotocol className="vocs:size-4" />
-                  Copy MCP URL
+                  {mcpCopied ? 'Copied!' : 'Copy MCP URL'}
                 </Menu.Item>
               </>
             )}


### PR DESCRIPTION
Adds "Copied!" feedback for both copy menu items in the Ask AI dropdown:

- **Copy page for AI**: Menu now stays open after clicking so users can see the "Copied!" confirmation
- **Copy MCP URL**: Added the same "Copied!" feedback (was missing previously)

Uses `closeOnClick={false}` on both copy menu items to prevent the menu from closing before the user sees the confirmation.

![CleanShot 2026-02-04 at 16 43 32](https://github.com/user-attachments/assets/d7391091-47b1-4a25-bcf7-dce1e164ec3e)

