### PR TITLE
fix: use local `zile` in prerelease workflow

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           pnpm build
           pnpm build:npm
-          pnpm dlx zile publish:prepare
+          pnpm exec zile publish:prepare
         env:
           ARTIFACTS_DIR: artifacts
 


### PR DESCRIPTION
Switches the twoslash prerelease package prep from `pnpm dlx zile publish:prepare` to the workspace-installed `zile` binary.

The failing job was pulling `zile@0.0.29` into an isolated dlx environment where `typescript` was unavailable. The repo already installs the pinned `zile` and `typescript`, so the workflow now uses that local toolchain.
