### PR TITLE
feat(icons): add builtin icons for AI coding agents

### DIFF
--- a/src/internal/icons.ts
+++ b/src/internal/icons.ts
@@ -5,6 +5,11 @@ import { icons as simpleIcons } from '@iconify-json/simple-icons'
 import { icons as vscodeIcons } from '@iconify-json/vscode-icons'
 
 export const builtinIcons: Record<string, string> = {
+  // AI coding agents
+  'claude code': 'simple-icons:anthropic',
+  codex: 'simple-icons:openai',
+  amp: '<svg viewBox="0 0 28 28" fill="currentColor"><path d="M13.9197 13.61L17.3816 26.566L14.242 27.4049L11.2645 16.2643L0.119926 13.2906L0.957817 10.15L13.9197 13.61Z"/><path d="M13.7391 16.0892L4.88169 24.9056L2.58872 22.6019L11.4461 13.7865L13.7391 16.0892Z"/><path d="M18.9386 8.58315L22.4005 21.5392L19.2609 22.3781L16.2833 11.2374L5.13879 8.26381L5.97668 5.12318L18.9386 8.58315Z"/><path d="M23.9803 3.55632L27.4422 16.5124L24.3025 17.3512L21.325 6.21062L10.1805 3.23698L11.0183 0.0963593L23.9803 3.55632Z"/></svg>',
+
   // Package managers
   npm: 'vscode-icons:file-type-npm',
   yarn: 'vscode-icons:file-type-yarn',

--- a/src/internal/icons.ts
+++ b/src/internal/icons.ts
@@ -7,6 +7,7 @@ import { icons as vscodeIcons } from '@iconify-json/vscode-icons'
 export const builtinIcons: Record<string, string> = {
   // AI coding agents
   'claude code': 'simple-icons:anthropic',
+  claude: 'simple-icons:anthropic',
   codex: 'simple-icons:openai',
   amp: '<svg viewBox="0 0 28 28" fill="currentColor"><path d="M13.9197 13.61L17.3816 26.566L14.242 27.4049L11.2645 16.2643L0.119926 13.2906L0.957817 10.15L13.9197 13.61Z"/><path d="M13.7391 16.0892L4.88169 24.9056L2.58872 22.6019L11.4461 13.7865L13.7391 16.0892Z"/><path d="M18.9386 8.58315L22.4005 21.5392L19.2609 22.3781L16.2833 11.2374L5.13879 8.26381L5.97668 5.12318L18.9386 8.58315Z"/><path d="M23.9803 3.55632L27.4422 16.5124L24.3025 17.3512L21.325 6.21062L10.1805 3.23698L11.0183 0.0963593L23.9803 3.55632Z"/></svg>',
 


### PR DESCRIPTION
Adds three new entries to `builtinIcons` so code-group tabs titled **Claude Code**, **Codex**, or **Amp** automatically display brand icons via the `group-icons` Vite plugin.

| Tab title | Icon source |
|-----------|-------------|
| Claude Code | `simple-icons:anthropic` |
| Codex | `simple-icons:openai` |
| Amp | Inline SVG (Amp brand mark) |

No changes needed in MDX — any `:::code-group` with these tab titles gets icons for free.