### PR TITLE
perf(twoslash): serialize hover popup payload

### DIFF
--- a/.changeset/twoslash-hover-payload.md
+++ b/.changeset/twoslash-hover-payload.md
@@ -1,0 +1,5 @@
+---
+'vocs': patch
+---
+
+Reduce Twoslash hover payload size by storing popup content as serialized HTML props instead of nested MDX children.

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -15,6 +15,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
+    "types": ["node"],
     "paths": {
       "vocs/server": ["../src/server/index.ts"],
       "vocs/server/*": ["../src/server/*"]

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -189,8 +189,10 @@ cli
         const { createTwoslasher } = await import('twoslash')
         const twoslasher = createTwoslasher({
           compilerOptions: {
+            ignoreDeprecations: '6.0',
             moduleResolution: 100, // bundler
             preserveSymlinks: false,
+            types: ['node'],
           },
           customTags: ['log', 'error', 'warn', 'annotate'],
         })

--- a/src/internal/twoslash/renderer.test.ts
+++ b/src/internal/twoslash/renderer.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { defaultMarkdownPatterns, reconstructDocs, rustMarkdownPatterns } from './renderer.js'
+import { defaultMarkdownPatterns, reconstructDocs, rich, rustMarkdownPatterns } from './renderer.js'
 
 // Re-implement fixUnclosedCodeBlocks for testing (since it's not exported)
 function fixUnclosedCodeBlocks(markdown: string, patterns: RegExp[]): string {
@@ -433,4 +433,90 @@ test('reconstructDocs: handles multiple example tags', () => {
   expect(reconstructDocs(docs, tags)).toBe(
     'Description\n\n**Example**\n\n```ts\nexample1\n```\n\n**Example**\n\n```ts\nexample2\n```',
   )
+})
+
+function createFakeContext(lang = 'ts') {
+  return {
+    codeToHast(code: string) {
+      return {
+        type: 'root',
+        children: [
+          {
+            type: 'element',
+            tagName: 'pre',
+            properties: { class: 'shiki' },
+            children: [
+              {
+                type: 'element',
+                tagName: 'code',
+                properties: {},
+                children: [{ type: 'text', value: `${lang}:${code}` }],
+              },
+            ],
+          },
+        ],
+      }
+    },
+    options: { lang },
+  } as any
+}
+
+test('rich: nodeStaticInfo stores popup payload in attrs instead of child nodes', () => {
+  const renderer = rich()
+  const token = { type: 'text', value: 'token' } as const
+
+  if (typeof renderer.nodeStaticInfo !== 'function') throw new Error('expected nodeStaticInfo')
+
+  const result = renderer.nodeStaticInfo.call(
+    createFakeContext(),
+    { docs: 'Useful docs', tags: [], text: 'value: string' },
+    token,
+  )
+
+  expect(result).toMatchObject({
+    type: 'element',
+    tagName: 'span',
+    properties: {
+      class: 'twoslash-hover twoslash-popup-container',
+    },
+    children: [token],
+  })
+  if (result.type !== 'element') throw new Error('expected element')
+  if (!result.properties) throw new Error('expected properties')
+
+  expect(result.children).toEqual([token])
+  expect(result.properties['data-v-twoslash-code-html']).toContain('twoslash-popup-code')
+  expect(result.properties['data-v-twoslash-code-html']).toContain('ts:value: string')
+  expect(result.properties['data-v-twoslash-code-html']).toContain('data-v-overflow-sentinel')
+  expect(result.properties['data-v-twoslash-docs-html']).toContain('twoslash-popup-docs')
+  expect(result.properties['data-v-twoslash-docs-html']).toContain('Useful docs')
+})
+
+test('rich: nodeQuery stores persisted popup payload in attrs', () => {
+  const renderer = rich()
+  const token = { type: 'text', value: 'token' } as const
+
+  if (typeof renderer.nodeQuery !== 'function') throw new Error('expected nodeQuery')
+
+  const result = renderer.nodeQuery.call(
+    createFakeContext('tsx'),
+    { docs: undefined, tags: [], text: 'fn(): Promise<void>' },
+    token,
+  )
+
+  expect(result).toMatchObject({
+    type: 'element',
+    tagName: 'span',
+    properties: {
+      class: 'twoslash-hover twoslash-query-persisted twoslash-popup-container',
+    },
+    children: [token],
+  })
+  if (result.type !== 'element') throw new Error('expected element')
+  if (!result.properties) throw new Error('expected properties')
+
+  expect(result.properties['data-v-twoslash-code-html']).toContain(
+    'tsx:function fn(): Promise&#x3C;void>',
+  )
+  expect(result.properties['data-v-twoslash-docs-html']).toBeUndefined()
 })

--- a/src/internal/twoslash/renderer.test.ts
+++ b/src/internal/twoslash/renderer.test.ts
@@ -1,3 +1,4 @@
+import type { NodeHover, NodeQuery } from 'twoslash'
 import { expect, test } from 'vitest'
 import { defaultMarkdownPatterns, reconstructDocs, rich, rustMarkdownPatterns } from './renderer.js'
 
@@ -467,11 +468,13 @@ test('rich: nodeStaticInfo stores popup payload in attrs instead of child nodes'
 
   if (typeof renderer.nodeStaticInfo !== 'function') throw new Error('expected nodeStaticInfo')
 
-  const result = renderer.nodeStaticInfo.call(
-    createFakeContext(),
-    { docs: 'Useful docs', tags: [], text: 'value: string' },
-    token,
-  )
+  const hover = {
+    docs: 'Useful docs',
+    tags: [],
+    text: 'value: string',
+  } as unknown as NodeHover
+
+  const result = renderer.nodeStaticInfo.call(createFakeContext(), hover, token)
 
   expect(result).toMatchObject({
     type: 'element',
@@ -498,11 +501,12 @@ test('rich: nodeQuery stores persisted popup payload in attrs', () => {
 
   if (typeof renderer.nodeQuery !== 'function') throw new Error('expected nodeQuery')
 
-  const result = renderer.nodeQuery.call(
-    createFakeContext('tsx'),
-    { docs: undefined, tags: [], text: 'fn(): Promise<void>' },
-    token,
-  )
+  const query = {
+    tags: [],
+    text: 'fn(): Promise<void>',
+  } as unknown as NodeQuery
+
+  const result = renderer.nodeQuery.call(createFakeContext('tsx'), query, token)
 
   expect(result).toMatchObject({
     type: 'element',

--- a/src/internal/twoslash/renderer.ts
+++ b/src/internal/twoslash/renderer.ts
@@ -4,6 +4,7 @@ import type { Element, ElementContent } from 'hast'
 import { fromMarkdown } from 'mdast-util-from-markdown'
 import { gfmFromMarkdown } from 'mdast-util-gfm'
 import { defaultHandlers, toHast } from 'mdast-util-to-hast'
+import { hastToHtml } from 'shiki'
 import type { NodeError, NodeHover, NodeQuery } from 'twoslash'
 import { remarkVocsScope } from '../remark-vocs-scope.js'
 
@@ -28,6 +29,11 @@ export const rustMarkdownPatterns: RegExp[] = [
   /^>\s/, // Blockquote
 ]
 
+export type PopupPayload = {
+  codeHtml?: string | undefined
+  docsHtml?: string | undefined
+}
+
 /**
  * An alternative renderer that providers better prefixed class names,
  * with syntax highlight for the info text.
@@ -35,36 +41,50 @@ export const rustMarkdownPatterns: RegExp[] = [
 export function rich(options: rich.Options = {}): TwoslashRenderer {
   const { markdownPatterns = defaultMarkdownPatterns } = options
 
-  function getPopupContent(
+  function getPopupPayload(
     this: ShikiTransformerContextCommon,
     info: NodeHover | NodeQuery,
-  ): ElementContent[] {
-    if (!info.text) return []
+  ): PopupPayload | undefined {
+    if (!info.text) return undefined
 
     // Rust twoslash combines code and docs in `text` separated by `---`
     // Split them so docs can be rendered as markdown
     const { code: extractedCode, docs: extractedDocs } = splitCodeAndDocs(info.text)
 
     const content = processHoverInfo(extractedCode)
-    if (!content || content === 'any') return []
-
-    const popupContents: ElementContent[] = []
+    if (!content || content === 'any') return undefined
 
     let lang = this.options.lang
     if (lang === 'jsx') lang = 'tsx'
     else if (lang === 'js' || lang === 'javascript') lang = 'ts'
 
-    popupContents.push({
-      type: 'element',
-      tagName: 'pre',
-      properties: {
-        class: 'twoslash-popup-code',
-        'data-v-code': content,
-        'data-v-codeToHtml': true,
-        'data-v-lang': lang,
-      },
-      children: [],
+    const codeHast = this.codeToHast(content, {
+      ...this.options,
+      defaultColor: 'light-dark()',
+      lang,
+      meta: { 'data-v-overflow-fade': true },
+      rootStyle: false,
+      structure: 'classic',
+      transformers: [],
     })
+
+    const codePre = codeHast.children[0]
+    if (codePre?.type === 'element' && codePre.tagName === 'pre') {
+      codePre.properties = {
+        ...codePre.properties,
+        class: mergeClasses(codePre.properties?.['class'], 'twoslash-popup-code'),
+      }
+      codePre.children.push({
+        type: 'element',
+        tagName: 'div',
+        properties: { 'data-v-overflow-sentinel': true },
+        children: [],
+      })
+    }
+
+    const payload: PopupPayload = {
+      codeHtml: hastToHtml(codeHast),
+    }
 
     // Use extracted docs from text (Rust) or explicit docs field (TypeScript)
     // Also reconstruct docs from spurious tags that were incorrectly parsed
@@ -104,7 +124,7 @@ export function rich(options: rich.Options = {}): TwoslashRenderer {
         },
       }) as Element
 
-      popupContents.push({
+      payload.docsHtml = hastToHtml({
         type: 'element',
         tagName: 'div',
         properties: { class: 'twoslash-popup-docs', 'data-v-overflow-fade': true },
@@ -120,9 +140,7 @@ export function rich(options: rich.Options = {}): TwoslashRenderer {
       })
     }
 
-    // TODO: render `info.tags`
-
-    return popupContents
+    return payload
   }
 
   return {
@@ -160,32 +178,38 @@ export function rich(options: rich.Options = {}): TwoslashRenderer {
     },
 
     nodeStaticInfo(info, node) {
-      const content = getPopupContent.call(this, info)
+      const payload = getPopupPayload.call(this, info)
 
-      if (!content.length) return node
+      if (!payload) return node
 
       return {
         type: 'element',
         tagName: 'span',
         properties: {
           class: 'twoslash-hover twoslash-popup-container',
+          'data-v-twoslash-code-html': payload.codeHtml,
+          'data-v-twoslash-docs-html': payload.docsHtml,
         },
-        children: [node, ...content],
+        children: [node],
       }
     },
 
     nodeQuery(query, node) {
       if (!query.text) return {}
 
-      const content = getPopupContent.call(this, query)
+      const payload = getPopupPayload.call(this, query)
+
+      if (!payload) return node
 
       return {
         type: 'element',
         tagName: 'span',
         properties: {
           class: 'twoslash-hover twoslash-query-persisted twoslash-popup-container',
+          'data-v-twoslash-code-html': payload.codeHtml,
+          'data-v-twoslash-docs-html': payload.docsHtml,
         },
-        children: [node, ...content],
+        children: [node],
       }
     },
 
@@ -411,6 +435,16 @@ function processHoverDocs(docs: string, markdownPatterns: RegExp[]): string {
   processed = fixUnclosedCodeBlocks(processed, markdownPatterns)
 
   return processed
+}
+
+function mergeClasses(existing: unknown, next: string): string {
+  const classes = Array.isArray(existing)
+    ? existing.flatMap((value) => String(value).split(' '))
+    : typeof existing === 'string'
+      ? existing.split(' ')
+      : []
+
+  return [...classes.filter(Boolean), next].join(' ')
 }
 
 /**

--- a/src/react/internal/TwoslashHover.client.tsx
+++ b/src/react/internal/TwoslashHover.client.tsx
@@ -5,34 +5,44 @@ import type * as React from 'react'
 import { useCallback } from 'react'
 
 export function TwoslashHover(props: TwoslashHover.Props) {
-  const { className = '', children, trigger } = props
+  const { children, className = '', codeHtml, docsHtml, trigger } = props
 
   const { ref } = TwoslashHover.useOverflowFade()
 
   const open = className?.includes('twoslash-query-persisted')
+  const contentHtml = [codeHtml, docsHtml].filter(Boolean).join('')
+
+  const popupContent = contentHtml ? (
+    // biome-ignore lint/security/noDangerouslySetInnerHtml: trusted build-time HTML payload
+    <div dangerouslySetInnerHTML={{ __html: contentHtml }} data-v-content ref={ref} />
+  ) : children ? (
+    <div data-v-content ref={ref}>
+      {children}
+    </div>
+  ) : null
 
   return (
     <Popover.Root {...(open ? { open } : {})}>
       <Popover.Trigger data-v-twoslash-trigger openOnHover delay={0}>
         <span>{trigger}</span>
       </Popover.Trigger>
-      <Popover.Portal>
-        <Popover.Positioner
-          align="start"
-          side="bottom"
-          sideOffset={4}
-          collisionAvoidance={{ side: 'none' }}
-        >
-          <Popover.Popup className={className} initialFocus={false}>
-            <Popover.Arrow className="vocs:data-[side=bottom]:top-[-8px] vocs:data-[side=left]:right-[-13px] vocs:data-[side=left]:rotate-90 vocs:data-[side=right]:left-[-13px] vocs:data-[side=right]:-rotate-90 vocs:data-[side=top]:bottom-[-8px] vocs:data-[side=top]:rotate-180">
-              <ArrowSvg />
-            </Popover.Arrow>
-            <div data-v-content ref={ref}>
-              {children}
-            </div>
-          </Popover.Popup>
-        </Popover.Positioner>
-      </Popover.Portal>
+      {popupContent ? (
+        <Popover.Portal>
+          <Popover.Positioner
+            align="start"
+            side="bottom"
+            sideOffset={4}
+            collisionAvoidance={{ side: 'none' }}
+          >
+            <Popover.Popup className={className} initialFocus={false}>
+              <Popover.Arrow className="vocs:data-[side=bottom]:top-[-8px] vocs:data-[side=left]:right-[-13px] vocs:data-[side=left]:rotate-90 vocs:data-[side=right]:left-[-13px] vocs:data-[side=right]:-rotate-90 vocs:data-[side=top]:bottom-[-8px] vocs:data-[side=top]:rotate-180">
+                <ArrowSvg />
+              </Popover.Arrow>
+              {popupContent}
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover.Portal>
+      ) : null}
     </Popover.Root>
   )
 }
@@ -41,6 +51,8 @@ export namespace TwoslashHover {
   export type Props = {
     className?: string | undefined
     children: React.ReactNode
+    codeHtml?: string | undefined
+    docsHtml?: string | undefined
     open?: boolean | undefined
     trigger: React.ReactNode
   }

--- a/src/react/internal/TwoslashHover.tsx
+++ b/src/react/internal/TwoslashHover.tsx
@@ -3,17 +3,36 @@ import * as React from 'react'
 import { TwoslashHover as TwoslashHover_client } from './TwoslashHover.client.js'
 
 export function TwoslashHover(props: TwoslashHover.Props) {
-  const { className = '', children } = props
+  const {
+    className = '',
+    children,
+    'data-v-twoslash-code-html': codeHtml,
+    'data-v-twoslash-docs-html': docsHtml,
+  } = props
   const [trigger, ...content] = React.Children.toArray(children)
   const open = className?.includes('twoslash-query-persisted')
-  if (!content) return null
+  if (!trigger) return null
+
+  const popupChildren = codeHtml || docsHtml ? undefined : content
+
   return (
-    <TwoslashHover_client className={className} open={open} trigger={trigger}>
-      {content}
+    <TwoslashHover_client
+      className={className}
+      codeHtml={codeHtml}
+      docsHtml={docsHtml}
+      open={open}
+      trigger={trigger}
+    >
+      {popupChildren}
     </TwoslashHover_client>
   )
 }
 
 export declare namespace TwoslashHover {
-  export type Props = React.PropsWithChildren<React.ComponentProps<'span'>>
+  export type Props = React.PropsWithChildren<
+    React.ComponentProps<'span'> & {
+      'data-v-twoslash-code-html'?: string | undefined
+      'data-v-twoslash-docs-html'?: string | undefined
+    }
+  >
 }

--- a/src/waku/internal/middleware/md-router.test.ts
+++ b/src/waku/internal/middleware/md-router.test.ts
@@ -25,6 +25,7 @@ function restoreNodeEnv() {
 
 afterEach(() => {
   restoreNodeEnv()
+  vi.clearAllMocks()
   vi.restoreAllMocks()
   vi.resetModules()
   globalThis.fetch = originalFetch
@@ -86,7 +87,7 @@ describe('middleware', () => {
     return import('./md-router.js').then(({ middleware }) => {
       app.use('*', middleware())
       app.get('*', (c) => c.html('<p>ok</p>'))
-      return app.request(url, { headers })
+      return app.request(url, headers ? { headers } : undefined)
     })
   }
 

--- a/twoslash-rust/src/project.rs
+++ b/twoslash-rust/src/project.rs
@@ -159,7 +159,10 @@ impl Project {
     }
 
     /// Like `scaffold`, but injects user code immediately.
-    pub fn scaffold_with_code<'a>(settings: ProjectSettings<'_>, source: &'a str) -> Result<Project> {
+    pub fn scaffold_with_code<'a>(
+        settings: ProjectSettings<'_>,
+        source: &'a str,
+    ) -> Result<Project> {
         let parse_result = find_queries(source);
         let source = parse_result.code;
         let queries = parse_result.queries;


### PR DESCRIPTION
## Motivation

Reduce Twoslash hover payload size by storing popup content as serialized HTML props instead of nested MDX children.

`next` already avoids rendering closed Twoslash popup DOM on initial SSR and initial client mount, but the renderer still emits the full popup subtree as nested MDX/HAST children. That leaves extra payload and React work even when the popup is closed.
