### PR TITLE
fix(link): make Waku prefetch configurable

### DIFF
--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -289,7 +289,14 @@ export type Config<partial extends boolean = false> = MaybePartial<
       | {
           [path: string]:
             | readonly Sidebar.SidebarItem<true>[]
-            | { backLink?: boolean; items: Sidebar.SidebarItem<true>[] }
+            | {
+                /** Whether to render a back link at the top of the sidebar. */
+                backLink?: boolean | undefined
+                /** Prefetch mode for links rendered in this sidebar section. @default 'view' */
+                prefetch?: Sidebar.Prefetch | undefined
+                /** Sidebar items for this path section. */
+                items: Sidebar.SidebarItem<true>[]
+              }
         }
       | undefined
     /**

--- a/src/internal/sidebar.test.ts
+++ b/src/internal/sidebar.test.ts
@@ -591,6 +591,31 @@ describe('fromConfig', () => {
       `)
     })
 
+    test('handles sidebar object with prefetch', () => {
+      const config = {
+        '/docs': {
+          items: [{ text: 'Item', link: '/docs/item' }],
+          prefetch: 'intent' as const,
+        },
+      }
+      expect(fromConfig(config, '/docs/page')).toMatchInlineSnapshot(`
+        {
+          "items": [
+            {
+              "items": [
+                {
+                  "link": "/docs/item",
+                  "text": "Item",
+                },
+              ],
+            },
+          ],
+          "key": "/docs",
+          "prefetch": "intent",
+        }
+      `)
+    })
+
     test('handles sidebar object with backLink false', () => {
       const config = {
         '/docs': {

--- a/src/internal/sidebar.ts
+++ b/src/internal/sidebar.ts
@@ -1,6 +1,8 @@
 import type { Config } from './config.js'
 import type { OneOf } from './types.js'
 
+export type Prefetch = 'none' | 'intent' | 'view'
+
 export type SidebarItem<strict extends boolean = false> = {
   /** Whether or not to disable the sidebar item. */
   disabled?: boolean | undefined
