### PR TITLE
fix: redirect .md URLs to clean paths for browser requests

### DIFF
--- a/src/waku/internal/middleware/md-router.ts
+++ b/src/waku/internal/middleware/md-router.ts
@@ -110,6 +110,16 @@ export function middleware(): MiddlewareHandler {
     const isMarkdownRequest = url.pathname.endsWith('.md')
     if (!isMarkdownRequest && !isAiAgent && !isTerminal) return next()
 
+    // Regular browsers requesting .md URLs should get the rendered HTML page,
+    // not raw markdown. Redirect to the clean URL so Vocs renders it.
+    if (isMarkdownRequest && !isAiAgent && !isTerminal && !acceptsMarkdown) {
+      const cleanPath = url.pathname.replace(/\.md$/, '').replace(/\/index$/, '') || '/'
+      const destination = new URL(cleanPath, url.origin)
+      destination.search = url.search
+      context.res = context.redirect(destination.toString(), 302)
+      return
+    }
+
     const pagePath = url.pathname.replace(/\.md$/, '').replace(/\/index$/, '')
 
     let text: string | null


### PR DESCRIPTION
Regular browsers requesting `.md` URLs (e.g. `/overview.md`) were either getting raw markdown or a 404 since Waku routes are extensionless.

Now redirects browser `.md` requests to the clean URL so Vocs renders the HTML page. AI agents, terminals, and `Accept: text/markdown` requests still receive raw markdown as before.