### PR TITLE
fix(mdx): preserve configured code fence languages

### DIFF
--- a/src/internal/mdx.test.ts
+++ b/src/internal/mdx.test.ts
@@ -1,0 +1,44 @@
+import ruby from 'shiki/langs/ruby.mjs'
+import { describe, expect, it } from 'vitest'
+import * as Config from './config.js'
+import { getCompileOptions, remarkCodeTitle } from './mdx.js'
+
+describe('getCompileOptions', () => {
+  it('preserves configured custom language fences', () => {
+    const config = Config.define({
+      codeHighlight: { langs: ruby },
+      rootDir: process.cwd(),
+    })
+
+    const { remarkPlugins } = getCompileOptions('react', config)
+    const codeTitlePlugin = remarkPlugins.find(
+      (plugin): plugin is [typeof remarkCodeTitle, remarkCodeTitle.Options] =>
+        Array.isArray(plugin) && plugin[0] === remarkCodeTitle,
+    )
+
+    expect(codeTitlePlugin).toBeDefined()
+    if (!codeTitlePlugin) throw new Error('remarkCodeTitle plugin not found')
+
+    expect(codeTitlePlugin[1].additionalLanguages).toEqual(expect.arrayContaining(['rb', 'ruby']))
+
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'code',
+          lang: 'ruby',
+          meta: '[server.rb]',
+          value: 'require "mpp"',
+        },
+      ],
+    }
+
+    remarkCodeTitle(codeTitlePlugin[1])(tree as never)
+
+    const codeNode = tree.children[0]
+    if (!codeNode) throw new Error('code node missing')
+
+    expect(codeNode.lang).toBe('ruby')
+    expect(codeNode.meta).toBe('[server.rb]')
+  })
+})

--- a/src/internal/mdx.test.ts
+++ b/src/internal/mdx.test.ts
@@ -1,7 +1,53 @@
 import ruby from 'shiki/langs/ruby.mjs'
 import { describe, expect, it } from 'vitest'
 import * as Config from './config.js'
-import { getCompileOptions, remarkCodeTitle } from './mdx.js'
+import { getCompileOptions, remarkCodeTitle, remarkLangCommaAttrs } from './mdx.js'
+
+type CodeNode = {
+  type: 'code'
+  lang?: string | undefined
+  meta?: string | undefined
+  value: string
+}
+
+type Root = {
+  type: 'root'
+  children: [CodeNode]
+}
+
+type TransformCodeNodeOptions = {
+  applyCommaAttrs?: boolean | undefined
+}
+
+function getCodeTitlePlugin(config: Config.Config) {
+  const { remarkPlugins } = getCompileOptions('react', config)
+  const codeTitlePlugin = remarkPlugins.find(
+    (plugin): plugin is [typeof remarkCodeTitle, remarkCodeTitle.Options] =>
+      Array.isArray(plugin) && plugin[0] === remarkCodeTitle,
+  )
+
+  expect(codeTitlePlugin).toBeDefined()
+  if (!codeTitlePlugin) throw new Error('remarkCodeTitle plugin not found')
+
+  return codeTitlePlugin[1]
+}
+
+function transformCodeNode(
+  config: Config.Config,
+  codeNode: Omit<CodeNode, 'type'>,
+  options: TransformCodeNodeOptions = {},
+) {
+  const tree: Root = {
+    type: 'root',
+    children: [{ type: 'code', ...codeNode }],
+  }
+
+  if (options.applyCommaAttrs) remarkLangCommaAttrs()(tree as never)
+
+  remarkCodeTitle(getCodeTitlePlugin(config))(tree as never)
+
+  return tree.children[0]
+}
 
 describe('getCompileOptions', () => {
   it('preserves configured custom language fences', () => {
@@ -10,35 +56,76 @@ describe('getCompileOptions', () => {
       rootDir: process.cwd(),
     })
 
-    const { remarkPlugins } = getCompileOptions('react', config)
-    const codeTitlePlugin = remarkPlugins.find(
-      (plugin): plugin is [typeof remarkCodeTitle, remarkCodeTitle.Options] =>
-        Array.isArray(plugin) && plugin[0] === remarkCodeTitle,
-    )
+    const codeTitleOptions = getCodeTitlePlugin(config)
 
-    expect(codeTitlePlugin).toBeDefined()
-    if (!codeTitlePlugin) throw new Error('remarkCodeTitle plugin not found')
+    expect(codeTitleOptions.additionalLanguages).toEqual(expect.arrayContaining(['rb', 'ruby']))
 
-    expect(codeTitlePlugin[1].additionalLanguages).toEqual(expect.arrayContaining(['rb', 'ruby']))
-
-    const tree = {
-      type: 'root',
-      children: [
-        {
-          type: 'code',
-          lang: 'ruby',
-          meta: '[server.rb]',
-          value: 'require "mpp"',
-        },
-      ],
-    }
-
-    remarkCodeTitle(codeTitlePlugin[1])(tree as never)
-
-    const codeNode = tree.children[0]
-    if (!codeNode) throw new Error('code node missing')
+    const codeNode = transformCodeNode(config, {
+      lang: 'ruby',
+      meta: '[server.rb]',
+      value: 'require "mpp"',
+    })
 
     expect(codeNode.lang).toBe('ruby')
     expect(codeNode.meta).toBe('[server.rb]')
+  })
+
+  it('preserves custom language aliases', () => {
+    const config = Config.define({
+      codeHighlight: { langs: ruby },
+      rootDir: process.cwd(),
+    })
+
+    const codeNode = transformCodeNode(config, {
+      lang: 'rb',
+      meta: '[client.rb]',
+      value: 'require "mpp"',
+    })
+
+    expect(codeNode.lang).toBe('rb')
+    expect(codeNode.meta).toBe('[client.rb]')
+  })
+
+  it('preserves built-in aliases with comma attrs', () => {
+    const config = Config.define({ rootDir: process.cwd() })
+
+    const codeNode = transformCodeNode(
+      config,
+      {
+        lang: 'rs,no_run',
+        meta: '[main.rs]',
+        value: 'fn main() {}',
+      },
+      { applyCommaAttrs: true },
+    )
+
+    expect(codeNode.lang).toBe('rs')
+    expect(codeNode.meta).toBe('[main.rs] no_run')
+  })
+
+  it('falls back unknown titled fences to plaintext', () => {
+    const config = Config.define({ rootDir: process.cwd() })
+
+    const codeNode = transformCodeNode(config, {
+      lang: 'foobarlang',
+      meta: '[sample.foo]',
+      value: 'hello world',
+    })
+
+    expect(codeNode.lang).toBe('plaintext')
+    expect(codeNode.meta).toBe('foobarlang')
+  })
+
+  it('keeps built-in titled fences unchanged', () => {
+    const config = Config.define({ rootDir: process.cwd() })
+
+    const codeNode = transformCodeNode(config, {
+      lang: 'ts',
+      meta: '[example.ts]',
+      value: 'export const x = 1',
+    })
+
+    expect(codeNode.lang).toBe('ts')
+    expect(codeNode.meta).toBe('[example.ts]')
   })
 })

