### PR TITLE
fix(changelog): de-dup leading H1 and prevent version badge overflow

### DIFF
--- a/src/react/internal/Changelog.client.tsx
+++ b/src/react/internal/Changelog.client.tsx
@@ -284,10 +284,10 @@ function Release(props: Release.Props): React.JSX.Element {
             href={release.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="vocs:inline-flex vocs:items-center vocs:gap-1.5 vocs:text-sm vocs:font-mono vocs:font-medium vocs:text-heading vocs:bg-surfaceTint vocs:border vocs:border-primary vocs:px-2.5 vocs:py-1 vocs:rounded-md vocs:w-fit vocs:hover:bg-surfaceTint/80 vocs:transition-colors"
+            className="vocs:inline-flex vocs:flex-wrap vocs:items-center vocs:gap-1.5 vocs:text-sm vocs:font-mono vocs:font-medium vocs:text-heading vocs:bg-surfaceTint vocs:border vocs:border-primary vocs:px-2.5 vocs:py-1 vocs:rounded-md vocs:w-fit vocs:max-w-full vocs:hover:bg-surfaceTint/80 vocs:transition-colors"
           >
-            {release.version}
-            <LucideExternalLink className="vocs:size-3 vocs:opacity-60" />
+            <span className="vocs:break-all vocs:min-w-0">{release.version}</span>
+            <LucideExternalLink className="vocs:size-3 vocs:opacity-60 vocs:shrink-0" />
           </a>
 
           {/* Date */}
@@ -317,10 +317,10 @@ function Release(props: Release.Props): React.JSX.Element {
             href={release.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="vocs:inline-flex vocs:items-center vocs:gap-1.5 vocs:text-sm vocs:font-mono vocs:font-medium vocs:text-heading vocs:bg-surfaceTint vocs:border vocs:border-primary vocs:px-2.5 vocs:py-1 vocs:rounded-md vocs:hover:bg-surfaceTint/80 vocs:transition-colors"
+            className="vocs:inline-flex vocs:flex-wrap vocs:items-center vocs:gap-1.5 vocs:text-sm vocs:font-mono vocs:font-medium vocs:text-heading vocs:bg-surfaceTint vocs:border vocs:border-primary vocs:px-2.5 vocs:py-1 vocs:rounded-md vocs:max-w-full vocs:hover:bg-surfaceTint/80 vocs:transition-colors"
           >
-            {release.version}
-            <LucideExternalLink className="vocs:size-3 vocs:opacity-60" />
+            <span className="vocs:break-all vocs:min-w-0">{release.version}</span>
+            <LucideExternalLink className="vocs:size-3 vocs:opacity-60 vocs:shrink-0" />
           </a>
           <time dateTime={release.date} className="vocs:text-sm vocs:text-secondary">
             {formattedDate}

--- a/src/server/changelog.ts
+++ b/src/server/changelog.ts
@@ -31,10 +31,42 @@ export async function fetchChangelog(
     prereleases: options.prereleases ?? false,
   })
 
-  return releases.map((release) => ({
-    ...release,
-    bodyHtml: Markdown.toHtml(release.body),
-  }))
+  return releases.map((release) => {
+    const body = stripDuplicateTitle(release.body, release.title)
+    return {
+      ...release,
+      body,
+      bodyHtml: Markdown.toHtml(body),
+    }
+  })
+}
+
+/**
+ * Strips a leading H1 from the release body when it duplicates the release title.
+ *
+ * GitHub renders the release name as the heading on the release page, so
+ * authors often write a body that *also* begins with `# <title>`. When such a
+ * release is shown in our changelog UI we already render the title above the
+ * body, which produces a visible duplicate (see e.g. release authors writing
+ * `# Release v1.6.0 — T3 …` while the GitHub release name is
+ * `Release v1.6.0 - T3 …`). We compare the leading H1 text against the title
+ * with loose normalization (lowercase, whitespace collapsing, all unicode
+ * dashes treated as the same character) and strip it on match.
+ */
+function stripDuplicateTitle(body: string, title: string): string {
+  if (!body || !title) return body
+  const match = body.match(/^\s*#\s+(.+?)\s*(?:\r?\n|$)/)
+  if (!match) return body
+  if (normalizeTitle(match[1] ?? '') !== normalizeTitle(title)) return body
+  return body.slice(match[0].length).replace(/^\s+/, '')
+}
+
+function normalizeTitle(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[-\u2010-\u2015\u2212]/g, '-')
+    .replace(/\s+/g, ' ')
+    .trim()
 }
 
 export declare namespace fetchChangelog {


### PR DESCRIPTION
Two small fixes for the new `Changelog` component on the `next` branch.

**1. Duplicate title.** When a GitHub release body starts with `# <title>` (a common pattern, since GitHub renders the release name as a heading on the release page), the changelog renders the title twice — once as the `<h2>` next to the version badge, and once from the body's leading H1. We now strip the leading markdown H1 from the body if it matches `release.title` after loose normalization (lowercase, whitespace collapsed, all unicode dashes treated as the same character — so `Release v1.6.0 - T3 …` matches `Release v1.6.0 — T3 …`).

**2. Version badge overflow.** The left column is fixed at `w-36` (144px) while the badge is `inline-flex w-fit` with no wrapping rules, so long package-scoped versions like `tempo-primitives@1.6.0` overflow the column. The badge now allows wrapping (`flex-wrap`, `max-w-full`, `break-all` on the version text) and the external-link icon stays `shrink-0`. Same fix applied to the mobile header for consistency.

Spotted on https://docs.tempo.xyz/changelog (which pins `pkg.pr.new/wevm/vocs@2fb25c2`).