### PR TITLE
fix: align callout text children

### DIFF
--- a/.changeset/fix-callout-component-styles.md
+++ b/.changeset/fix-callout-component-styles.md
@@ -2,4 +2,4 @@
 "vocs": patch
 ---
 
-Fixed `Callout` component styles when rendered directly from MDX.
+Fixed `Callout` component alignment when rendered with plain JSX text children.

--- a/src/react/Callout.tsx
+++ b/src/react/Callout.tsx
@@ -4,7 +4,16 @@ import LucideLightbulb from '~icons/lucide/lightbulb'
 import LucideTriangleAlert from '~icons/lucide/triangle-alert'
 
 export function Callout(props: Callout.Props) {
-  const { variant, ...rest } = props
+  const { children, variant, ...rest } = props
+  const content =
+    typeof children === 'string' || typeof children === 'number' ? (
+      <div data-v-callout-content data-v-content>
+        {children}
+      </div>
+    ) : (
+      children
+    )
+
   return (
     <aside {...rest} data-v data-v-callout data-v-content data-v-context={variant}>
       <div data-v-callout-icon>
@@ -15,7 +24,7 @@ export function Callout(props: Callout.Props) {
         {props.variant === 'tip' ? <LucideLightbulb /> : null}
         {props.variant === 'success' ? <LucideCircleCheck /> : null}
       </div>
-      {props.children}
+      {content}
     </aside>
   )
 }


### PR DESCRIPTION
Wraps primitive `Callout` children in a content element so JSX text receives the same left offset as regular element children.

This fixes the component reference preview while leaving markdown callouts and code-containing callouts on their existing structure.