--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -68,6 +68,24 @@ const validLanguageNames = new Set([
   ),
 ])
 
+function getLanguageNames(langs: readonly unknown[] | undefined): string[] {
+  if (!langs) return []
+
+  return langs.flatMap((lang) => {
+    if (Array.isArray(lang)) return getLanguageNames(lang)
+    if (typeof lang === 'string') return [lang]
+    if (!lang || typeof lang !== 'object') return []
+    if ('default' in lang) {
+      const defaultLangs = lang.default
+      return getLanguageNames(Array.isArray(defaultLangs) ? defaultLangs : [defaultLangs])
+    }
+    if (!('name' in lang)) return []
+
+    const { aliases, name } = lang as LanguageRegistration
+    return name ? [name, ...(aliases ?? [])] : (aliases ?? [])
+  })
+}
+
 /**
  * Remark plugin that transforms mermaid code blocks into Mermaid components.
  * Replaces ```mermaid code blocks with a paragraph that has hName/hProperties
@@ -132,6 +150,10 @@ export function getCompileOptions(
             : [],
         )
       : []
+  const codeHighlightLanguageNames = getLanguageNames(codeHighlight.langs)
+  const additionalLanguageNames = Array.from(
+    new Set([...twoslashTransformerLangs, ...codeHighlightLanguageNames]),
+  )
 
   const { recmaPlugins, rehypePlugins, remarkPlugins } = (() => {
     if (type === 'txt')
@@ -210,7 +232,7 @@ export function getCompileOptions(
           remarkChangelog,
           remarkCodeGroup,
           remarkLangCommaAttrs,
-          [remarkCodeTitle, { additionalLanguages: twoslashTransformerLangs }] as Pluggable,
+          [remarkCodeTitle, { additionalLanguages: additionalLanguageNames }] as Pluggable,
           remarkDefaultFrontmatter,
           remarkDetails,
           remarkDirective,


### PR DESCRIPTION
## Summary
- preserve custom Shiki languages when deriving valid code fence languages for `remarkCodeTitle`
- avoid downgrading titled fences like ```ruby [client.rb] to `plaintext` before Shiki runs
- add a regression test covering configured Ruby fences

## Testing
- `pnpm test src/internal/mdx.test.ts`
- `pnpm exec biome check src/internal/mdx.ts src/internal/mdx.test.ts`

## Notes
- `pnpm check:types` currently fails on `next` in `site/` with unresolved `viem` and `process` references, unrelated to this patch