### PR TITLE
fix(waku): keep search crawlers on html

### DIFF
--- a/site/src/pages/guide/ai-support.mdx
+++ b/site/src/pages/guide/ai-support.mdx
@@ -33,11 +33,13 @@ The following user agents are automatically detected:
 
 - **OpenAI**: `GPTBot`, `OAI-SearchBot`, `ChatGPT-User`
 - **Anthropic**: `anthropic-ai`, `ClaudeBot`, `claude-web`
-- **Google**: `Google-Extended`, `Googlebot`, `GoogleAgent-Mariner`
+- **Google**: `Google-Extended`, `GoogleAgent-Mariner`
 - **Perplexity**: `PerplexityBot`, `Perplexity-User`
 - **Mistral**: `MistralAI-User`
 - **Cohere**: `cohere-ai`
-- **Others**: `Bingbot`, `Amazonbot`, `Applebot`, `DuckAssistBot`, `YouBot`, and more
+- **Others**: `FacebookBot`, `meta-externalagent`, `Bytespider`, `AI2Bot`, and more
+
+Search engine crawlers such as `Googlebot`, `Bingbot`, `Amazonbot`, and `Applebot` continue to receive rendered HTML so standard indexing behavior is preserved.
 
 ### Manual Markdown Access
 

--- a/src/waku/internal/middleware/md-router.test.ts
+++ b/src/waku/internal/middleware/md-router.test.ts
@@ -1,3 +1,4 @@
+import { Hono } from 'hono'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('node:fs/promises', () => ({
@@ -14,14 +15,22 @@ vi.mock('node:url', async () => {
   return { ...actual }
 })
 
+const originalFetch = globalThis.fetch
+const originalNodeEnv = process.env['NODE_ENV']
+
+function restoreNodeEnv() {
+  if (originalNodeEnv === undefined) delete process.env['NODE_ENV']
+  else process.env['NODE_ENV'] = originalNodeEnv
+}
+
+afterEach(() => {
+  restoreNodeEnv()
+  vi.restoreAllMocks()
+  vi.resetModules()
+  globalThis.fetch = originalFetch
+})
+
 describe('fetchMarkdown', () => {
-  const originalFetch = globalThis.fetch
-
-  afterEach(() => {
-    vi.restoreAllMocks()
-    globalThis.fetch = originalFetch
-  })
-
   it('returns content from disk without making an HTTP fetch', async () => {
     const { readFile } = await import('node:fs/promises')
     vi.mocked(readFile).mockResolvedValue('# Hello from disk')
@@ -68,5 +77,48 @@ describe('fetchMarkdown', () => {
     const result = await fetchMarkdown(new URL('https://example.com'), '/assets/md/missing.md')
 
     expect(result).toBeNull()
+  })
+})
+
+describe('middleware', () => {
+  function request(url: string, headers?: HeadersInit) {
+    const app = new Hono()
+    return import('./md-router.js').then(({ middleware }) => {
+      app.use('*', middleware())
+      app.get('*', (c) => c.html('<p>ok</p>'))
+      return app.request(url, { headers })
+    })
+  }
+
+  it('passes search engine crawlers through to HTML', async () => {
+    process.env['NODE_ENV'] = 'production'
+
+    const { readFile } = await import('node:fs/promises')
+    vi.mocked(readFile).mockResolvedValue('# Hello from disk')
+
+    const response = await request('http://localhost/docs', {
+      'user-agent': 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('text/html')
+    expect(await response.text()).toBe('<p>ok</p>')
+    expect(readFile).not.toHaveBeenCalled()
+  })
+
+  it('still serves markdown to AI agents', async () => {
+    process.env['NODE_ENV'] = 'production'
+
+    const { readFile } = await import('node:fs/promises')
+    vi.mocked(readFile).mockResolvedValue('# Hello from disk')
+
+    const response = await request('http://localhost/docs', {
+      'user-agent': 'Mozilla/5.0 (compatible; GPTBot/1.0; +https://openai.com/gptbot)',
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('text/markdown; charset=utf-8')
+    expect(await response.text()).toBe('# Hello from disk')
+    expect(readFile).toHaveBeenCalledOnce()
   })
 })

--- a/src/waku/internal/middleware/md-router.ts
+++ b/src/waku/internal/middleware/md-router.ts
@@ -11,24 +11,27 @@ export const aiUserAgents = [
   'PerplexityBot',
   'Perplexity-User',
   'Google-Extended',
-  'Googlebot',
-  'Bingbot',
-  'Amazonbot',
-  'Applebot',
-  'Applebot-Extended',
   'FacebookBot',
   'meta-externalagent',
   'Bytespider',
-  'DuckAssistBot',
   'cohere-ai',
   'AI2Bot',
   'CCBot',
   'Diffbot',
   'omgili',
   'Timpibot',
-  'YouBot',
   'MistralAI-User',
   'GoogleAgent-Mariner',
+]
+
+export const searchEngineUserAgents = [
+  'Googlebot',
+  'Bingbot',
+  'Amazonbot',
+  'Applebot',
+  'Applebot-Extended',
+  'DuckAssistBot',
+  'YouBot',
 ]
 
 export const terminalUserAgents = ['curl/', 'Wget/', 'HTTPie/', 'httpie-go/', 'xh/']
@@ -98,11 +101,12 @@ export function middleware(): MiddlewareHandler {
     if (isOgBot) return next()
 
     const isAiAgent = aiUserAgents.some((agent) => userAgent.includes(agent))
+    const isSearchEngine = searchEngineUserAgents.some((agent) => userAgent.includes(agent))
     const isTerminal = terminalUserAgents.some((agent) => userAgent.includes(agent))
     const acceptHeader = context.req.header('accept') ?? ''
     const acceptsMarkdown = acceptHeader.includes('text/markdown')
 
-    if (url.pathname === '/' && (acceptsMarkdown || isTerminal)) {
+    if (url.pathname === '/' && (acceptsMarkdown || isTerminal) && !isSearchEngine) {
       let text: string | null
       if (isDev) {
         const content = await resolveContent()
@@ -121,7 +125,7 @@ export function middleware(): MiddlewareHandler {
     }
 
     const isMarkdownRequest = url.pathname.endsWith('.md')
-    if (!isMarkdownRequest && !isAiAgent && !isTerminal) return next()
+    if (!isMarkdownRequest && (isSearchEngine || (!isAiAgent && !isTerminal))) return next()
 
     const pagePath = url.pathname.replace(/\.md$/, '').replace(/\/index$/, '')
 


### PR DESCRIPTION
## Summary
- keep classic search-engine crawlers on rendered HTML instead of auto-routing them to markdown
- preserve markdown responses for AI agents and terminal clients
- add middleware coverage for crawler vs AI behavior and update the AI support docs

## Testing
- `git diff --check`
- not run: `pnpm test -- --run src/waku/internal/middleware/md-router.test.ts` (`vitest` unavailable because dependencies are not installed in this workspace)