### PR TITLE
fix: read markdown assets from disk instead of self-fetching

### DIFF
--- a/src/waku/internal/middleware/md-router.test.ts
+++ b/src/waku/internal/middleware/md-router.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+}))
+
+vi.mock('node:path', async () => {
+  const actual = await vi.importActual<typeof import('node:path')>('node:path')
+  return { ...actual, resolve: actual.resolve, join: actual.join, dirname: actual.dirname }
+})
+
+vi.mock('node:url', async () => {
+  const actual = await vi.importActual<typeof import('node:url')>('node:url')
+  return { ...actual }
+})
+
+describe('fetchMarkdown', () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    globalThis.fetch = originalFetch
+  })
+
+  it('returns content from disk without making an HTTP fetch', async () => {
+    const { readFile } = await import('node:fs/promises')
+    vi.mocked(readFile).mockResolvedValue('# Hello from disk')
+
+    const fetchSpy = vi.fn()
+    globalThis.fetch = fetchSpy
+
+    const { fetchMarkdown } = await import('./md-router.js')
+    const result = await fetchMarkdown(new URL('https://example.com'), '/llms.txt')
+
+    expect(result).toBe('# Hello from disk')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('falls back to HTTP fetch with cookies when disk read fails', async () => {
+    const { readFile } = await import('node:fs/promises')
+    vi.mocked(readFile).mockRejectedValue(new Error('ENOENT'))
+
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('# Hello from fetch', { status: 200 }))
+    globalThis.fetch = fetchSpy
+
+    const { fetchMarkdown } = await import('./md-router.js')
+    const result = await fetchMarkdown(
+      new URL('https://example.com'),
+      '/assets/md/docs.md',
+      'session=abc123',
+    )
+
+    expect(result).toBe('# Hello from fetch')
+    expect(fetchSpy).toHaveBeenCalledOnce()
+    const [url, init] = fetchSpy.mock.calls[0]
+    expect(url.toString()).toBe('https://example.com/assets/md/docs.md')
+    expect(init.headers).toEqual({ cookie: 'session=abc123' })
+  })
+
+  it('returns null when both disk and HTTP fetch fail', async () => {
+    const { readFile } = await import('node:fs/promises')
+    vi.mocked(readFile).mockRejectedValue(new Error('ENOENT'))
+
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('Not Found', { status: 404 }))
+    globalThis.fetch = fetchSpy
+
+    const { fetchMarkdown } = await import('./md-router.js')
+    const result = await fetchMarkdown(new URL('https://example.com'), '/assets/md/missing.md')
+
+    expect(result).toBeNull()
+  })
+})

--- a/src/waku/internal/middleware/md-router.test.ts
+++ b/src/waku/internal/middleware/md-router.test.ts
@@ -52,9 +52,9 @@ describe('fetchMarkdown', () => {
 
     expect(result).toBe('# Hello from fetch')
     expect(fetchSpy).toHaveBeenCalledOnce()
-    const [url, init] = fetchSpy.mock.calls[0]
-    expect(url.toString()).toBe('https://example.com/assets/md/docs.md')
-    expect(init.headers).toEqual({ cookie: 'session=abc123' })
+    const call = fetchSpy.mock.calls[0]
+    expect(call?.[0].toString()).toBe('https://example.com/assets/md/docs.md')
+    expect(call?.[1].headers).toEqual({ cookie: 'session=abc123' })
   })
 
   it('returns null when both disk and HTTP fetch fail', async () => {

--- a/src/waku/internal/middleware/md-router.ts
+++ b/src/waku/internal/middleware/md-router.ts
@@ -83,7 +83,7 @@ export async function fetchMarkdown(url: URL, assetPath: string, cookie?: string
   // Fall back to HTTP fetch, forwarding cookies for auth-protected deployments.
   const assetUrl = new URL(assetPath, url.origin)
   const headers: HeadersInit = {}
-  if (cookie) headers.cookie = cookie
+  if (cookie) headers['cookie'] = cookie
   const response = await globalThis.fetch(assetUrl, { headers })
   if (!response.ok) return null
   return response.text()

--- a/src/waku/internal/middleware/md-router.ts
+++ b/src/waku/internal/middleware/md-router.ts
@@ -69,7 +69,7 @@ async function resolveContent() {
   })
 }
 
-async function fetchMarkdown(url: URL, assetPath: string, cookie?: string) {
+export async function fetchMarkdown(url: URL, assetPath: string, cookie?: string) {
   // Try reading from disk first (avoids self-fetch issues with deployment protection).
   try {
     const fs = await import('node:fs/promises')

--- a/src/waku/internal/middleware/md-router.ts
+++ b/src/waku/internal/middleware/md-router.ts
@@ -69,9 +69,22 @@ async function resolveContent() {
   })
 }
 
-async function fetchMarkdown(url: URL, assetPath: string) {
+async function fetchMarkdown(url: URL, assetPath: string, cookie?: string) {
+  // Try reading from disk first (avoids self-fetch issues with deployment protection).
+  try {
+    const fs = await import('node:fs/promises')
+    const path = await import('node:path')
+    const { fileURLToPath } = await import('node:url')
+    const distDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+    const filePath = path.join(distDir, 'public', assetPath.replace(/^\//, ''))
+    return await fs.readFile(filePath, 'utf-8')
+  } catch {}
+
+  // Fall back to HTTP fetch, forwarding cookies for auth-protected deployments.
   const assetUrl = new URL(assetPath, url.origin)
-  const response = await globalThis.fetch(assetUrl)
+  const headers: HeadersInit = {}
+  if (cookie) headers.cookie = cookie
+  const response = await globalThis.fetch(assetUrl, { headers })
   if (!response.ok) return null
   return response.text()
 }
@@ -95,7 +108,7 @@ export function middleware(): MiddlewareHandler {
         const content = await resolveContent()
         text = content.short
       } else {
-        text = await fetchMarkdown(url, '/llms.txt')
+        text = await fetchMarkdown(url, '/llms.txt', context.req.header('cookie'))
       }
       if (!text) return next()
 
@@ -123,7 +136,7 @@ export function middleware(): MiddlewareHandler {
       const assetPath = url.pathname.endsWith('.md')
         ? `/assets/md${url.pathname}`
         : `/assets/md${url.pathname}.md`
-      text = await fetchMarkdown(url, assetPath)
+      text = await fetchMarkdown(url, assetPath, context.req.header('cookie'))
     }
     if (!text) return next()
 


### PR DESCRIPTION
The `md-router` middleware fetches markdown assets via HTTP back to the same origin (`globalThis.fetch(assetUrl)`). This self-fetch fails when Vercel deployment protection is enabled because the request lacks auth cookies, returning 401 — causing all `.md` URLs to 404.

**Fix:** Read the build output files directly from disk first (`dist/public/assets/md/`), which is faster and avoids auth issues entirely. Falls back to HTTP fetch with cookie forwarding if the file isn't on disk.