### PR TITLE
fix: sync theme toggle with color tokens

### DIFF
--- a/.changeset/theme-toggle-light-dark.md
+++ b/.changeset/theme-toggle-light-dark.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed theme toggles so explicit light and dark selections overrode compiled `light-dark()` theme tokens instead of continuing to follow the system preference.

--- a/src/react/Head.tsx
+++ b/src/react/Head.tsx
@@ -46,7 +46,7 @@ export function Head() {
         <script
           // biome-ignore lint/security/noDangerouslySetInnerHtml: blocking script to prevent FOUC
           dangerouslySetInnerHTML={{
-            __html: `(function(){try{var t=localStorage.getItem('vocs-theme');if(t==='light'||t==='dark'){document.documentElement.style.colorScheme=t}else if(window.matchMedia('(prefers-color-scheme:dark)').matches){document.documentElement.style.colorScheme='dark'}else if(window.matchMedia('(prefers-color-scheme:light)').matches){document.documentElement.style.colorScheme='light'}else{document.documentElement.style.colorScheme='dark'}}catch(e){}})()`,
+            __html: `(function(){try{var e=document.documentElement;var s=function(t){e.setAttribute('data-vocs-theme',t);e.style.colorScheme=t};var t=localStorage.getItem('vocs-theme');if(t==='light'||t==='dark'){s(t)}else if(window.matchMedia('(prefers-color-scheme:dark)').matches){s('dark')}else if(window.matchMedia('(prefers-color-scheme:light)').matches){s('light')}else{s('dark')}}catch(e){}})()`,
           }}
         />
       )}

--- a/src/react/Root.client.tsx
+++ b/src/react/Root.client.tsx
@@ -24,13 +24,15 @@ const disableTransitionsCSS =
 
 function applyTheme(theme: 'light' | 'dark' | 'system') {
   const resolved = theme === 'system' ? getSystemTheme() : theme
+  const html = document.documentElement
 
   // Disable transitions to prevent flash
   const style = document.createElement('style')
   style.appendChild(document.createTextNode(disableTransitionsCSS))
   document.head.appendChild(style)
 
-  document.documentElement.style.colorScheme = resolved
+  html.setAttribute('data-vocs-theme', resolved)
+  html.style.colorScheme = resolved
 
   // Force reflow and re-enable transitions
   ;(() => window.getComputedStyle(document.body))()
@@ -50,8 +52,10 @@ export function Root_client({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     const html = document.documentElement
 
-    if (staticScheme) html.style.colorScheme = colorScheme
-    else applyTheme(getStoredTheme())
+    if (staticScheme) {
+      html.setAttribute('data-vocs-theme', colorScheme)
+      html.style.colorScheme = colorScheme
+    } else applyTheme(getStoredTheme())
 
     if (html) {
       if (!import.meta.env.PROD) html.style.setProperty('--vocs-color-accent', accentColor)

--- a/src/react/Root.tsx
+++ b/src/react/Root.tsx
@@ -11,6 +11,9 @@ export async function Root({ children }: { children: React.ReactNode }) {
   return (
     <html
       data-vocs
+      {...(colorScheme === 'light' || colorScheme === 'dark'
+        ? { 'data-vocs-theme': colorScheme }
+        : {})}
       lang="en"
       style={{ colorScheme, '--vocs-color-accent': accentColor } as never}
       suppressHydrationWarning

--- a/src/react/internal/ThemeToggle.client.tsx
+++ b/src/react/internal/ThemeToggle.client.tsx
@@ -29,13 +29,15 @@ const disableTransitionsCSS =
 
 function applyTheme(theme: Theme) {
   const resolved = theme === 'system' ? getSystemTheme() : theme
+  const html = document.documentElement
 
   // Disable transitions to prevent flash
   const style = document.createElement('style')
   style.appendChild(document.createTextNode(disableTransitionsCSS))
   document.head.appendChild(style)
 
-  document.documentElement.style.colorScheme = resolved
+  html.setAttribute('data-vocs-theme', resolved)
+  html.style.colorScheme = resolved
 
   // Force reflow and re-enable transitions
   ;(() => window.getComputedStyle(document.body))()

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -31,6 +31,19 @@
     -moz-osx-font-smoothing: grayscale;
   }
 
+  /* Keep Lightning CSS light-dark() output aligned with Vocs' theme toggle. */
+  :root[data-vocs-theme="light"] {
+    --lightningcss-light: initial;
+    --lightningcss-dark: ;
+    color-scheme: light;
+  }
+
+  :root[data-vocs-theme="dark"] {
+    --lightningcss-light: ;
+    --lightningcss-dark: initial;
+    color-scheme: dark;
+  }
+
   html {
     scroll-padding-top: calc(var(--vocs-spacing-topNav) + var(--vocs-spacing-banner) + 1rem);
   }


### PR DESCRIPTION
Fixes theme switching for production builds where compiled `light-dark()` theme tokens continued following the system preference after the Vocs theme toggle changed `color-scheme`.

The active resolved theme is now written to `data-vocs-theme`, and the generated light/dark token switches are overridden from that attribute. This keeps the initial head script, root client, static color schemes, and theme toggle in sync.
