### PR TITLE
fix(mcp): use pre-built page index instead of filesystem scanning

### DIFF
--- a/src/internal/mcp.ts
+++ b/src/internal/mcp.ts
@@ -38,6 +38,41 @@ export type McpConfig = {
   sources?: readonly McpSource.Adapter[] | undefined
 }
 
+export type McpPage = {
+  path: string
+  title: string
+  description?: string | undefined
+  content: string
+}
+
+async function loadPages(config: Config): Promise<McpPage[]> {
+  // Try pre-built index first (works in production and after local build)
+  const indexPath = path.resolve(config.rootDir, config.outDir, 'public', 'mcp-index.json')
+  try {
+    const data = await fs.readFile(indexPath, 'utf-8')
+    return JSON.parse(data) as McpPage[]
+  } catch {}
+
+  // Fallback: scan source files directly (dev mode)
+  try {
+    const pagesDir = path.resolve(config.rootDir, config.srcDir, config.pagesDir)
+    const files = await Array.fromAsync(fs.glob(`${pagesDir}/**/*.{md,mdx}`))
+    return await Promise.all(
+      files.map(async (file) => {
+        const content = await fs.readFile(file, 'utf-8')
+        const pagePath = file
+          .replace(pagesDir, '')
+          .replace(/\.mdx?$/, '')
+          .replace(/\/$/, '')
+          .replace(/index$/, '')
+        return { path: pagePath || '/', title: '', content }
+      }),
+    )
+  } catch {}
+
+  return []
+}
+
 /**
  * Create an MCP server instance with all documentation tools registered.
  */
@@ -50,8 +85,6 @@ export function createServer(config: Config): McpServer {
     { capabilities: { logging: {} } },
   )
 
-  const pagesDir = path.resolve(config.rootDir, config.srcDir, config.pagesDir)
-
   server.registerTool(
     'list_pages',
     {
@@ -59,16 +92,8 @@ export function createServer(config: Config): McpServer {
       inputSchema: {},
     },
     async () => {
-      const pages = await Array.fromAsync(fs.glob(`${pagesDir}/**/*.{md,mdx}`))
-
-      const results = pages.map((page) => {
-        const relativePath = page
-          .replace(pagesDir, '')
-          .replace(/\.mdx?$/, '')
-          .replace(/\/$/, '')
-          .replace(/index$/, '')
-        return relativePath || '/'
-      })
+      const pages = await loadPages(config)
+      const results = pages.map((p) => p.path)
 
       return {
         content: [{ type: 'text', text: JSON.stringify(results, null, 2) }],
@@ -85,19 +110,13 @@ export function createServer(config: Config): McpServer {
       },
     },
     async ({ pagePath }) => {
-      const possiblePaths = [
-        path.join(pagesDir, `${pagePath}.mdx`),
-        path.join(pagesDir, `${pagePath}.md`),
-        path.join(pagesDir, pagePath, 'index.mdx'),
-        path.join(pagesDir, pagePath, 'index.md'),
-      ]
+      const pages = await loadPages(config)
+      const normalized = pagePath.replace(/\/index$/, '').replace(/\/$/, '') || '/'
+      const page = pages.find(
+        (p) => p.path === normalized || p.path === `${normalized}/` || p.path === pagePath,
+      )
 
-      for (const filePath of possiblePaths) {
-        try {
-          const content = await fs.readFile(filePath, 'utf-8')
-          return { content: [{ type: 'text', text: content }] }
-        } catch {}
-      }
+      if (page) return { content: [{ type: 'text', text: page.content }] }
 
       return {
         content: [{ type: 'text', text: `Page not found: ${pagePath}` }],
@@ -116,23 +135,16 @@ export function createServer(config: Config): McpServer {
     },
     async ({ query }) => {
       const lowerQuery = query.toLowerCase()
-      const pages = await Array.fromAsync(fs.glob(`${pagesDir}/**/*.{md,mdx}`))
+      const pages = await loadPages(config)
 
       const results: { path: string; snippet: string }[] = []
 
       for (const page of pages) {
-        const content = await fs.readFile(page, 'utf-8')
-        if (content.toLowerCase().includes(lowerQuery)) {
-          const lines = content.split('\n')
+        if (page.content.toLowerCase().includes(lowerQuery)) {
+          const lines = page.content.split('\n')
           const matchLine = lines.find((line) => line.toLowerCase().includes(lowerQuery))
-          const relativePath = page
-            .replace(pagesDir, '')
-            .replace(/\.mdx?$/, '')
-            .replace(/\/$/, '')
-            .replace(/index$/, '')
-
           results.push({
-            path: relativePath || '/',
+            path: page.path,
             snippet: matchLine?.trim().slice(0, 200) || '',
           })
         }

--- a/src/internal/vite-plugins.ts
+++ b/src/internal/vite-plugins.ts
@@ -190,6 +190,19 @@ export function llms(config: Config.Config): PluginOption {
           return
         }
 
+        if (req.url === '/mcp-index.json') {
+          content = await buildLlmsContent()
+          const mcpIndex = content.results.map(({ content, path, title, description }) => ({
+            path,
+            title,
+            description,
+            content,
+          }))
+          res.setHeader('Content-Type', 'application/json')
+          res.end(JSON.stringify(mcpIndex))
+          return
+        }
+
         if (req.url?.startsWith('/assets/md/')) {
           content = await buildLlmsContent()
           const pagePath = req.url.slice('/assets/md'.length, -3) || '/'
@@ -210,9 +223,20 @@ export function llms(config: Config.Config): PluginOption {
       const content = await buildLlmsContent()
       const outDir = path.resolve(viteConfig.root, config.outDir, 'public')
       await fs.mkdir(outDir, { recursive: true })
+
+      const mcpIndex = content.results.map(({ content, path, title, description }) => ({
+        path,
+        title,
+        description,
+        content,
+      }))
+
       await Promise.all([
         fs.writeFile(path.join(outDir, 'llms-full.txt'), content.full, { encoding: 'utf-8' }),
         fs.writeFile(path.join(outDir, 'llms.txt'), content.short, { encoding: 'utf-8' }),
+        fs.writeFile(path.join(outDir, 'mcp-index.json'), JSON.stringify(mcpIndex), {
+          encoding: 'utf-8',
+        }),
         ...content.results.map(async ({ content, path: pagePath }) => {
           const mdPath = path.join(
             outDir,


### PR DESCRIPTION
MCP documentation tools (list_pages, read_page, search_docs) were failing with 500 errors in production because they used fs.glob to scan for source .mdx files at runtime, which don't exist in serverless environments like Vercel where only compiled JS is deployed. This fix generates an mcp-index.json manifest at build time (alongside llms.txt) containing all page paths, titles, and content, and updates the MCP server to read from this index in production while falling back to filesystem scanning in dev.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how MCP tools source and normalize documentation content/paths across dev vs production, and adds a new build artifact that must be generated and deployed correctly.
> 
> **Overview**
> **MCP documentation tools now read from a build-time page manifest instead of scanning source files at runtime.** `list_pages`, `read_page`, and `search_docs` load pages via a new `loadPages()` helper that prefers `public/mcp-index.json` (production/local build) and only falls back to `fs.glob` scanning in dev.
> 
> **Build/dev server now generates and serves `mcp-index.json`.** The `llms` Vite plugin derives an MCP index from `buildLlmsContent()` results, serves it at `/mcp-index.json` in dev, and writes it to `dist/public/mcp-index.json` on build alongside existing `llms*.txt` outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23bd49f6551b6fe0c0f7159da15f0dbf78eb8d94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->