### PR TITLE
fix: use relative paths in redirect Location headers

### DIFF
--- a/src/internal/redirects.test.ts
+++ b/src/internal/redirects.test.ts
@@ -1,6 +1,50 @@
 import { describe, expect, it } from 'vitest'
 import * as Redirects from './redirects.js'
 
+describe('Redirects.appendSearch', () => {
+  it('appends query string to bare path', () => {
+    expect(Redirects.appendSearch('/overview', '?ref=nav')).toBe('/overview?ref=nav')
+  })
+
+  it('merges with existing query string', () => {
+    expect(Redirects.appendSearch('/overview?tab=api', '?ref=nav')).toBe(
+      '/overview?tab=api&ref=nav',
+    )
+  })
+
+  it('inserts query before hash fragment', () => {
+    expect(Redirects.appendSearch('/overview#intro', '?ref=nav')).toBe('/overview?ref=nav#intro')
+  })
+
+  it('merges query and preserves hash fragment', () => {
+    expect(Redirects.appendSearch('/overview?tab=api#intro', '?ref=nav')).toBe(
+      '/overview?tab=api&ref=nav#intro',
+    )
+  })
+
+  it('returns destination unchanged when search is empty', () => {
+    expect(Redirects.appendSearch('/overview', '')).toBe('/overview')
+  })
+
+  it('works with absolute URLs', () => {
+    expect(Redirects.appendSearch('https://example.com/docs', '?ref=nav')).toBe(
+      'https://example.com/docs?ref=nav',
+    )
+  })
+
+  it('merges query on absolute URL with existing params', () => {
+    expect(Redirects.appendSearch('https://example.com/docs?tab=api', '?ref=nav')).toBe(
+      'https://example.com/docs?tab=api&ref=nav',
+    )
+  })
+
+  it('handles absolute URL with hash', () => {
+    expect(Redirects.appendSearch('https://example.com/docs#intro', '?ref=nav')).toBe(
+      'https://example.com/docs?ref=nav#intro',
+    )
+  })
+})
+
 describe('Redirects.from', () => {
   it('compiles simple rules', () => {
     const rules = Redirects.from([

--- a/src/internal/redirects.ts
+++ b/src/internal/redirects.ts
@@ -96,6 +96,28 @@ export declare namespace resolve {
 }
 
 /**
+ * Appends a request's query string to a redirect destination, handling
+ * destinations that may already contain query parameters or hash fragments.
+ *
+ * @example
+ * appendSearch('/overview', '?ref=nav')           // '/overview?ref=nav'
+ * appendSearch('/overview?tab=api', '?ref=nav')   // '/overview?tab=api&ref=nav'
+ * appendSearch('/overview#intro', '?ref=nav')     // '/overview?ref=nav#intro'
+ * appendSearch('https://example.com', '')         // 'https://example.com'
+ */
+export function appendSearch(destination: string, search: string): string {
+  if (!search) return destination
+
+  const hashIndex = destination.indexOf('#')
+  const [base, hash] = hashIndex >= 0
+    ? [destination.slice(0, hashIndex), destination.slice(hashIndex)]
+    : [destination, '']
+
+  const query = search.slice(1) // strip leading '?'
+  return `${base}${base.includes('?') ? '&' : '?'}${query}${hash}`
+}
+
+/**
  * Interpolates path parameters into a template string.
  */
 function interpolate(template: string, params: Record<string, string | undefined>): string {

--- a/src/waku/internal/middleware/redirects.test.ts
+++ b/src/waku/internal/middleware/redirects.test.ts
@@ -1,0 +1,168 @@
+import { Hono } from 'hono'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Mock Config.resolve so we can inject redirect rules without a real vocs config.
+vi.mock('../../../internal/config.js', () => ({
+  resolve: vi.fn(),
+}))
+
+import * as Config from '../../../internal/config.js'
+import { redirects } from './redirects.js'
+
+const mockConfig = vi.mocked(Config.resolve)
+
+afterEach(() => vi.restoreAllMocks())
+
+/**
+ * Creates a Hono app with the redirects middleware and a catch-all handler,
+ * then sends a request to the given URL.
+ */
+function request(url: string) {
+  const app = new Hono()
+  app.use('*', redirects())
+  app.get('*', (c) => c.text('ok'))
+  return app.request(url)
+}
+
+describe('redirects middleware', () => {
+  it('redirects exact path match', async () => {
+    mockConfig.mockResolvedValue({
+      redirects: [{ source: '/docs', destination: '/overview' }],
+    } as any)
+
+    const res = await request('http://localhost/docs')
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toBe('/overview')
+  })
+
+  it('uses custom status code', async () => {
+    mockConfig.mockResolvedValue({
+      redirects: [{ source: '/old', destination: '/new', status: 301 }],
+    } as any)
+
+    const res = await request('http://localhost/old')
+    expect(res.status).toBe(301)
+    expect(res.headers.get('location')).toBe('/new')
+  })
+
+  it('preserves query string on relative destination', async () => {
+    mockConfig.mockResolvedValue({
+      redirects: [{ source: '/docs', destination: '/overview' }],
+    } as any)
+
+    const res = await request('http://localhost/docs?ref=nav&lang=en')
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toBe('/overview?ref=nav&lang=en')
+  })
+
+  it('preserves query string on absolute destination', async () => {
+    mockConfig.mockResolvedValue({
+      redirects: [{ source: '/spec', destination: 'https://paymentauth.org' }],
+    } as any)
+
+    const res = await request('http://localhost/spec?section=core')
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toBe('https://paymentauth.org?section=core')
+  })
+
+  it('does not inherit http:// protocol from reverse proxy', async () => {
+    // Behind TLS-terminating proxies (e.g. Vercel), the internal request
+    // URL uses http:// even though the client connected over https://.
+    // The Location header must be a relative path — not an absolute URL
+    // with the wrong protocol.
+    mockConfig.mockResolvedValue({
+      redirects: [{ source: '/docs', destination: '/overview' }],
+    } as any)
+
+    const res = await request('http://mpp.dev/docs')
+    expect(res.status).toBe(307)
+    const location = res.headers.get('location')!
+    expect(location).toBe('/overview')
+    expect(location).not.toContain('http://')
+  })
+
+  it('redirects to external URL without modification', async () => {
+    mockConfig.mockResolvedValue({
+      redirects: [{ source: '/github', destination: 'https://github.com/wevm/vocs' }],
+    } as any)
+
+    const res = await request('http://localhost/github')
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toBe('https://github.com/wevm/vocs')
+  })
+
+  it('resolves parameterized paths', async () => {
+    mockConfig.mockResolvedValue({
+      redirects: [{ source: '/blog/:slug', destination: '/posts/:slug' }],
+    } as any)
+
+    const res = await request('http://localhost/blog/hello-world')
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toBe('/posts/hello-world')
+  })
+
+  it('resolves wildcard paths', async () => {
+    mockConfig.mockResolvedValue({
+      redirects: [{ source: '/docs/:path*', destination: '/v2/:path*' }],
+    } as any)
+
+    const res = await request('http://localhost/docs/getting-started/intro')
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toBe('/v2/getting-started/intro')
+  })
+
+  it('passes through when no redirects configured', async () => {
+    mockConfig.mockResolvedValue({ redirects: [] } as any)
+
+    const res = await request('http://localhost/about')
+    expect(res.status).toBe(200)
+  })
+
+  it('passes through when no rules match', async () => {
+    mockConfig.mockResolvedValue({
+      redirects: [{ source: '/old', destination: '/new' }],
+    } as any)
+
+    const res = await request('http://localhost/about')
+    expect(res.status).toBe(200)
+  })
+
+  it('passes through when redirects is undefined', async () => {
+    mockConfig.mockResolvedValue({} as any)
+
+    const res = await request('http://localhost/anything')
+    expect(res.status).toBe(200)
+  })
+
+  it('merges query when destination already has query params', async () => {
+    mockConfig.mockResolvedValue({
+      redirects: [{ source: '/docs', destination: '/overview?tab=api' }],
+    } as any)
+
+    const res = await request('http://localhost/docs?ref=nav')
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toBe('/overview?tab=api&ref=nav')
+  })
+
+  it('inserts query before destination hash fragment', async () => {
+    mockConfig.mockResolvedValue({
+      redirects: [{ source: '/docs', destination: '/overview#intro' }],
+    } as any)
+
+    const res = await request('http://localhost/docs?ref=nav')
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toBe('/overview?ref=nav#intro')
+  })
+
+  it('merges query and preserves hash on absolute destination', async () => {
+    mockConfig.mockResolvedValue({
+      redirects: [{ source: '/spec', destination: 'https://paymentauth.org/core?v=2#overview' }],
+    } as any)
+
+    const res = await request('http://localhost/spec?section=challenges')
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toBe(
+      'https://paymentauth.org/core?v=2&section=challenges#overview',
+    )
+  })
+})

--- a/src/waku/internal/middleware/redirects.ts
+++ b/src/waku/internal/middleware/redirects.ts
@@ -2,6 +2,13 @@ import type { MiddlewareHandler } from 'hono'
 import * as Config from '../../../internal/config.js'
 import * as Redirects from '../../../internal/redirects.js'
 
+/**
+ * Applies configured redirects.
+ *
+ * Uses relative Location values for relative destinations so redirects work
+ * correctly behind TLS-terminating reverse proxies, where the internal
+ * request URL may use `http://`.
+ */
 export const redirects = (): MiddlewareHandler => {
   return async (context, next) => {
     const config = await Config.resolve({ server: true })
@@ -14,13 +21,9 @@ export const redirects = (): MiddlewareHandler => {
     const result = Redirects.resolve(url.pathname, rules)
     if (!result) return next()
 
-    const destination = new URL(result.destination, url.origin)
-    destination.search = url.search
+    const destination = Redirects.appendSearch(result.destination, url.search)
 
-    context.res = context.redirect(
-      destination.toString(),
-      result.status as 301 | 302 | 303 | 307 | 308,
-    )
+    context.res = context.redirect(destination, result.status as 301 | 302 | 303 | 307 | 308)
     return
   }
 }

--- a/src/waku/internal/middleware/trailing-slash.test.ts
+++ b/src/waku/internal/middleware/trailing-slash.test.ts
@@ -1,0 +1,60 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import { trailingSlash } from './trailing-slash.js'
+
+/**
+ * Creates a Hono app with trailing-slash middleware and a catch-all handler,
+ * then sends a request to the given path.
+ */
+function request(path: string) {
+  const app = new Hono()
+  app.use('*', trailingSlash())
+  app.get('*', (c) => c.text('ok'))
+  return app.request(path)
+}
+
+describe('trailingSlash', () => {
+  it('strips trailing slash and redirects with 308', async () => {
+    const res = await request('http://localhost/about/')
+    expect(res.status).toBe(308)
+    expect(res.headers.get('location')).toBe('/about')
+  })
+
+  it('preserves query string', async () => {
+    const res = await request('http://localhost/docs/?ref=nav')
+    expect(res.status).toBe(308)
+    expect(res.headers.get('location')).toBe('/docs?ref=nav')
+  })
+
+  it('skips root path', async () => {
+    const res = await request('http://localhost/')
+    expect(res.status).toBe(200)
+  })
+
+  it('skips paths with file extensions', async () => {
+    const res = await request('http://localhost/styles.css')
+    expect(res.status).toBe(200)
+  })
+
+  it('passes through paths without trailing slash', async () => {
+    const res = await request('http://localhost/about')
+    expect(res.status).toBe(200)
+  })
+
+  it('does not inherit http:// protocol from reverse proxy', async () => {
+    // Behind TLS-terminating proxies (e.g. Vercel), the internal request
+    // URL uses http:// even though the client connected over https://.
+    // The Location header must not leak the internal http:// origin.
+    const res = await request('http://mpp.dev/about/')
+    expect(res.status).toBe(308)
+    const location = res.headers.get('location')!
+    expect(location).toBe('/about')
+    expect(location).not.toContain('http://')
+  })
+
+  it('handles deeply nested paths', async () => {
+    const res = await request('http://localhost/sdk/typescript/core/')
+    expect(res.status).toBe(308)
+    expect(res.headers.get('location')).toBe('/sdk/typescript/core')
+  })
+})

--- a/src/waku/internal/middleware/trailing-slash.ts
+++ b/src/waku/internal/middleware/trailing-slash.ts
@@ -1,5 +1,16 @@
 import type { MiddlewareHandler } from 'hono'
+import { appendSearch } from '../../../internal/redirects.js'
 
+/**
+ * Removes trailing slashes from URLs.
+ *
+ * Redirects `/about/` → `/about` with a 308 Permanent Redirect.
+ * Skips the root path (`/`) and paths with file extensions.
+ *
+ * Uses relative Location values so redirects work correctly behind
+ * TLS-terminating reverse proxies, where the internal request URL
+ * may use `http://`.
+ */
 export const trailingSlash = (): MiddlewareHandler => {
   return async (context, next) => {
     const url = new URL(context.req.url)
@@ -9,10 +20,8 @@ export const trailingSlash = (): MiddlewareHandler => {
 
     // Redirect trailing slash to non-trailing slash
     if (url.pathname.endsWith('/')) {
-      const destination = new URL(url.pathname.slice(0, -1), url.origin)
-      destination.search = url.search
-
-      context.res = context.redirect(destination.toString(), 308)
+      const destination = appendSearch(url.pathname.slice(0, -1), url.search)
+      context.res = context.redirect(destination, 308)
       return
     }
 


### PR DESCRIPTION
## Problem

Behind TLS-terminating reverse proxies (Vercel, Cloudflare, etc.), Hono receives requests with `http://` URLs even when clients connected over `https://`. Both the **redirects** and **trailing-slash** middleware were constructing `Location` headers via `new URL(path, url.origin)`, which leaked the internal `http://` protocol into the response.

This caused a **double-redirect chain** for every configured redirect:

```
/docs → http://example.com/overview → https://example.com/overview
```

Google Search Console reports these as "Page with redirect" validation failures.

### Evidence from mpp.dev (deployed on Vercel)

```
$ curl -sI https://mpp.dev/docs
HTTP/2 307
location: http://mpp.dev/overview    ← wrong protocol

$ curl -sI https://mpp.dev/getting-started
HTTP/2 307
location: http://mpp.dev/quickstart  ← wrong protocol
```

## Fix

Emit destinations as-is instead of resolving against the request origin:
- **Relative paths** (`/overview`) stay relative — browsers resolve them against the original request URL, preserving `https://`
- **Absolute URLs** (`https://paymentauth.org`) pass through unchanged

```diff
-const destination = new URL(result.destination, url.origin)
-destination.search = url.search
-context.res = context.redirect(destination.toString(), ...)
+const destination = Redirects.appendSearch(result.destination, url.search)
+context.res = context.redirect(destination, ...)
```

Applied to both `redirects.ts` and `trailing-slash.ts` middleware.

### `appendSearch` helper

Added `Redirects.appendSearch()` to correctly merge request query strings with destinations that may already contain query params or hash fragments:

```ts
appendSearch("/overview", "?ref=nav")           // "/overview?ref=nav"
appendSearch("/overview?tab=api", "?ref=nav")   // "/overview?tab=api&ref=nav"
appendSearch("/overview#intro", "?ref=nav")     // "/overview?ref=nav#intro"
appendSearch("https://example.com", "")         // "https://example.com"
```

## Tests

Added **29 new tests** across three files:

**`redirects.test.ts`** (8 new) — `appendSearch` unit tests covering bare paths, existing query params, hash fragments, absolute URLs, and empty search strings.

**`redirects.test.ts` middleware** (14 new) — Full Hono integration tests:
- Exact path, custom status, parameterized, wildcard redirects
- Query string preservation (relative + absolute destinations)
- Destination with existing query params (merge semantics)
- Destination with hash fragment (correct insertion order)
- External URL redirects
- Pass-through on no match / no config / undefined
- **Protocol leak regression** — verifies `Location` never contains `http://` for relative redirects

**`trailing-slash.test.ts`** (7 new) — Full Hono integration tests:
- Trailing slash removal with 308
- Query string preservation
- Root path and file extension skip
- Deeply nested paths
- **Protocol leak regression**

## Checklist

- [x] All 231 tests pass
- [x] No changes to public API
- [x] Both middleware files documented with JSDoc
- [x] Edge cases covered: existing query params, hash fragments, absolute URLs