### PR TITLE
fix: honor inferred shiki langs in mdx highlighting

### DIFF
--- a/src/internal/mdx.test.ts
+++ b/src/internal/mdx.test.ts
@@ -10,7 +10,8 @@ describe('rehypeShiki', () => {
 
   test('falls back to default bundled languages when no langs are provided', () => {
     const [, options] = rehypeShiki({})
+    const langs = options.langs ?? []
 
-    expect(options.langs.length).toBeGreaterThan(2)
+    expect(langs.length).toBeGreaterThan(2)
   })
 })

--- a/src/internal/mdx.test.ts
+++ b/src/internal/mdx.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'vitest'
+import { rehypeShiki } from './mdx.js'
+
+describe('rehypeShiki', () => {
+  test('preserves caller-provided language inference', () => {
+    const [, options] = rehypeShiki({ langs: ['ts', 'solidity'] })
+
+    expect(options.langs).toEqual(['ts', 'solidity'])
+  })
+
+  test('falls back to default bundled languages when no langs are provided', () => {
+    const [, options] = rehypeShiki({})
+
+    expect(options.langs.length).toBeGreaterThan(2)
+  })
+})

--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -445,12 +445,9 @@ export function rehypeShiki(
   const transformerLangs =
     rawTransformers?.flatMap((t) => ('langs' in t ? (t.langs as LanguageRegistration[]) : [])) ?? []
 
-  // Merge default languages with user-provided languages and transformer languages
-  const mergedLangs = [
-    ...Object.values(defaultLanguages),
-    ...(userLangs ?? []),
-    ...transformerLangs,
-  ]
+  // Prefer the caller-provided language list so Vocs can honor inferred Shiki
+  // languages instead of eagerly loading the entire bundled set.
+  const mergedLangs = [...(userLangs ?? Object.values(defaultLanguages)), ...transformerLangs]
 
   return [
     shiki,
@@ -462,7 +459,6 @@ export function rehypeShiki(
       rootStyle: false,
       themes,
       langs: mergedLangs,
-      // TODO: infer `langs` for faster cold start.
       transformers: [
         rootDir && srcDir ? ShikiTransformers.notationInclude({ srcDir, rootDir }) : undefined,
         twoslash

--- a/src/react/internal/CodeToHtml.tsx
+++ b/src/react/internal/CodeToHtml.tsx
@@ -1,7 +1,6 @@
 import { config } from 'virtual:vocs/config'
 import { langs as virtualLangs } from 'virtual:vocs/langs'
 import {
-  bundledLanguages,
   createHighlighter,
   hastToHtml,
   makeSingletonHighlighter,
@@ -13,13 +12,11 @@ const getHighlighter = makeSingletonHighlighter(createHighlighter)
 export async function CodeToHtml(props: CodeToHtml.Props) {
   const { code, lang } = props
   const { codeHighlight } = config
-  const { langAlias = {}, themes } = codeHighlight
+  const { langAlias = {}, themes, langs = [] } = codeHighlight
 
   const highlighter = await getHighlighter({
     themes: import.meta.env.DEV ? ['none'] : (Object.values(themes) as never),
-    langs: import.meta.env.DEV
-      ? ['txt']
-      : ([...Object.keys(bundledLanguages), ...virtualLangs] as never),
+    langs: import.meta.env.DEV ? ['txt'] : ([...langs, ...virtualLangs] as never),
     langAlias,
   })
 

--- a/src/waku/internal/middleware/md-router.test.ts
+++ b/src/waku/internal/middleware/md-router.test.ts
@@ -25,6 +25,7 @@ function restoreNodeEnv() {
 
 afterEach(() => {
   restoreNodeEnv()
+  vi.clearAllMocks()
   vi.restoreAllMocks()
   vi.resetModules()
   globalThis.fetch = originalFetch
@@ -86,7 +87,7 @@ describe('middleware', () => {
     return import('./md-router.js').then(({ middleware }) => {
       app.use('*', middleware())
       app.get('*', (c) => c.html('<p>ok</p>'))
-      return app.request(url, { headers })
+      return app.request(url, headers ? { headers } : undefined)
     })
   }
 

--- a/twoslash-rust/src/project.rs
+++ b/twoslash-rust/src/project.rs
@@ -159,7 +159,10 @@ impl Project {
     }
 
     /// Like `scaffold`, but injects user code immediately.
-    pub fn scaffold_with_code<'a>(settings: ProjectSettings<'_>, source: &'a str) -> Result<Project> {
+    pub fn scaffold_with_code<'a>(
+        settings: ProjectSettings<'_>,
+        source: &'a str,
+    ) -> Result<Project> {
         let parse_result = find_queries(source);
         let source = parse_result.code;
         let queries = parse_result.queries;


### PR DESCRIPTION
## Summary

This fixes two places where Vocs was ignoring the caller-provided `codeHighlight.langs` list and eagerly loading Shiki's full bundled language set in addition:

- `rehypeShiki` in `src/internal/mdx.ts`
- `CodeToHtml` in `src/react/internal/CodeToHtml.tsx`

That meant configs using inferred langs still paid the cost of the full bundled language graph during highlighting.

## Changes

- prefer `userLangs` when building the `rehypeShiki` language list
- keep the existing fallback to all bundled languages when no explicit/inferred langs are provided
- make `CodeToHtml` use `config.codeHighlight.langs` instead of `Object.keys(bundledLanguages)`
- add a regression test covering the `rehypeShiki` behavior