@@ -34,6 +36,7 @@ export type Sidebar = {
   backLink?: boolean | undefined
   items: SidebarItem[]
   key?: string | undefined
+  prefetch?: Prefetch | undefined
 }
 
 export function flatten(items: SidebarItem[]): Omit<SidebarItem, 'items'>[] {
@@ -93,9 +96,10 @@ export function fromConfig(config: Config['sidebar'], path: string) {
   if (Array.isArray(value)) return { key: sidebarKey, items: group(value) }
   if (value && typeof value === 'object' && 'items' in value) {
     return {
+      ...(value.backLink !== undefined ? { backLink: value.backLink } : {}),
       key: sidebarKey,
-      backLink: value.backLink,
       items: group(value.items),
+      ...(value.prefetch !== undefined ? { prefetch: value.prefetch } : {}),
     }
   }
 

--- a/src/react/Link.test.tsx
+++ b/src/react/Link.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('waku', () => ({
+  Link: (props: Record<string, unknown>) => ({ props, type: 'waku-link' }),
+  useRouter: () => ({ path: '/guide/payments' }),
+}))
+
+import { Link } from './Link.js'
+
+describe('Link', () => {
+  test('maps prefetch="view" to prefetch on view', () => {
+    const element = Link({
+      children: null,
+      prefetch: 'view',
+      to: '/guide/payments/send-a-payment',
+    })
+
+    expect(element.props.to).toBe('/guide/payments/send-a-payment')
+    expect(element.props.unstable_prefetchOnEnter).toBe(false)
+    expect(element.props.unstable_prefetchOnView).toBe(true)
+  })
+
+  test('maps prefetch="intent" to prefetch on enter', () => {
+    const element = Link({
+      children: null,
+      prefetch: 'intent',
+      to: '/guide/payments/send-a-payment',
+    })
+
+    expect(element.props.unstable_prefetchOnEnter).toBe(true)
+    expect(element.props.unstable_prefetchOnView).toBe(false)
+  })
+
+  test('disables prefetch when prefetch="none"', () => {
+    const element = Link({
+      children: null,
+      prefetch: 'none',
+      to: '/guide/payments/send-a-payment',
+    })
+
+    expect(element.props.unstable_prefetchOnEnter).toBe(false)
+    expect(element.props.unstable_prefetchOnView).toBe(false)
+  })
+
+  test('renders external links without Waku prefetch props', () => {
+    const element = Link({
+      children: null,
+      prefetch: 'view',
+      to: 'https://tempo.xyz',
+    })
+
+    expect(element.type).toBe('a')
+    expect(element.props.href).toBe('https://tempo.xyz')
+    expect(element.props.unstable_prefetchOnEnter).toBeUndefined()
+    expect(element.props.unstable_prefetchOnView).toBeUndefined()
+  })
+})

--- a/src/react/Link.test.tsx
+++ b/src/react/Link.test.tsx
@@ -8,6 +8,16 @@ vi.mock('waku', () => ({
 import { Link } from './Link.js'
 
 describe('Link', () => {
+  test('defaults to prefetch on view', () => {
+    const element = Link({
+      children: null,
+      to: '/guide/payments/send-a-payment',
+    })
+
+    expect(element.props.unstable_prefetchOnEnter).toBe(false)
+    expect(element.props.unstable_prefetchOnView).toBe(true)
+  })
+
   test('maps prefetch="view" to prefetch on view', () => {
     const element = Link({
       children: null,

--- a/src/react/Link.tsx
+++ b/src/react/Link.tsx
@@ -4,7 +4,7 @@ import { useRouter, Link as WakuLink } from 'waku'
 import * as Path from '../internal/path.js'
 
 export function Link(props: Link.Props) {
-  const { to, ...rest } = props
+  const { prefetch = import.meta.env.DEV ? 'none' : 'view', to, ...rest } = props
   const { path } = useRouter()
 
   if (Path.isExternal(props.to))
@@ -12,9 +12,20 @@ export function Link(props: Link.Props) {
 
   const [before, after] = (props.to || '').split('#')
   const resolvedTo = `${before ? before : path}${after ? `#${after}` : ''}`
-  return <WakuLink {...rest} to={resolvedTo} unstable_prefetchOnView={!import.meta.env.DEV} />
+  return (
+    <WakuLink
+      {...rest}
+      to={resolvedTo}
+      unstable_prefetchOnEnter={prefetch === 'intent'}
+      unstable_prefetchOnView={prefetch === 'view'}
+    />
+  )
 }
 
 export namespace Link {
-  export type Props = React.ComponentProps<typeof WakuLink>
+  export type Prefetch = 'none' | 'intent' | 'view'
+
+  export type Props = React.ComponentProps<typeof WakuLink> & {
+    prefetch?: Prefetch | undefined
+  }
 }

--- a/src/react/Link.tsx
+++ b/src/react/Link.tsx
@@ -4,7 +4,7 @@ import { useRouter, Link as WakuLink } from 'waku'
 import * as Path from '../internal/path.js'
 
 export function Link(props: Link.Props) {
-  const { prefetch = import.meta.env.DEV ? 'none' : 'view', to, ...rest } = props
+  const { prefetch = 'view', to, ...rest } = props
   const { path } = useRouter()
 
   if (Path.isExternal(props.to))

--- a/src/react/internal/Sidebar.tsx
+++ b/src/react/internal/Sidebar.tsx
@@ -51,6 +51,7 @@ function BackLink(props: { onNavigate?: (() => void) | undefined }) {
       className="vocs:flex vocs:items-center vocs:gap-1.5 vocs:text-secondary vocs:hover:text-heading vocs:mb-4 vocs:-ml-0.5"
       data-v-sidebar-back-link
       onClick={onNavigate}
+      prefetch="intent"
       to="/"
     >
       <LucideArrowLeft className="vocs:size-4" />
@@ -70,8 +71,16 @@ export declare namespace Sidebar {
 /** @internal */
 // biome-ignore lint/correctness/noUnusedVariables: _
 function Item(props: Item.Props) {
-  const { condensed = false, depth = 0, disabled, external, link, onNavigate, scrollRef, text } =
-    props
+  const {
+    condensed = false,
+    depth = 0,
+    disabled,
+    external,
+    link,
+    onNavigate,
+    scrollRef,
+    text,
+  } = props
 
   const { path } = useRouter()
   const isExternal = external ?? Path.isExternal(link)
@@ -137,6 +146,7 @@ function Item(props: Item.Props) {
         data-condensed={condensed && depth > 1}
         data-link={true}
         data-v-sidebar-item
+        prefetch="intent"
         to={link}
         ref={itemRef as never}
         onClick={onNavigate}

--- a/src/react/internal/Sidebar.tsx
+++ b/src/react/internal/Sidebar.tsx
@@ -30,13 +30,14 @@ export function Sidebar(props: Sidebar.Props) {
       )}
       data-v-sidebar
     >
-      {sidebar.backLink && <BackLink onNavigate={onNavigate} />}
+      {sidebar.backLink && <BackLink onNavigate={onNavigate} prefetch={sidebar.prefetch} />}
       {sidebar.items.map((item, i) => (
         <Section
           key={`${item.text}-${i}`}
           {...item}
           condensed={condenseSidebar}
           onNavigate={onNavigate}
+          prefetch={sidebar.prefetch}
           scrollRef={scrollRef}
         />
       ))}
@@ -44,14 +45,14 @@ export function Sidebar(props: Sidebar.Props) {
   )
 }
 
-function BackLink(props: { onNavigate?: (() => void) | undefined }) {
-  const { onNavigate } = props
+function BackLink(props: { onNavigate?: (() => void) | undefined; prefetch?: Link.Prefetch }) {
+  const { onNavigate, prefetch } = props
   return (
     <Link
       className="vocs:flex vocs:items-center vocs:gap-1.5 vocs:text-secondary vocs:hover:text-heading vocs:mb-4 vocs:-ml-0.5"
       data-v-sidebar-back-link
       onClick={onNavigate}
-      prefetch="intent"
+      prefetch={prefetch}
       to="/"
     >
       <LucideArrowLeft className="vocs:size-4" />
@@ -78,6 +79,7 @@ function Item(props: Item.Props) {
     external,
     link,
     onNavigate,
+    prefetch,
     scrollRef,
     text,
   } = props
@@ -146,7 +148,7 @@ function Item(props: Item.Props) {
         data-condensed={condensed && depth > 1}
         data-link={true}
         data-v-sidebar-item
-        prefetch="intent"
+        prefetch={prefetch}
         to={link}
         ref={itemRef as never}
         onClick={onNavigate}
@@ -175,6 +177,7 @@ namespace Item {
     condensed?: boolean | undefined
     depth?: number | undefined
     onNavigate?: (() => void) | undefined
+    prefetch?: Link.Prefetch | undefined
     scrollRef?: React.RefObject<HTMLDivElement | null>
   }
 
@@ -185,7 +188,7 @@ namespace Item {
 /** @internal */
 // biome-ignore lint/correctness/noUnusedVariables: _
 function Section(props: Section.Props) {
-  const { condensed = false, depth = 0, link, items, onNavigate, scrollRef, text } = props
+  const { condensed = false, depth = 0, link, items, onNavigate, prefetch, scrollRef, text } = props
 
   const { path } = useRouter()
 
@@ -282,6 +285,7 @@ function Section(props: Section.Props) {
                   condensed={condensed}
                   depth={depth + 1}
                   onNavigate={onNavigate}
+                  prefetch={prefetch}
                   scrollRef={scrollRef}
                 />
               ))}
@@ -298,6 +302,7 @@ namespace Section {
     condensed?: boolean | undefined
     depth?: number | undefined
     onNavigate?: (() => void) | undefined
+    prefetch?: Link.Prefetch | undefined
     scrollRef: React.RefObject<HTMLDivElement | null>
   }
 


### PR DESCRIPTION
## Summary
- add a `prefetch` prop to the React `Link` wrapper with `none`, `intent`, and `view` modes
- keep the existing production default for content links while disabling default prefetch in dev
- switch sidebar links to `prefetch="intent"` so large navs do not eagerly prefetch every route on load
- add a focused unit test for the Waku prefetch prop mapping and external-link behavior