### PR TITLE
perf: dedupe shiki token colors into classes

### DIFF
--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -9,6 +9,7 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
+    "types": ["node"],
     "jsx": "react-jsx",
     "strict": true,
     "noUnusedLocals": true,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -192,7 +192,6 @@ cli
             ignoreDeprecations: '6.0',
             moduleResolution: 100, // bundler
             preserveSymlinks: false,
-            types: ['node'],
           },
           customTags: ['log', 'error', 'warn', 'annotate'],
         })

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -189,8 +189,10 @@ cli
         const { createTwoslasher } = await import('twoslash')
         const twoslasher = createTwoslasher({
           compilerOptions: {
+            ignoreDeprecations: '6.0',
             moduleResolution: 100, // bundler
             preserveSymlinks: false,
+            types: ['node'],
           },
           customTags: ['log', 'error', 'warn', 'annotate'],
         })

--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -39,6 +39,7 @@ import * as Icons from './icons.js'
 import { rehypeImageSize } from './rehype-image-size.js'
 import { remarkVocsScope } from './remark-vocs-scope.js'
 import { remarkSandbox } from './sandbox.js'
+import { tokenClasses } from './shiki-token-classes.js'
 import * as ShikiTransformers from './shiki-transformers.js'
 import * as Snippets from './snippets.js'
 import type { ExactPartial, UnionOmit } from './types.js'
@@ -490,6 +491,7 @@ export function rehypeShiki(
         ShikiTransformers.title(),
         ShikiTransformers.inlineLanguage(),
         ...(options.transformers ?? []),
+        tokenClasses(),
       ].filter(Boolean),
     } as RehypeShikiOptions,
   ]

--- a/src/internal/shiki-token-classes.test.ts
+++ b/src/internal/shiki-token-classes.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { createHighlighter } from 'shiki'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   classNameForTokenStyle,
   dataAttribute,
@@ -11,8 +11,18 @@ import {
   tokenClasses,
 } from './shiki-token-classes.js'
 
+const styleA = 'color:light-dark(#D73A49, #F47067);--shiki-light:#D73A49;--shiki-dark:#F47067'
+const styleB = 'color:light-dark(#24292E, #ADBAC7);--shiki-light:#24292E;--shiki-dark:#ADBAC7'
+
+type SpanFixture = {
+  children?: SpanFixture[]
+  className?: string | string[]
+  style?: string
+  text?: string
+}
+
 // biome-ignore lint/suspicious/noExplicitAny: test fixture for untyped HAST nodes
