### PR TITLE
feat: add configurable link prefetching

### DIFF
--- a/playground/vocs.config.ts
+++ b/playground/vocs.config.ts
@@ -27,6 +27,10 @@ export default defineConfig({
   editLink: {
     link: 'https://github.com/wevm/vocs/edit/next/playground/src/pages/:path',
   },
+  linkPrefetch: {
+    mode: false,
+    topNav: 'enter',
+  },
   logoUrl: {
     light: '/logo-tight-light.svg',
     dark: '/logo-tight-dark.svg',
@@ -132,14 +136,16 @@ export default defineConfig({
     ],
     '/sub/': {
       backLink: true,
+      linkPrefetch: false,
       items: [
         {
           text: 'API Reference',
+          linkPrefetch: 'enter',
           items: [
             { text: 'Links', link: '/sub/links' },
             { text: 'defineConfig', link: '/api/define-config' },
             { text: 'CLI', link: '/api/cli' },
-            { text: 'Hooks', link: '/api/hooks' },
+            { text: 'Hooks', link: '/api/hooks', linkPrefetch: false },
           ],
         },
       ],

--- a/site/src/pages/guide/navigation.mdx
+++ b/site/src/pages/guide/navigation.mdx
@@ -28,6 +28,24 @@ export default defineConfig({
 })
 ```
 
+You can also scope sidebar config by route prefix:
+
+```ts
+export default defineConfig({
+  sidebar: {
+    '/guide': {
+      items: [
+        { text: 'Introduction', link: '/guide/intro' },
+        { text: 'Getting Started', link: '/guide/getting-started' },
+      ],
+    },
+    '/api': {
+      items: [{ text: 'Configuration', link: '/api/config' }],
+    },
+  },
+})
+```
+
 ## Top Navigation
 
 Configure the top navigation bar:
@@ -59,3 +77,90 @@ Sidebar groups can be collapsible:
 ## External Links
 
 Both sidebar and top nav support external links with automatic external link icons.
+
+## Link Prefetch
+
+Vocs prefetches internal links on hover in production and disables eager prefetching in development.
+
+Use `linkPrefetch` to control this behavior globally:
+
+```ts
+export default defineConfig({
+  linkPrefetch: false,
+})
+```
+
+You can also use scoped global overrides:
+
+```ts
+export default defineConfig({
+  linkPrefetch: {
+    mode: false,
+    topNav: 'enter',
+    sidebar: 'view',
+  },
+})
+```
+
+Valid values are:
+
+- `false` — disable eager prefetching
+- `true` or `'view'` — prefetch when the link enters the viewport
+- `'enter'` — prefetch on hover
+
+Route-based sidebar configs can override the global setting:
+
+```ts
+export default defineConfig({
+  linkPrefetch: {
+    mode: false,
+    topNav: 'enter',
+  },
+  sidebar: {
+    '/guide': {
+      linkPrefetch: 'view',
+      items: [
+        { text: 'Introduction', link: '/guide/intro' },
+        { text: 'Getting Started', link: '/guide/getting-started' },
+      ],
+    },
+    '/api': {
+      linkPrefetch: false,
+      items: [{ text: 'Configuration', link: '/api/config' }],
+    },
+  },
+})
+```
+
+Nested sidebar groups and leaf items can override the nearest inherited setting:
+
+```ts
+export default defineConfig({
+  sidebar: {
+    '/guide': {
+      linkPrefetch: false,
+      items: [
+        {
+          text: 'Guides',
+          linkPrefetch: 'enter',
+          items: [
+            { text: 'Introduction', link: '/guide/intro' },
+            {
+              text: 'Advanced',
+              linkPrefetch: false,
+              items: [{ text: 'Plugins', link: '/guide/plugins' }],
+            },
+          ],
+        },
+      ],
+    },
+  },
+})
+```
+
+Prefetch precedence is:
+
+1. Global `linkPrefetch`
+2. Matched route sidebar config `sidebar['/path'].linkPrefetch`
+3. Nested sidebar group `linkPrefetch`
+4. Leaf sidebar item `linkPrefetch`

--- a/site/src/pages/reference/site-config.mdx
+++ b/site/src/pages/reference/site-config.mdx
@@ -36,9 +36,57 @@ Path to the logo image.
 
 ### `sidebar`
 
-- **Type:** `SidebarItem[]`
+- **Type:** `SidebarItem[] | Record<string, SidebarItem[] | { items: SidebarItem[]; backLink?: boolean; linkPrefetch?: LinkPrefetch }>`
 
 Sidebar navigation configuration.
+
+When using the object form, the deepest matching route prefix wins.
+
+### `linkPrefetch`
+
+- **Type:** `false | true | 'view' | 'enter' | { mode?: LinkPrefetch; topNav?: LinkPrefetch; sidebar?: LinkPrefetch }`
+
+Controls when internal links prefetch their destination.
+
+- `false` disables eager prefetching
+- `true` or `'view'` prefetches when the link enters the viewport
+- `'enter'` prefetches on hover
+
+Defaults to hover prefetching in production and no eager prefetching in development.
+
+```ts
+linkPrefetch: {
+  mode: false,
+  topNav: 'enter',
+}
+```
+
+Sidebar route groups can override it:
+
+```ts
+sidebar: {
+  '/docs': {
+    linkPrefetch: false,
+    items: [{ text: 'Intro', link: '/docs/intro' }],
+  },
+}
+```
+
+Nested sidebar groups and leaf items can also override it:
+
+```ts
+sidebar: {
+  '/docs': {
+    items: [
+      {
+        text: 'Guides',
+        linkPrefetch: 'enter',
+        items: [{ text: 'Intro', link: '/docs/intro' }],
+      },
+    ],
+  },
+}
+```
 
 ### `topNav`
 

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -4,6 +4,7 @@ import type * as MdxRollup from '@mdx-js/rollup'
 import type * as Changelog from './changelog.js'
 import type * as Feedback from './feedback.js'
 import * as Langs from './langs.js'
+import type * as LinkPrefetch from './link-prefetch.js'
 import type * as McpSource from './mcp-source.js'
 import type * as Mdx from './mdx.js'
 import type * as Redirects from './redirects.js'
@@ -184,6 +185,27 @@ export type Config<partial extends boolean = false> = MaybePartial<
      */
     logoUrl?: string | ThemeValue<string> | undefined
     /**
+     * Control when internal links prefetch their target route.
+     *
+     * - `false`: Disable eager prefetching.
+     * - `true` or `'view'`: Prefetch when a link enters the viewport.
+     * - `'enter'`: Prefetch when a link is hovered.
+     * - Object form allows scoped overrides for `topNav` and `sidebar`.
+     *
+     * By default, Vocs prefetches on hover in production and disables eager
+     * prefetching in development.
+     *
+     * @example
+     * linkPrefetch: false
+     *
+     * @example
+     * linkPrefetch: {
+     *   mode: false,
+     *   topNav: 'enter',
+     * }
+     */
+    linkPrefetch?: LinkPrefetch.Config | undefined
+    /**
      * Markdown configuration.
      */
     markdown?: MdxRollup.Options | undefined
@@ -289,7 +311,11 @@ export type Config<partial extends boolean = false> = MaybePartial<
       | {
           [path: string]:
             | readonly Sidebar.SidebarItem<true>[]
-            | { backLink?: boolean; items: Sidebar.SidebarItem<true>[] }
+            | {
+                backLink?: boolean
+                items: Sidebar.SidebarItem<true>[]
+                linkPrefetch?: LinkPrefetch.Config | undefined
+              }
         }
       | undefined
     /**
@@ -412,6 +438,7 @@ export function define(config: define.Options = {}): Config {
     colorScheme = 'light dark',
     description,
     iconUrl,
+    linkPrefetch,
     logoUrl,
     markdown,
     mcp,
@@ -477,6 +504,7 @@ export function define(config: define.Options = {}): Config {
     _feedback: (config as { _feedback?: Feedback.Adapter })._feedback ?? config.feedback,
     groupIcons: config.groupIcons,
     iconUrl,
+    linkPrefetch,
     logoUrl,
     markdown,
     mcp,

--- a/src/internal/link-prefetch.test.ts
+++ b/src/internal/link-prefetch.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'vitest'
+import { resolve, toWakuProps } from './link-prefetch.js'
+
+describe('resolve', () => {
+  test('supports global and scoped overrides', () => {
+    expect([
+      resolve({ config: false, fallbackMode: 'view' }),
+      resolve({ config: { mode: false, topNav: 'enter' }, fallbackMode: 'view' }),
+      resolve({
+        config: { mode: false, topNav: 'enter' },
+        fallbackMode: 'view',
+        scope: 'topNav',
+      }),
+      resolve({
+        config: { mode: false, sidebar: 'enter' },
+        fallbackMode: 'view',
+        routeConfig: { mode: 'view', sidebar: false },
+        scope: 'sidebar',
+      }),
+      resolve({
+        config: { mode: false, sidebar: 'enter' },
+        fallbackMode: 'view',
+        routeConfig: { mode: 'view', sidebar: false },
+      }),
+      resolve({
+        config: { mode: false, topNav: 'enter' },
+        fallbackMode: 'view',
+        mode: true,
+      }),
+    ]).toMatchInlineSnapshot(`
+      [
+        false,
+        false,
+        "enter",
+        false,
+        "view",
+        "view",
+      ]
+    `)
+  })
+})
+
+describe('toWakuProps', () => {
+  test('maps modes to Waku link props', () => {
+    expect([toWakuProps(false), toWakuProps('enter'), toWakuProps('view')])
+      .toMatchInlineSnapshot(`
+        [
+          {},
+          {
+            "unstable_prefetchOnEnter": true,
+          },
+          {
+            "unstable_prefetchOnView": true,
+          },
+        ]
+      `)
+  })
+})

--- a/src/internal/link-prefetch.ts
+++ b/src/internal/link-prefetch.ts
@@ -1,0 +1,69 @@
+export type Mode = false | 'view' | 'enter'
+
+export type Input = boolean | Mode
+
+export type Scope = 'default' | 'sidebar' | 'topNav'
+
+export type Config =
+  | Input
+  | {
+      mode?: Input | undefined
+      sidebar?: Input | undefined
+      topNav?: Input | undefined
+    }
+
+export function normalize(value: normalize.Options): normalize.ReturnType {
+  if (value === undefined) return undefined
+  if (value === true) return 'view'
+  return value
+}
+
+export declare namespace normalize {
+  type Options = Input | undefined
+  type ReturnType = Mode | undefined
+}
+
+export function resolve(options: resolve.Options): resolve.ReturnType {
+  const { config, fallbackMode, mode, routeConfig, scope = 'default' } = options
+
+  return (
+    normalize(mode) ??
+    getScopedMode(routeConfig, scope) ??
+    getScopedMode(config, scope) ??
+    fallbackMode
+  )
+}
+
+export declare namespace resolve {
+  type Options = {
+    config?: Config | undefined
+    fallbackMode: Mode
+    mode?: Input | undefined
+    routeConfig?: Config | undefined
+    scope?: Scope | undefined
+  }
+
+  type ReturnType = Mode
+}
+
+export function toWakuProps(mode: toWakuProps.Options): toWakuProps.ReturnType {
+  if (mode === 'enter') return { unstable_prefetchOnEnter: true }
+  if (mode === 'view') return { unstable_prefetchOnView: true }
+  return {}
+}
+
+export declare namespace toWakuProps {
+  type Options = Mode
+  type ReturnType =
+    | { unstable_prefetchOnEnter: true }
+    | { unstable_prefetchOnView: true }
+    | {}
+}
+
+function getScopedMode(config: Config | undefined, scope: Scope): Mode | undefined {
+  if (config === undefined) return undefined
+  if (typeof config !== 'object') return normalize(config)
+
+  const scopedMode = scope === 'default' ? undefined : normalize(config[scope])
+  return scopedMode ?? normalize(config.mode)
+}

--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -432,7 +432,8 @@ export { remarkVocsScope } from './remark-vocs-scope.js'
 export function rehypeShiki(
   options: ExactPartial<rehypeShiki.Options> = {},
 ): [typeof shiki, RehypeShikiOptions] {
-  const { cacheDir, langs: userLangs, srcDir, rootDir, themes, twoslash = true } = options
+  const { cacheDir, langAlias, langs: userLangs, srcDir, rootDir, themes, twoslash = true } =
+    options
 
   // Process twoslash transformers - inject cacheDir if they're factory functions
   const rawTransformers =
@@ -450,7 +451,10 @@ export function rehypeShiki(
     ...Object.values(defaultLanguages),
     ...(userLangs ?? []),
     ...transformerLangs,
-  ]
+  ].map((lang) => {
+    if (typeof lang !== 'string') return lang
+    return langAlias?.[lang] ?? lang
+  })
 
   return [
     shiki,

--- a/src/internal/sidebar.test.ts
+++ b/src/internal/sidebar.test.ts
@@ -616,6 +616,79 @@ describe('fromConfig', () => {
       `)
     })
 
+    test('returns route-level linkPrefetch from sidebar object config', () => {
+      const config = {
+        '/docs': {
+          linkPrefetch: false,
+          items: [{ text: 'Item', link: '/docs/item' }],
+        },
+      }
+      expect(fromConfig(config, '/docs/page')).toMatchInlineSnapshot(`
+        {
+          "items": [
+            {
+              "items": [
+                {
+                  "link": "/docs/item",
+                  "text": "Item",
+                },
+              ],
+            },
+          ],
+          "key": "/docs",
+          "linkPrefetch": false,
+        }
+      `)
+    })
+
+    test('preserves nested group and leaf linkPrefetch overrides', () => {
+      const config = {
+        '/docs': {
+          items: [
+            {
+              text: 'Guides',
+              linkPrefetch: 'enter' as const,
+              items: [
+                { text: 'Intro', link: '/docs/intro' },
+                {
+                  text: 'Advanced',
+                  linkPrefetch: false,
+                  items: [{ text: 'Perf', link: '/docs/advanced/perf' }],
+                },
+              ],
+            },
+          ],
+        },
+      }
+      expect(fromConfig(config, '/docs/page')).toMatchInlineSnapshot(`
+        {
+          "items": [
+            {
+              "items": [
+                {
+                  "link": "/docs/intro",
+                  "text": "Intro",
+                },
+                {
+                  "items": [
+                    {
+                      "link": "/docs/advanced/perf",
+                      "text": "Perf",
+                    },
+                  ],
+                  "linkPrefetch": false,
+                  "text": "Advanced",
+                },
+              ],
+              "linkPrefetch": "enter",
+              "text": "Guides",
+            },
+          ],
+          "key": "/docs",
+        }
+      `)
+    })
+
     test('complex multi-section object config with deep nesting', () => {
       const config = {
         '/': [{ text: 'Home', link: '/' }],

--- a/src/internal/sidebar.ts
+++ b/src/internal/sidebar.ts
@@ -1,4 +1,5 @@
 import type { Config } from './config.js'
+import type * as LinkPrefetch from './link-prefetch.js'
 import type { OneOf } from './types.js'
 
 export type SidebarItem<strict extends boolean = false> = {
@@ -8,6 +9,8 @@ export type SidebarItem<strict extends boolean = false> = {
   external?: boolean | undefined
   /** Optional children to nest under this item. */
   items?: SidebarItem<true>[] | undefined
+  /** Override link prefetch behavior for this item and its descendants. */
+  linkPrefetch?: LinkPrefetch.Input | undefined
   /** Text to display on the sidebar. */
   text?: string | undefined
 } & (strict extends true
@@ -34,6 +37,7 @@ export type Sidebar = {
   backLink?: boolean | undefined
   items: SidebarItem[]
   key?: string | undefined
+  linkPrefetch?: LinkPrefetch.Config | undefined
 }
 
 export function flatten(items: SidebarItem[]): Omit<SidebarItem, 'items'>[] {
@@ -94,8 +98,9 @@ export function fromConfig(config: Config['sidebar'], path: string) {
   if (value && typeof value === 'object' && 'items' in value) {
     return {
       key: sidebarKey,
-      backLink: value.backLink,
+      ...(value.backLink !== undefined ? { backLink: value.backLink } : {}),
       items: group(value.items),
+      ...(value.linkPrefetch !== undefined ? { linkPrefetch: value.linkPrefetch } : {}),
     }
   }
 

--- a/src/react/Link.tsx
+++ b/src/react/Link.tsx
@@ -1,20 +1,34 @@
 'use client'
 
 import { useRouter, Link as WakuLink } from 'waku'
+import * as LinkPrefetch from '../internal/link-prefetch.js'
 import * as Path from '../internal/path.js'
+import { useLinkPrefetchMode } from './useLinkPrefetchMode.js'
 
 export function Link(props: Link.Props) {
-  const { to, ...rest } = props
+  const { children, prefetch, to, ...rest } = props
   const { path } = useRouter()
+  const prefetchMode = useLinkPrefetchMode({ mode: prefetch })
 
-  if (Path.isExternal(props.to))
-    return <a {...rest} href={props.to} rel="noopener noreferrer" target="_blank" />
+  if (Path.isExternal(to))
+    return (
+      <a {...rest} href={to} rel="noopener noreferrer" target="_blank">
+        {children}
+      </a>
+    )
 
-  const [before, after] = (props.to || '').split('#')
+  const [before, after] = (to || '').split('#')
   const resolvedTo = `${before ? before : path}${after ? `#${after}` : ''}`
-  return <WakuLink {...rest} to={resolvedTo} unstable_prefetchOnView={!import.meta.env.DEV} />
+  return (
+    <WakuLink {...rest} to={resolvedTo} {...LinkPrefetch.toWakuProps(prefetchMode)}>
+      {children}
+    </WakuLink>
+  )
 }
 
 export namespace Link {
-  export type Props = React.ComponentProps<typeof WakuLink>
+  export type Props = Omit<React.ComponentProps<typeof WakuLink>, 'children'> & {
+    children?: React.ReactNode
+    prefetch?: LinkPrefetch.Input | undefined
+  }
 }

--- a/src/react/internal/MobileNav.tsx
+++ b/src/react/internal/MobileNav.tsx
@@ -12,6 +12,7 @@ import LucideX from '~icons/lucide/x'
 import * as Path from '../../internal/path.js'
 import * as TopNav_core from '../../internal/topNav.js'
 import { Link } from '../Link.js'
+import { useLinkPrefetchMode } from '../useLinkPrefetchMode.js'
 import { useConfig } from '../useConfig.js'
 import * as Sidebar from './Sidebar.js'
 import * as Socials from './Socials.client.js'
@@ -89,6 +90,7 @@ function MobileTopNav(props: MobileTopNav.Props) {
 
   const { topNav } = useConfig()
   const { path } = useRouter()
+  const linkPrefetch = useLinkPrefetchMode({ scope: 'topNav' })
 
   const [menuOpen, setMenuOpen] = React.useState(false)
 
@@ -139,9 +141,8 @@ function MobileTopNav(props: MobileTopNav.Props) {
                             key={j}
                             value={child.link}
                             onClick={handleNavigate}
-                            // @ts-expect-error
                             // biome-ignore lint/style/noNonNullAssertion: _
-                            render={<Link to={child.link!} />}
+                            render={<Link prefetch={linkPrefetch} to={child.link!} />}
                           >
                             {child.text}
                             {isExternal && (
@@ -162,9 +163,8 @@ function MobileTopNav(props: MobileTopNav.Props) {
                     key={i}
                     value={item.link}
                     onClick={handleNavigate}
-                    // @ts-expect-error
                     // biome-ignore lint/style/noNonNullAssertion: _
-                    render={<Link to={item.link!} />}
+                    render={<Link prefetch={linkPrefetch} to={item.link!} />}
                   >
                     {item.text}
                     {isExternal && (

--- a/src/react/internal/Sidebar.tsx
+++ b/src/react/internal/Sidebar.tsx
@@ -6,9 +6,11 @@ import { useRouter } from 'waku'
 import LucideArrowLeft from '~icons/lucide/arrow-left'
 import LucideArrowUpRight from '~icons/lucide/arrow-up-right'
 import LucideChevronRight from '~icons/lucide/chevron-right'
+import * as LinkPrefetch from '../../internal/link-prefetch.js'
 import * as Path from '../../internal/path.js'
 import * as Sidebar_core from '../../internal/sidebar.js'
 import { Link } from '../Link.js'
+import { useLinkPrefetchMode } from '../useLinkPrefetchMode.js'
 import { useSidebar } from '../useSidebar.js'
 
 const maxDepth = 5
@@ -17,6 +19,7 @@ export function Sidebar(props: Sidebar.Props) {
   const { className, onNavigate, scrollRef } = props
 
   const sidebar = useSidebar()
+  const linkPrefetch = useLinkPrefetchMode({ scope: 'sidebar' })
   const condenseSidebar = React.useMemo(
     () => Sidebar_core.length(sidebar.items, { startDepth: 2 }) > 25,
     [sidebar.items],
@@ -30,13 +33,14 @@ export function Sidebar(props: Sidebar.Props) {
       )}
       data-v-sidebar
     >
-      {sidebar.backLink && <BackLink onNavigate={onNavigate} />}
+      {sidebar.backLink && <BackLink onNavigate={onNavigate} prefetch={linkPrefetch} />}
       {sidebar.items.map((item, i) => (
         <Section
           key={`${item.text}-${i}`}
           {...item}
           condensed={condenseSidebar}
           onNavigate={onNavigate}
+          prefetch={linkPrefetch}
           scrollRef={scrollRef}
         />
       ))}
@@ -44,19 +48,27 @@ export function Sidebar(props: Sidebar.Props) {
   )
 }
 
-function BackLink(props: { onNavigate?: (() => void) | undefined }) {
-  const { onNavigate } = props
+function BackLink(props: BackLink.Props) {
+  const { onNavigate, prefetch } = props
   return (
     <Link
       className="vocs:flex vocs:items-center vocs:gap-1.5 vocs:text-secondary vocs:hover:text-heading vocs:mb-4 vocs:-ml-0.5"
       data-v-sidebar-back-link
       onClick={onNavigate}
+      prefetch={prefetch}
       to="/"
     >
       <LucideArrowLeft className="vocs:size-4" />
       <span>Back</span>
     </Link>
   )
+}
+
+declare namespace BackLink {
+  type Props = {
+    onNavigate?: (() => void) | undefined
+    prefetch: LinkPrefetch.Mode
+  }
 }
 
 export declare namespace Sidebar {
@@ -70,8 +82,23 @@ export declare namespace Sidebar {
 /** @internal */
 // biome-ignore lint/correctness/noUnusedVariables: _
 function Item(props: Item.Props) {
-  const { condensed = false, depth = 0, disabled, external, link, onNavigate, scrollRef, text } =
-    props
+  const {
+    condensed = false,
+    depth = 0,
+    disabled,
+    external,
+    link,
+    linkPrefetch,
+    onNavigate,
+    prefetch,
+    scrollRef,
+    text,
+  } = props
+
+  const resolvedPrefetch = LinkPrefetch.resolve({
+    fallbackMode: prefetch,
+    mode: linkPrefetch,
+  })
 
   const { path } = useRouter()
   const isExternal = external ?? Path.isExternal(link)
@@ -137,6 +164,7 @@ function Item(props: Item.Props) {
         data-condensed={condensed && depth > 1}
         data-link={true}
         data-v-sidebar-item
+        prefetch={resolvedPrefetch}
         to={link}
         ref={itemRef as never}
         onClick={onNavigate}
@@ -165,6 +193,7 @@ namespace Item {
     condensed?: boolean | undefined
     depth?: number | undefined
     onNavigate?: (() => void) | undefined
+    prefetch: LinkPrefetch.Mode
     scrollRef?: React.RefObject<HTMLDivElement | null>
   }
 
@@ -175,7 +204,22 @@ namespace Item {
 /** @internal */
 // biome-ignore lint/correctness/noUnusedVariables: _
 function Section(props: Section.Props) {
-  const { condensed = false, depth = 0, link, items, onNavigate, scrollRef, text } = props
+  const {
+    condensed = false,
+    depth = 0,
+    link,
+    linkPrefetch,
+    items,
+    onNavigate,
+    prefetch,
+    scrollRef,
+    text,
+  } = props
+
+  const resolvedPrefetch = LinkPrefetch.resolve({
+    fallbackMode: prefetch,
+    mode: linkPrefetch,
+  })
 
   const { path } = useRouter()
 
@@ -221,7 +265,7 @@ function Section(props: Section.Props) {
       <section data-collapsed={collapsed} data-v-sidebar-section>
         {(() => {
           // Not a header if includes a link.
-          if (link) return <Item {...props} />
+          if (link) return <Item {...props} prefetch={resolvedPrefetch} />
 
           // Non-link item is a header.
           if (text)
@@ -272,6 +316,7 @@ function Section(props: Section.Props) {
                   condensed={condensed}
                   depth={depth + 1}
                   onNavigate={onNavigate}
+                  prefetch={resolvedPrefetch}
                   scrollRef={scrollRef}
                 />
               ))}
@@ -280,7 +325,7 @@ function Section(props: Section.Props) {
       </section>
     )
 
-  return <Item {...props} />
+  return <Item {...props} prefetch={resolvedPrefetch} />
 }
 
 namespace Section {
@@ -288,6 +333,7 @@ namespace Section {
     condensed?: boolean | undefined
     depth?: number | undefined
     onNavigate?: (() => void) | undefined
+    prefetch: LinkPrefetch.Mode
     scrollRef: React.RefObject<HTMLDivElement | null>
   }
 

--- a/src/react/internal/TopNav.tsx
+++ b/src/react/internal/TopNav.tsx
@@ -7,6 +7,7 @@ import LucideChevronDown from '~icons/lucide/chevron-down'
 import * as Path from '../../internal/path.js'
 import * as TopNav_core from '../../internal/topNav.js'
 import { Link } from '../Link.js'
+import { useLinkPrefetchMode } from '../useLinkPrefetchMode.js'
 import { useConfig } from '../useConfig.js'
 
 export function TopNav(props: TopNav.Props) {
@@ -47,6 +48,7 @@ export function Item(props: Item.Props) {
   const { active, external, items, link, text } = props
 
   const isExternal = external ?? Path.isExternal(link)
+  const linkPrefetch = useLinkPrefetchMode({ scope: 'topNav' })
 
   if (items)
     return (
@@ -66,9 +68,8 @@ export function Item(props: Item.Props) {
                 data-v-active={item.active}
                 // biome-ignore lint/suspicious/noArrayIndexKey: _
                 key={i}
-                // @ts-expect-error
                 // biome-ignore lint/style/noNonNullAssertion: _
-                render={<Link to={item.link!} />}
+                render={<Link prefetch={linkPrefetch} to={item.link!} />}
               >
                 {item.text}
                 {itemIsExternal && (
@@ -88,8 +89,7 @@ export function Item(props: Item.Props) {
       <NavigationMenu.Link
         className={Item.className}
         data-v-active={active}
-        // @ts-expect-error
-        render={<Link to={link} />}
+        render={<Link prefetch={linkPrefetch} to={link} />}
       >
         {text}
         {isExternal && (

--- a/src/react/useLinkPrefetchMode.ts
+++ b/src/react/useLinkPrefetchMode.ts
@@ -1,0 +1,31 @@
+'use client'
+
+import * as LinkPrefetch from '../internal/link-prefetch.js'
+import { useConfig } from './useConfig.js'
+import { useSidebar } from './useSidebar.js'
+
+export function useLinkPrefetchMode(
+  options: useLinkPrefetchMode.Options = {},
+): useLinkPrefetchMode.ReturnType {
+  const { mode, scope = 'default' } = options
+
+  const { linkPrefetch } = useConfig()
+  const sidebar = useSidebar()
+
+  return LinkPrefetch.resolve({
+    config: linkPrefetch,
+    fallbackMode: import.meta.env.DEV ? false : 'enter',
+    mode,
+    routeConfig: sidebar.linkPrefetch,
+    scope,
+  })
+}
+
+export declare namespace useLinkPrefetchMode {
+  type Options = {
+    mode?: LinkPrefetch.Input | undefined
+    scope?: LinkPrefetch.Scope | undefined
+  }
+
+  type ReturnType = LinkPrefetch.Mode
+}


### PR DESCRIPTION
## Summary
- add a shared link prefetch resolver with global, scoped, route-level, and sidebar item overrides
- switch the production default from viewport prefetching to hover prefetching while keeping dev eager prefetching off
- document the new config and fix aliased Shiki languages like `sol` during MDX setup

## Testing
- pnpm vitest src/internal/link-prefetch.test.ts src/internal/sidebar.test.ts --run
- pnpm check:types