-function makeRoot(styles: string[]): any {
+function makeRoot(spans: SpanFixture[]): any {
   return {
     type: 'root',
     children: [
@@ -25,14 +35,27 @@ function makeRoot(styles: string[]): any {
             type: 'element',
             tagName: 'code',
             properties: {},
-            children: styles.map((style) => ({
-              type: 'element',
-              tagName: 'span',
-              properties: { style },
-              children: [{ type: 'text', value: 'token' }],
-            })),
+            children: spans.map(makeSpan),
           },
         ],
+      },
+    ],
+  }
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: test fixture for untyped HAST nodes
+function makeSpan({ children, className, style, text = 'token' }: SpanFixture): any {
+  return {
+    type: 'element',
+    tagName: 'span',
+    properties: {
+      ...(className ? { class: Array.isArray(className) ? className : [className] } : {}),
+      ...(style ? { style } : {}),
+    },
+    children: children?.map(makeSpan) ?? [
+      {
+        type: 'text',
+        value: text,
       },
     ],
   }
@@ -52,6 +75,11 @@ function getClassName(value: unknown) {
   return Array.isArray(value) ? value.join(' ') : String(value)
 }
 
+function getRules(root: any) {
+  const css = root.children[0]?.properties[dataAttribute]
+  return typeof css === 'string' ? css.split('\n') : []
+}
+
 beforeEach(() => {
   document.head.innerHTML = ''
   document.body.innerHTML = ''
@@ -59,59 +87,124 @@ beforeEach(() => {
 })
 
 describe('splitStyle', () => {
-  it('separates token colors from other inline styles', () => {
-    expect(
-      splitStyle(
+  it.each([
+    {
+      name: 'separates token colors from other inline styles',
+      style:
         'color:light-dark(#111111, #eeeeee);--shiki-light:#111111;--shiki-dark:#eeeeee;font-style:italic',
-      ),
-    ).toEqual({
-      color: 'color:light-dark(#111111, #eeeeee);--shiki-light:#111111;--shiki-dark:#eeeeee',
-      rest: 'font-style:italic',
-    })
+      expected: {
+        color: 'color:light-dark(#111111, #eeeeee);--shiki-light:#111111;--shiki-dark:#eeeeee',
+        rest: 'font-style:italic',
+      },
+    },
+    {
+      name: 'extracts background token declarations',
+      style:
+        'background-color:light-dark(#ffffff, #000000);--shiki-light-bg:#ffffff;--shiki-dark-bg:#000000;opacity:0.8',
+      expected: {
+        color:
+          'background-color:light-dark(#ffffff, #000000);--shiki-light-bg:#ffffff;--shiki-dark-bg:#000000',
+        rest: 'opacity:0.8',
+      },
+    },
+    {
+      name: 'ignores malformed declarations while keeping valid ones',
+      style: 'color:light-dark(#111111, #eeeeee);broken;font-weight:700',
+      expected: {
+        color: 'color:light-dark(#111111, #eeeeee)',
+        rest: 'font-weight:700',
+      },
+    },
+  ])('$name', ({ style, expected }) => {
+    expect(splitStyle(style)).toEqual(expected)
   })
 })
 
 describe('tokenClasses', () => {
-  it('replaces repeated color styles with shared classes and per-block css', () => {
-    const styleA = 'color:light-dark(#D73A49, #F47067);--shiki-light:#D73A49;--shiki-dark:#F47067'
-    const styleB = 'color:light-dark(#24292E, #ADBAC7);--shiki-light:#24292E;--shiki-dark:#ADBAC7'
-    const root = makeRoot([styleA, styleB, styleA, styleB])
+  it.each([
+    {
+      name: 'replaces repeated color styles with shared classes and per-block css',
+      spans: [{ style: styleA }, { style: styleB }, { style: styleA }, { style: styleB }],
+      expectedRuleCount: 2,
+      expectedInlineStyles: [undefined, undefined, undefined, undefined],
+      assert(spans: any[]) {
+        expect(getClassName(spans[0]?.properties.class)).toBe(
+          getClassName(spans[2]?.properties.class),
+        )
+        expect(getClassName(spans[1]?.properties.class)).toBe(
+          getClassName(spans[3]?.properties.class),
+        )
+      },
+    },
+    {
+      name: 'preserves non-color inline styles',
+      spans: [{ style: `${styleA};font-style:italic` }],
+      expectedRuleCount: 1,
+      expectedInlineStyles: ['font-style:italic'],
+    },
+    {
+      name: 'leaves non-token inline styles untouched',
+      spans: [{ style: 'font-style:italic' }],
+      expectedRuleCount: 0,
+      expectedInlineStyles: ['font-style:italic'],
+      expectTokenClass: false,
+    },
+    {
+      name: 'keeps existing classes when appending token classes',
+      spans: [{ className: 'existing-token', style: styleA }],
+      expectedRuleCount: 1,
+      expectedInlineStyles: [undefined],
+      assert(spans: any[]) {
+        expect(getClassName(spans[0]?.properties.class)).toContain('existing-token')
+      },
+    },
+  ])('$name', ({
+    spans: fixtures,
+    expectedInlineStyles,
+    expectedRuleCount,
+    expectTokenClass = true,
+    assert,
+  }) => {
+    const root = makeRoot(fixtures)
 
     tokenClasses().root?.call({} as never, root)
 
-    const pre = getPre(root)
     const spans = getSpans(root)
-    const css = String(pre.properties[dataAttribute])
-    const rules = css.split('\n')
+    const rules = getRules(root)
 
-    expect(rules).toHaveLength(2)
-    expect(rules[0]).toContain(styleA)
-    expect(rules[1]).toContain(styleB)
-    expect(getClassName(spans[0]?.properties.class)).toBe(getClassName(spans[2]?.properties.class))
-    expect(getClassName(spans[1]?.properties.class)).toBe(getClassName(spans[3]?.properties.class))
+    expect(rules).toHaveLength(expectedRuleCount)
+    expectedInlineStyles.forEach((style, index) => {
+      expect(spans[index]?.properties.style).toBe(style)
+      if (expectTokenClass) {
+        expect(getClassName(spans[index]?.properties.class)).toMatch(/(?:^| )vocs-shiki-/)
+      } else {
+        expect(spans[index]?.properties.class).toBeUndefined()
+      }
+    })
 
-    for (const span of spans) {
-      expect(span.properties.style).toBeUndefined()
-      expect(getClassName(span.properties.class)).toMatch(/^vocs-shiki-/)
-    }
+    assert?.(spans)
   })
 
-  it('preserves non-color inline styles', () => {
+  it('walks nested spans and emits css for descendant tokens', () => {
     const root = makeRoot([
-      'color:light-dark(#D73A49, #F47067);--shiki-light:#D73A49;--shiki-dark:#F47067;font-style:italic',
+      {
+        children: [{ style: styleA, text: 'nested-token' }],
+      },
     ])
 
     tokenClasses().root?.call({} as never, root)
 
-    const [span] = getSpans(root)
-    expect(span?.properties.style).toBe('font-style:italic')
-    expect(getClassName(span?.properties.class)).toMatch(/^vocs-shiki-/)
+    const outerSpan = getSpans(root)[0]
+    const innerSpan = outerSpan?.children[0]
+
+    expect(outerSpan?.properties.class).toBeUndefined()
+    expect(getClassName(innerSpan?.properties.class)).toMatch(/^vocs-shiki-/)
+    expect(getRules(root)).toEqual([expect.stringContaining(styleA)])
   })
 
   it('emits css on every block while keeping class names stable', () => {
-    const style = 'color:light-dark(#D73A49, #F47067);--shiki-light:#D73A49;--shiki-dark:#F47067'
-    const firstRoot = makeRoot([style])
-    const secondRoot = makeRoot([style])
+    const firstRoot = makeRoot([{ style: styleA }])
+    const secondRoot = makeRoot([{ style: styleA }])
 
     tokenClasses().root?.call({} as never, firstRoot)
     tokenClasses().root?.call({} as never, secondRoot)
@@ -122,8 +215,8 @@ describe('tokenClasses', () => {
     const secondClass = getClassName(getSpans(secondRoot)[0]?.properties.class)
 
     expect(firstClass).toBe(secondClass)
-    expect(firstPre.properties[dataAttribute]).toContain(`.${firstClass}{${style}}`)
-    expect(secondPre.properties[dataAttribute]).toContain(`.${secondClass}{${style}}`)
+    expect(firstPre.properties[dataAttribute]).toContain(`.${firstClass}{${styleA}}`)
+    expect(secondPre.properties[dataAttribute]).toContain(`.${secondClass}{${styleA}}`)
   })
 
   it('integrates with dual-theme shiki output', async () => {
@@ -148,45 +241,75 @@ describe('tokenClasses', () => {
   })
 })
 
-describe('tokenClassesScript', () => {
-  it('collects block css once and removes data attributes', () => {
-    const sharedClass = classNameForTokenStyle(
-      'color:light-dark(#D73A49, #F47067);--shiki-light:#D73A49;--shiki-dark:#F47067',
-    )
-    const uniqueClass = classNameForTokenStyle(
-      'color:light-dark(#24292E, #ADBAC7);--shiki-light:#24292E;--shiki-dark:#ADBAC7',
-    )
-    const sharedRule = `.${sharedClass}{color:light-dark(#D73A49, #F47067);--shiki-light:#D73A49;--shiki-dark:#F47067}`
-    const uniqueRule = `.${uniqueClass}{color:light-dark(#24292E, #ADBAC7);--shiki-light:#24292E;--shiki-dark:#ADBAC7}`
+describe('installTokenClassesRuntime', () => {
+  it.each([
+    {
+      name: 'collects block css once and removes data attributes',
+      setup() {
+        const sharedClass = classNameForTokenStyle(styleA)
+        const uniqueClass = classNameForTokenStyle(styleB)
+        const sharedRule = `.${sharedClass}{${styleA}}`
+        const uniqueRule = `.${uniqueClass}{${styleB}}`
 
-    document.body.innerHTML = `
-      <pre ${dataAttribute}="${sharedRule}\n${uniqueRule}"></pre>
-      <pre ${dataAttribute}="${sharedRule}"></pre>
-    `
+        document.body.innerHTML = `
+          <pre ${dataAttribute}="${sharedRule}\n${uniqueRule}"></pre>
+          <pre ${dataAttribute}="${sharedRule}"></pre>
+        `
 
-    installTokenClassesRuntime(document, window, dataAttribute, styleAttribute)
+        return {
+          expectedCss: `${sharedRule}${uniqueRule}`,
+          flushRoot: document,
+          installFirst: false,
+          pre: document.querySelector('pre'),
+          wrapper: undefined,
+        }
+      },
+    },
+    {
+      name: 'flushes nested blocks added after the initial render',
+      setup() {
+        const className = classNameForTokenStyle(
+          'color:light-dark(#79C0FF, #79C0FF);--shiki-light:#79C0FF;--shiki-dark:#79C0FF',
+        )
+        const rule = `.${className}{color:light-dark(#79C0FF, #79C0FF);--shiki-light:#79C0FF;--shiki-dark:#79C0FF}`
+        const wrapper = document.createElement('div')
+        wrapper.innerHTML = `<section><pre ${dataAttribute}="${rule}"></pre></section>`
+        return {
+          expectedCss: rule,
+          flushRoot: wrapper,
+          installFirst: true,
+          pre: wrapper.querySelector('pre'),
+          wrapper,
+        }
+      },
+    },
+  ])('$name', ({ setup }) => {
+    const { expectedCss, flushRoot, installFirst, pre, wrapper } = setup()
+    if (installFirst) installTokenClassesRuntime(document, window, dataAttribute, styleAttribute)
+    if (wrapper) document.body.appendChild(wrapper)
+    if (!installFirst) installTokenClassesRuntime(document, window, dataAttribute, styleAttribute)
+    window.__vocsShikiTokenClasses?.flush(flushRoot)
 
     const style = document.querySelector(`style[${styleAttribute}]`)
-    expect(style?.textContent).toBe(`${sharedRule}${uniqueRule}`)
-    expect(document.querySelectorAll(`pre[${dataAttribute}]`)).toHaveLength(0)
+    expect(style?.textContent).toBe(expectedCss)
+    expect(pre?.hasAttribute(dataAttribute)).toBe(false)
   })
 
-  it('flushes code blocks added after the initial render', () => {
-    const className = classNameForTokenStyle(
-      'color:light-dark(#79C0FF, #79C0FF);--shiki-light:#79C0FF;--shiki-dark:#79C0FF',
-    )
-    const rule = `.${className}{color:light-dark(#79C0FF, #79C0FF);--shiki-light:#79C0FF;--shiki-dark:#79C0FF}`
+  it('reuses the installed runtime and existing style element on repeat installs', () => {
+    const className = classNameForTokenStyle(styleA)
+    const rule = `.${className}{${styleA}}`
+    document.body.innerHTML = `<pre ${dataAttribute}="${rule}"></pre>`
 
     installTokenClassesRuntime(document, window, dataAttribute, styleAttribute)
 
-    const pre = document.createElement('pre')
-    pre.setAttribute(dataAttribute, rule)
-    document.body.appendChild(pre)
+    const runtime = window.__vocsShikiTokenClasses
+    const flushSpy = runtime ? vi.spyOn(runtime, 'flush') : undefined
+    document.body.innerHTML = `<pre ${dataAttribute}="${rule}"></pre>`
 
-    window.__vocsShikiTokenClasses?.flush(document.body)
+    installTokenClassesRuntime(document, window, dataAttribute, styleAttribute)
 
-    const style = document.querySelector(`style[${styleAttribute}]`)
-    expect(style?.textContent).toBe(rule)
-    expect(pre.hasAttribute(dataAttribute)).toBe(false)
+    expect(flushSpy).toHaveBeenCalledWith(document)
+    expect(document.querySelectorAll(`style[${styleAttribute}]`)).toHaveLength(1)
+    expect(document.querySelector(`style[${styleAttribute}]`)?.textContent).toBe(rule)
   })
 })

--- a/src/internal/shiki-token-classes.test.ts
+++ b/src/internal/shiki-token-classes.test.ts
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+
+import { createHighlighter } from 'shiki'
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  classNameForTokenStyle,
+  dataAttribute,
+  installTokenClassesRuntime,
+  splitStyle,
+  styleAttribute,
+  tokenClasses,
+} from './shiki-token-classes.js'
+
+// biome-ignore lint/suspicious/noExplicitAny: test fixture for untyped HAST nodes
+function makeRoot(styles: string[]): any {
+  return {
+    type: 'root',
+    children: [
+      {
+        type: 'element',
+        tagName: 'pre',
+        properties: {},
+        children: [
+          {
+            type: 'element',
+            tagName: 'code',
+            properties: {},
+            children: styles.map((style) => ({
+              type: 'element',
+              tagName: 'span',
+              properties: { style },
+              children: [{ type: 'text', value: 'token' }],
+            })),
+          },
+        ],
+      },
+    ],
+  }
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: test fixture for untyped HAST nodes
+function getPre(root: any) {
+  return root.children[0]
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: test fixture for untyped HAST nodes
+function getSpans(root: any) {
+  return root.children[0].children[0].children
+}
+
+function getClassName(value: unknown) {
+  return Array.isArray(value) ? value.join(' ') : String(value)
+}
+
+beforeEach(() => {
+  document.head.innerHTML = ''
+  document.body.innerHTML = ''
+  Reflect.deleteProperty(window as unknown as Record<string, unknown>, '__vocsShikiTokenClasses')
+})
+
+describe('splitStyle', () => {
+  it('separates token colors from other inline styles', () => {
+    expect(
+      splitStyle(
+        'color:light-dark(#111111, #eeeeee);--shiki-light:#111111;--shiki-dark:#eeeeee;font-style:italic',
+      ),
+    ).toEqual({
+      color: 'color:light-dark(#111111, #eeeeee);--shiki-light:#111111;--shiki-dark:#eeeeee',
+      rest: 'font-style:italic',
+    })
+  })
+})
+
+describe('tokenClasses', () => {
+  it('replaces repeated color styles with shared classes and per-block css', () => {
+    const styleA = 'color:light-dark(#D73A49, #F47067);--shiki-light:#D73A49;--shiki-dark:#F47067'
+    const styleB = 'color:light-dark(#24292E, #ADBAC7);--shiki-light:#24292E;--shiki-dark:#ADBAC7'
+    const root = makeRoot([styleA, styleB, styleA, styleB])
+
+    tokenClasses().root?.call({} as never, root)
+
+    const pre = getPre(root)
+    const spans = getSpans(root)
+    const css = String(pre.properties[dataAttribute])
+    const rules = css.split('\n')
+
+    expect(rules).toHaveLength(2)
+    expect(rules[0]).toContain(styleA)
+    expect(rules[1]).toContain(styleB)
+    expect(getClassName(spans[0]?.properties.class)).toBe(getClassName(spans[2]?.properties.class))
+    expect(getClassName(spans[1]?.properties.class)).toBe(getClassName(spans[3]?.properties.class))
+
+    for (const span of spans) {
+      expect(span.properties.style).toBeUndefined()
+      expect(getClassName(span.properties.class)).toMatch(/^vocs-shiki-/)
+    }
+  })
+
+  it('preserves non-color inline styles', () => {
+    const root = makeRoot([
+      'color:light-dark(#D73A49, #F47067);--shiki-light:#D73A49;--shiki-dark:#F47067;font-style:italic',
+    ])
+
+    tokenClasses().root?.call({} as never, root)
+
+    const [span] = getSpans(root)
+    expect(span?.properties.style).toBe('font-style:italic')
+    expect(getClassName(span?.properties.class)).toMatch(/^vocs-shiki-/)
+  })
+
+  it('emits css on every block while keeping class names stable', () => {
+    const style = 'color:light-dark(#D73A49, #F47067);--shiki-light:#D73A49;--shiki-dark:#F47067'
+    const firstRoot = makeRoot([style])
+    const secondRoot = makeRoot([style])
+
+    tokenClasses().root?.call({} as never, firstRoot)
+    tokenClasses().root?.call({} as never, secondRoot)
+
+    const firstPre = getPre(firstRoot)
+    const secondPre = getPre(secondRoot)
+    const firstClass = getClassName(getSpans(firstRoot)[0]?.properties.class)
+    const secondClass = getClassName(getSpans(secondRoot)[0]?.properties.class)
+
+    expect(firstClass).toBe(secondClass)
+    expect(firstPre.properties[dataAttribute]).toContain(`.${firstClass}{${style}}`)
+    expect(secondPre.properties[dataAttribute]).toContain(`.${secondClass}{${style}}`)
+  })
+
+  it('integrates with dual-theme shiki output', async () => {
+    const highlighter = await createHighlighter({
+      themes: ['github-light', 'github-dark-dimmed'],
+      langs: ['typescript'],
+    })
+
+    const html = highlighter.codeToHtml('const value = 1', {
+      lang: 'typescript',
+      themes: { dark: 'github-dark-dimmed', light: 'github-light' },
+      defaultColor: 'light-dark()',
+      rootStyle: false,
+      transformers: [tokenClasses()],
+    })
+
+    highlighter.dispose()
+
+    expect(html).toContain(dataAttribute)
+    expect(html).toContain('class="vocs-shiki-')
+    expect(html).not.toContain('style="color:light-dark(')
+  })
+})
+
+describe('tokenClassesScript', () => {
+  it('collects block css once and removes data attributes', () => {
+    const sharedClass = classNameForTokenStyle(
+      'color:light-dark(#D73A49, #F47067);--shiki-light:#D73A49;--shiki-dark:#F47067',
+    )
+    const uniqueClass = classNameForTokenStyle(
+      'color:light-dark(#24292E, #ADBAC7);--shiki-light:#24292E;--shiki-dark:#ADBAC7',
+    )
+    const sharedRule = `.${sharedClass}{color:light-dark(#D73A49, #F47067);--shiki-light:#D73A49;--shiki-dark:#F47067}`
+    const uniqueRule = `.${uniqueClass}{color:light-dark(#24292E, #ADBAC7);--shiki-light:#24292E;--shiki-dark:#ADBAC7}`
+
+    document.body.innerHTML = `
+      <pre ${dataAttribute}="${sharedRule}\n${uniqueRule}"></pre>
+      <pre ${dataAttribute}="${sharedRule}"></pre>
+    `
+
+    installTokenClassesRuntime(document, window, dataAttribute, styleAttribute)
+
+    const style = document.querySelector(`style[${styleAttribute}]`)
+    expect(style?.textContent).toBe(`${sharedRule}${uniqueRule}`)
+    expect(document.querySelectorAll(`pre[${dataAttribute}]`)).toHaveLength(0)
+  })
+
+  it('flushes code blocks added after the initial render', () => {
+    const className = classNameForTokenStyle(
+      'color:light-dark(#79C0FF, #79C0FF);--shiki-light:#79C0FF;--shiki-dark:#79C0FF',
+    )
+    const rule = `.${className}{color:light-dark(#79C0FF, #79C0FF);--shiki-light:#79C0FF;--shiki-dark:#79C0FF}`
+
+    installTokenClassesRuntime(document, window, dataAttribute, styleAttribute)
+
+    const pre = document.createElement('pre')
+    pre.setAttribute(dataAttribute, rule)
+    document.body.appendChild(pre)
+
+    window.__vocsShikiTokenClasses?.flush(document.body)
+
+    const style = document.querySelector(`style[${styleAttribute}]`)
+    expect(style?.textContent).toBe(rule)
+    expect(pre.hasAttribute(dataAttribute)).toBe(false)
+  })
+})

--- a/src/internal/shiki-token-classes.ts
+++ b/src/internal/shiki-token-classes.ts
@@ -2,6 +2,10 @@ import type { ShikiTransformer } from '@shikijs/types'
 import type { Element as HastElement } from 'hast'
 import { addClassToHast } from 'shiki'
 
+// Shiki emits token colors as inline styles on every span. This module lifts
+// the reusable color declarations into stable CSS classes, stores the emitted
+// rules on each <pre>, and lets a tiny runtime merge those rules into one
+// shared <style> tag after hydration and client navigations.
 const colorProperties = new Set([
   '--shiki-dark',
   '--shiki-dark-bg',
@@ -11,6 +15,7 @@ const colorProperties = new Set([
   'color',
 ])
 
+// Module-level caches keep class names stable across separate render passes.
 const styleToClassName = new Map<string, string>()
 const classNameToStyle = new Map<string, string>()
 
@@ -61,6 +66,7 @@ export declare namespace tokenClasses {
 }
 
 export function splitStyle(style: string): splitStyle.ReturnType {
+  // Preserve declaration order so equivalent styles keep the same cache key.
   const colorDeclarations: string[] = []
   const restDeclarations: string[] = []
 
@@ -143,6 +149,7 @@ export function installTokenClassesRuntime(
     document_.head.appendChild(style)
   }
 
+  // Deduping on the full CSS text makes repeated render passes idempotent.
   const seen = new Set<string>()
 
   const append = (css: string) => {

--- a/src/internal/shiki-token-classes.ts
+++ b/src/internal/shiki-token-classes.ts
@@ -1,0 +1,193 @@
+import type { ShikiTransformer } from '@shikijs/types'
+import type { Element as HastElement } from 'hast'
+import { addClassToHast } from 'shiki'
+
+const colorProperties = new Set([
+  '--shiki-dark',
+  '--shiki-dark-bg',
+  '--shiki-light',
+  '--shiki-light-bg',
+  'background-color',
+  'color',
+])
+
+const styleToClassName = new Map<string, string>()
+const classNameToStyle = new Map<string, string>()
+
+export const dataAttribute = 'data-v-shiki-css'
+export const styleAttribute = 'data-v-shiki-colors'
+
+export function tokenClasses(): tokenClasses.ReturnType {
+  return {
+    name: 'vocs:token-classes',
+    root(root) {
+      const pre = root.children.find(
+        (child): child is HastElement => child.type === 'element' && child.tagName === 'pre',
+      )
+      if (!pre) return
+
+      const code = pre.children.find(
+        (child): child is HastElement => child.type === 'element' && child.tagName === 'code',
+      )
+      if (!code) return
+
+      const rules = new Map<string, string>()
+
+      walkStyledSpans(code, (span) => {
+        const style =
+          typeof span.properties['style'] === 'string' ? span.properties['style'] : undefined
+        if (!style) return
+
+        const { color, rest } = splitStyle(style)
+        if (!color) return
+
+        const className = classNameForTokenStyle(color)
+        addClassToHast(span, className)
+        rules.set(className, `.${className}{${color}}`)
+
+        if (rest) span.properties['style'] = rest
+        else delete span.properties['style']
+      })
+
+      if (rules.size === 0) return
+
+      pre.properties[dataAttribute] = Array.from(rules.values()).join('\n')
+    },
+  }
+}
+
+export declare namespace tokenClasses {
+  type ReturnType = ShikiTransformer
+}
+
+export function splitStyle(style: string): splitStyle.ReturnType {
+  const colorDeclarations: string[] = []
+  const restDeclarations: string[] = []
+
+  for (const rawDeclaration of style.split(';')) {
+    const declaration = rawDeclaration.trim()
+    if (!declaration) continue
+
+    const separatorIndex = declaration.indexOf(':')
+    if (separatorIndex < 0) continue
+
+    const property = declaration.slice(0, separatorIndex).trim()
+    if (colorProperties.has(property)) colorDeclarations.push(declaration)
+    else restDeclarations.push(declaration)
+  }
+
+  return {
+    color: colorDeclarations.join(';'),
+    rest: restDeclarations.join(';'),
+  }
+}
+
+export declare namespace splitStyle {
+  type ReturnType = {
+    color: string
+    rest: string
+  }
+}
+
+export function classNameForTokenStyle(style: string) {
+  const existing = styleToClassName.get(style)
+  if (existing) return existing
+
+  const baseClassName = `vocs-shiki-${hashStyle(style)}`
+  let className = baseClassName
+  let suffix = 1
+
+  while (classNameToStyle.has(className) && classNameToStyle.get(className) !== style) {
+    className = `${baseClassName}-${suffix++}`
+  }
+
+  styleToClassName.set(style, className)
+  classNameToStyle.set(className, style)
+  return className
+}
+
+export function installTokenClassesRuntime(
+  document_: Document,
+  window_: Window,
+  dataAttribute_: string,
+  styleAttribute_: string,
+) {
+  const existingRuntime = window_.__vocsShikiTokenClasses
+  if (existingRuntime) {
+    existingRuntime.flush(document_)
+    return
+  }
+
+  let style = document_.querySelector(`style[${styleAttribute_}]`)
+  if (!style) {
+    style = document_.createElement('style')
+    style.setAttribute(styleAttribute_, '')
+    document_.head.appendChild(style)
+  }
+
+  const seen = new Set<string>()
+
+  const append = (css: string) => {
+    if (!css || seen.has(css)) return
+    seen.add(css)
+    style.textContent = `${style.textContent ?? ''}${css}`
+  }
+
+  const flush = (root: ParentNode) => {
+    const nodes: globalThis.Element[] = []
+    if (root instanceof Element && root.matches(`pre[${dataAttribute_}]`)) nodes.push(root)
+    if ('querySelectorAll' in root) {
+      root.querySelectorAll(`pre[${dataAttribute_}]`).forEach((node) => {
+        nodes.push(node)
+      })
+    }
+
+    for (const pre of nodes) {
+      const css = pre.getAttribute(dataAttribute_)
+      if (css) css.split('\n').forEach(append)
+      pre.removeAttribute(dataAttribute_)
+    }
+  }
+
+  if (document_.body) {
+    new MutationObserver((records) => {
+      for (const record of records) {
+        for (const node of record.addedNodes) {
+          if (node instanceof Element) flush(node)
+        }
+      }
+    }).observe(document_.body, { childList: true, subtree: true })
+  }
+
+  window_.__vocsShikiTokenClasses = { flush }
+  flush(document_)
+}
+
+export const tokenClassesScript = `;(${installTokenClassesRuntime.toString()})(document, window, ${JSON.stringify(dataAttribute)}, ${JSON.stringify(styleAttribute)});`
+
+declare global {
+  interface Window {
+    __vocsShikiTokenClasses?: {
+      flush(root: ParentNode): void
+    }
+  }
+}
+
+function hashStyle(style: string) {
+  let hash = 2166136261
+
+  for (let index = 0; index < style.length; index++) {
+    hash ^= style.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+
+  return (hash >>> 0).toString(36)
+}
+
+function walkStyledSpans(node: HastElement, callback: (span: HastElement) => void) {
+  for (const child of node.children) {
+    if (child.type !== 'element') continue
+    if (child.tagName === 'span' && typeof child.properties['style'] === 'string') callback(child)
+    walkStyledSpans(child, callback)
+  }
+}

--- a/src/internal/shiki-token-classes.ts
+++ b/src/internal/shiki-token-classes.ts
@@ -107,11 +107,29 @@ export function classNameForTokenStyle(style: string) {
 }
 
 export function installTokenClassesRuntime(
-  document_: Document,
-  window_: Window,
+  document_: installTokenClassesRuntime.DocumentLike,
+  window_: installTokenClassesRuntime.WindowLike,
   dataAttribute_: string,
   styleAttribute_: string,
 ) {
+  const isElementLike = (value: unknown): value is installTokenClassesRuntime.ElementLike => {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      'getAttribute' in value &&
+      typeof value.getAttribute === 'function' &&
+      'matches' in value &&
+      typeof value.matches === 'function' &&
+      'removeAttribute' in value &&
+      typeof value.removeAttribute === 'function'
+    )
+  }
+
+  const querySelectorAll = (root: installTokenClassesRuntime.ParentNodeLike, selector: string) => {
+    if (typeof root.querySelectorAll !== 'function') return []
+    return Array.from(root.querySelectorAll(selector))
+  }
+
   const existingRuntime = window_.__vocsShikiTokenClasses
   if (existingRuntime) {
     existingRuntime.flush(document_)
@@ -133,14 +151,11 @@ export function installTokenClassesRuntime(
     style.textContent = `${style.textContent ?? ''}${css}`
   }
 
-  const flush = (root: ParentNode) => {
-    const nodes: globalThis.Element[] = []
-    if (root instanceof Element && root.matches(`pre[${dataAttribute_}]`)) nodes.push(root)
-    if ('querySelectorAll' in root) {
-      root.querySelectorAll(`pre[${dataAttribute_}]`).forEach((node) => {
-        nodes.push(node)
-      })
-    }
+  const flush = (root: installTokenClassesRuntime.ParentNodeLike) => {
+    const nodes = [
+      ...(isElementLike(root) && root.matches(`pre[${dataAttribute_}]`) ? [root] : []),
+      ...querySelectorAll(root, `pre[${dataAttribute_}]`),
+    ]
 
     for (const pre of nodes) {
       const css = pre.getAttribute(dataAttribute_)
@@ -149,11 +164,12 @@ export function installTokenClassesRuntime(
     }
   }
 
-  if (document_.body) {
-    new MutationObserver((records) => {
+  const MutationObserver_ = window_.MutationObserver
+  if (document_.body && MutationObserver_) {
+    new MutationObserver_((records) => {
       for (const record of records) {
-        for (const node of record.addedNodes) {
-          if (node instanceof Element) flush(node)
+        for (const node of Array.from(record.addedNodes)) {
+          if (isElementLike(node)) flush(node)
         }
       }
     }).observe(document_.body, { childList: true, subtree: true })
@@ -163,12 +179,54 @@ export function installTokenClassesRuntime(
   flush(document_)
 }
 
+export declare namespace installTokenClassesRuntime {
+  type ParentNodeLike = {
+    querySelectorAll?: (selector: string) => Iterable<ElementLike> | ArrayLike<ElementLike>
+  }
+
+  type ElementLike = ParentNodeLike & {
+    getAttribute(name: string): string | null
+    matches(selector: string): boolean
+    removeAttribute(name: string): void
+    setAttribute(name: string, value: string): void
+    textContent: string | null
+  }
+
+  type DocumentLike = ParentNodeLike & {
+    body: ParentNodeLike | null
+    createElement(tagName: string): ElementLike
+    head: {
+      appendChild(node: unknown): unknown
+    }
+    querySelector(selector: string): ElementLike | null
+  }
+
+  type MutationRecordLike = {
+    addedNodes: Iterable<unknown> | ArrayLike<unknown>
+  }
+
+  type MutationObserverLike = {
+    observe(target: unknown, options?: unknown): unknown
+  }
+
+  type MutationObserverConstructor = new (
+    callback: (records: MutationRecordLike[]) => void,
+  ) => MutationObserverLike
+
+  type WindowLike = {
+    MutationObserver?: MutationObserverConstructor
+    __vocsShikiTokenClasses?: {
+      flush(root: ParentNodeLike): void
+    }
+  }
+}
+
 export const tokenClassesScript = `;(${installTokenClassesRuntime.toString()})(document, window, ${JSON.stringify(dataAttribute)}, ${JSON.stringify(styleAttribute)});`
 
 declare global {
   interface Window {
     __vocsShikiTokenClasses?: {
-      flush(root: ParentNode): void
+      flush(root: installTokenClassesRuntime.ParentNodeLike): void
     }
   }
 }

--- a/src/internal/shiki-transformers.ts
+++ b/src/internal/shiki-transformers.ts
@@ -233,7 +233,6 @@ export function twoslash(options: twoslash.Options): ShikiTransformer {
       ignoreDeprecations: '6.0', // needed for TS 6 (baseUrl deprecation in @typescript/vfs)
       moduleResolution: 100, // bundler (default, can be overridden)
       preserveSymlinks: false, // needed for monorepo/workspace symlinks
-      types: ['node'], // include node types by default (process.env, etc.)
       ...(twoslashOptions?.compilerOptions ?? {}),
     },
   })

--- a/src/react/Root.tsx
+++ b/src/react/Root.tsx
@@ -5,6 +5,7 @@ import groupIconsCss from 'virtual:vocs/group-icons.css?inline'
 // biome-ignore lint/suspicious/noTsIgnore: _
 // @ts-ignore
 import userStyles from 'virtual:vocs/user-styles?inline'
+import { tokenClassesScript } from '../internal/shiki-token-classes.js'
 // biome-ignore lint/suspicious/noTsIgnore: _
 // @ts-ignore
 import styles from '../styles/index.css?inline'
@@ -33,6 +34,8 @@ export async function Root({ children }: { children: React.ReactNode }) {
       </head>
       <body data-version="1.0">
         <Root_client>{children}</Root_client>
+        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: inline script hydrates token colors */}
+        <script dangerouslySetInnerHTML={{ __html: tokenClassesScript }} />
         <ScrollRestoration />
       </body>
     </html>

--- a/src/waku/internal/middleware/md-router.test.ts
+++ b/src/waku/internal/middleware/md-router.test.ts
@@ -25,6 +25,7 @@ function restoreNodeEnv() {
 
 afterEach(() => {
   restoreNodeEnv()
+  vi.clearAllMocks()
   vi.restoreAllMocks()
   vi.resetModules()
   globalThis.fetch = originalFetch
@@ -86,7 +87,7 @@ describe('middleware', () => {
     return import('./md-router.js').then(({ middleware }) => {
       app.use('*', middleware())
       app.get('*', (c) => c.html('<p>ok</p>'))
-      return app.request(url, { headers })
+      return app.request(url, headers ? { headers } : undefined)
     })
   }
 

--- a/twoslash-rust/src/project.rs
+++ b/twoslash-rust/src/project.rs
@@ -159,7 +159,10 @@ impl Project {
     }
 
     /// Like `scaffold`, but injects user code immediately.
-    pub fn scaffold_with_code<'a>(settings: ProjectSettings<'_>, source: &'a str) -> Result<Project> {
+    pub fn scaffold_with_code<'a>(
+        settings: ProjectSettings<'_>,
+        source: &'a str,
+    ) -> Result<Project> {
         let parse_result = find_queries(source);
         let source = parse_result.code;
         let queries = parse_result.queries;


### PR DESCRIPTION
## Summary
- add an internal Shiki transformer that replaces repeated token color inline styles with short CSS classes
- attach per-block color rules to the rendered `<pre>` so direct page loads still have everything they need
- inject one small runtime in `Root` that collects and dedupes those rules across the page
- add focused tests for style splitting, class generation, per-block CSS emission, dual-theme integration, and runtime flushing

## Why this shape

Shiki dual-theme output repeats the same token color styles thousands of times. Converting those repeated styles into classes shrinks the HTML and RSC payload substantially, but each page still needs to be self-contained on direct load.

Reference impl: https://github.com/shikijs/shiki/issues/671#issuecomment-3605458169

## Performance

Verified locally with the perf harness in dedicated `next` and PR worktrees.

- `site` build totals: raw `-301.4 KiB`, JS raw `-303.4 KiB`
- compressed `site` totals stayed effectively flat: gzip `+5.5 KiB`, brotli `+10.5 KiB`
- additional local-only stress routes built from code-heavy playground pages show raw `-276.4 KiB` and JS raw `-276.9 KiB`
- stress route HTML reductions: `/stress-twoslash` `-206.5 KiB`, `/stress-ethers-migration` `-124.3 KiB`, `/stress-kitchen-sink` `-42.0 KiB`, `/stress-account-abstraction` `-19.0 KiB`
- browser timings on the stress routes were roughly flat/noisy, but FCP/load remained in the same range overall
