### PR TITLE
fix: improve mdx dev hmr

### DIFF
--- a/.changeset/mdx-hmr-typegen.md
+++ b/.changeset/mdx-hmr-typegen.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Improved MDX development hot updates to avoid delayed or stale page updates after edits.

--- a/src/internal/vite-plugins.ts
+++ b/src/internal/vite-plugins.ts
@@ -601,6 +601,9 @@ export function search(config: Config.Config): PluginOption {
   let server: ViteDevServer | undefined
   let mode: 'development' | 'production' = 'development'
   const fileIds = new Map<string, string[]>()
+  let indexUpdatePromise = Promise.resolve()
+  let indexUpdateTimer: ReturnType<typeof setTimeout> | undefined
+  const pendingIndexUpdateFiles = new Set<string>()
 
   async function buildIndex(): Promise<SearchIndex.SearchIndex> {
     logger.info('Building search index...', { timestamp: true })
@@ -629,6 +632,41 @@ export function search(config: Config.Config): PluginOption {
       type: 'update',
       updates: [{ acceptedPath: mod.url, path: mod.url, timestamp: Date.now(), type: 'js-update' }],
     })
+  }
+
+  function updateIndex(file: string): void {
+    indexUpdatePromise = indexUpdatePromise
+      .then(async () => {
+        const index = await indexPromise
+        if (!index) return
+
+        const previousIds = fileIds.get(file) ?? []
+        const newIds = SearchIndex.updateFile(index, file, {
+          pagesDir: pagesDirPath,
+          config,
+          previousIds,
+        })
+        fileIds.set(file, newIds)
+
+        invalidateModule()
+        logger.info(`Search index updated: ${path.relative(rootDir, file)}`, { timestamp: true })
+      })
+      .catch((error) => {
+        logger.error(
+          `Failed to update search index: ${error instanceof Error ? error.message : String(error)}`,
+        )
+      })
+  }
+
+  function scheduleIndexUpdate(file: string): void {
+    pendingIndexUpdateFiles.add(file)
+    if (indexUpdateTimer) clearTimeout(indexUpdateTimer)
+    indexUpdateTimer = setTimeout(() => {
+      indexUpdateTimer = undefined
+      const files = [...pendingIndexUpdateFiles]
+      pendingIndexUpdateFiles.clear()
+      for (const file of files) updateIndex(file)
+    }, 250)
   }
 
   return {
@@ -680,23 +718,11 @@ export function search(config: Config.Config): PluginOption {
       const outDir = options.dir ?? path.resolve(rootDir, config.outDir)
       indexHash = SearchIndex.saveToFile(index, path.resolve(outDir, 'assets'))
     },
-    async handleHotUpdate({ file }) {
+    handleHotUpdate({ file }) {
       if (!file.endsWith('.md') && !file.endsWith('.mdx')) return
       if (!file.startsWith(pagesDirPath)) return
 
-      const index = await indexPromise
-      if (!index) return
-
-      const previousIds = fileIds.get(file) ?? []
-      const newIds = SearchIndex.updateFile(index, file, {
-        pagesDir: pagesDirPath,
-        config,
-        previousIds,
-      })
-      fileIds.set(file, newIds)
-
-      invalidateModule()
-      logger.info(`Search index updated: ${path.relative(rootDir, file)}`, { timestamp: true })
+      scheduleIndexUpdate(file)
     },
   }
 }

--- a/src/waku/internal/patches/vite-plugins/fs-router-typegen.ts
+++ b/src/waku/internal/patches/vite-plugins/fs-router-typegen.ts
@@ -3,7 +3,7 @@
 // get automatic type generation with better DX.
 
 import { existsSync, readFileSync } from 'node:fs'
-import { readdir, writeFile } from 'node:fs/promises'
+import { readdir, readFile, writeFile } from 'node:fs/promises'
 import type { ParseResult, Plugin } from 'vite'
 import { parse, transformWithOxc } from 'vite'
 import { EXTENSIONS, SRC_PAGES, SRC_SERVER_ENTRY } from '../constants.js'
@@ -119,6 +119,16 @@ export const fsRouterTypegenPlugin = (opts: { srcDir: string }): Plugin => {
         if (!generation) {
           // skip failures
           return
+        }
+        // Skip writes when nothing about the route shape changed (e.g. when the
+        // user just edited the body of an MDX page). Rewriting the file would
+        // otherwise trigger a full page reload via the module graph and break
+        // HMR for in-place MDX edits.
+        try {
+          const current = await readFile(outputFile, 'utf-8')
+          if (current === generation) return
+        } catch {
+          // file doesn't exist yet; fall through to write
         }
         await writeFile(outputFile, generation, 'utf-8')
       }

--- a/src/waku/internal/vite-plugins.test.ts
+++ b/src/waku/internal/vite-plugins.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { patchClientRscPrefetchCode, patchRouterPrefetchCode } from './vite-plugins.js'
+import {
+  patchBrowserRscUpdateCode,
+  patchClientRscPrefetchCode,
+  patchRouterHmrRefetchCode,
+  patchRouterPrefetchCode,
+} from './vite-plugins.js'
 
 describe('patchRouterPrefetchCode', () => {
   it('maps route module ids through the global module id list', () => {
@@ -78,6 +83,64 @@ const fetchRscInternal = (fetchRscStore, rscPath, rscParams, prefetchOnly)=>{
 
   it('ignores other modules', () => {
     expect(patchClientRscPrefetchCode('', '/repo/node_modules/waku/dist/router/client.js')).toBe(
+      undefined,
+    )
+  })
+})
+
+describe('patchRouterHmrRefetchCode', () => {
+  it('bypasses prefetched and browser-cached RSC data during route HMR', () => {
+    const code = `
+const InnerRouter = ()=>{
+    if (import.meta.hot) {
+        const refetchRoute = ()=>{
+            staticPathSetRef.current.clear();
+            cachedIdSetRef.current.clear();
+            const rscPath = encodeRoutePath(route.path);
+            const rscParams = createRscParams(route.query);
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            refetch(rscPath, rscParams);
+        };
+    }
+}`
+
+    const patched = patchRouterHmrRefetchCode(code, '/repo/node_modules/waku/dist/router/client.js')
+
+    expect(patched).toContain("init.cache = 'no-store';")
+    expect(patched).toContain('delete globalThis.__WAKU_PREFETCHED__?.[rscPath];')
+    expect(patched).toContain('withEnhanceFetchFn(hmrRefetchEnhancer)')
+  })
+
+  it('ignores other modules', () => {
+    expect(
+      patchRouterHmrRefetchCode('', '/repo/node_modules/waku/dist/router/define-router.js'),
+    ).toBe(undefined)
+  })
+})
+
+describe('patchBrowserRscUpdateCode', () => {
+  it('prefers the router refetcher for RSC updates', () => {
+    const code = `
+if (import.meta.hot) {
+    import.meta.hot.on('rsc:update', (e)=>{
+        console.log('[rsc:update]', e);
+        globalThis.__WAKU_RSC_RELOAD_LISTENERS__?.forEach((l)=>l());
+    });
+}`
+
+    const patched = patchBrowserRscUpdateCode(
+      code,
+      '/repo/node_modules/waku/dist/lib/vite-entries/entry.browser.js',
+    )
+
+    expect(patched).toContain('import.meta.hot.accept();')
+    expect(patched).toContain('if (globalThis.__WAKU_REFETCH_ROUTE__)')
+    expect(patched).toContain('globalThis.__WAKU_REFETCH_ROUTE__();')
+    expect(patched).toContain('globalThis.__WAKU_RSC_RELOAD_LISTENERS__?.forEach((l)=>l());')
+  })
+
+  it('ignores other modules', () => {
+    expect(patchBrowserRscUpdateCode('', '/repo/node_modules/waku/dist/router/client.js')).toBe(
       undefined,
     )
   })

--- a/src/waku/internal/vite-plugins.test.ts
+++ b/src/waku/internal/vite-plugins.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest'
 import {
-  patchBrowserRscUpdateCode,
   patchClientRscPrefetchCode,
   patchRouterHmrRefetchCode,
   patchRouterPrefetchCode,
@@ -115,33 +114,5 @@ const InnerRouter = ()=>{
     expect(
       patchRouterHmrRefetchCode('', '/repo/node_modules/waku/dist/router/define-router.js'),
     ).toBe(undefined)
-  })
-})
-
-describe('patchBrowserRscUpdateCode', () => {
-  it('prefers the router refetcher for RSC updates', () => {
-    const code = `
-if (import.meta.hot) {
-    import.meta.hot.on('rsc:update', (e)=>{
-        console.log('[rsc:update]', e);
-        globalThis.__WAKU_RSC_RELOAD_LISTENERS__?.forEach((l)=>l());
-    });
-}`
-
-    const patched = patchBrowserRscUpdateCode(
-      code,
-      '/repo/node_modules/waku/dist/lib/vite-entries/entry.browser.js',
-    )
-
-    expect(patched).toContain('import.meta.hot.accept();')
-    expect(patched).toContain('if (globalThis.__WAKU_REFETCH_ROUTE__)')
-    expect(patched).toContain('globalThis.__WAKU_REFETCH_ROUTE__();')
-    expect(patched).toContain('globalThis.__WAKU_RSC_RELOAD_LISTENERS__?.forEach((l)=>l());')
-  })
-
-  it('ignores other modules', () => {
-    expect(patchBrowserRscUpdateCode('', '/repo/node_modules/waku/dist/router/client.js')).toBe(
-      undefined,
-    )
   })
 })

--- a/src/waku/internal/vite-plugins.ts
+++ b/src/waku/internal/vite-plugins.ts
@@ -99,11 +99,36 @@ await import('./serve-node.js');
 }
 
 const wakuDefineRouterRegex = /[/\\]waku[/\\]dist[/\\]router[/\\]define-router\.js(?:\?.*)?$/
+const wakuRouterClientRegex = /[/\\]waku[/\\]dist[/\\]router[/\\]client\.js(?:\?.*)?$/
 const wakuMinimalClientRegex = /[/\\]waku[/\\]dist[/\\]minimal[/\\]client\.js(?:\?.*)?$/
+const wakuBrowserEntryRegex =
+  /[/\\]waku[/\\]dist[/\\]lib[/\\]vite-entries[/\\]entry\.browser\.js(?:\?.*)?$/
 
 // TODO: Remove these Waku prefetch patches once https://github.com/wakujs/waku/issues/2099 is fixed.
 const wakuRouterPrefetchCodeRegex =
   /Object\.entries\(path2moduleIds\)\.forEach\(\(\[path,\s*ids\]\)=>\{\s*path2idxs\[path\]\s*=\s*ids\.map\(\(id\)=>ids\.indexOf\(id\)\);\s*\}\);/
+
+const wakuRouterHmrRefetchCode = `        const refetchRoute = ()=>{
+            staticPathSetRef.current.clear();
+            cachedIdSetRef.current.clear();
+            const rscPath = encodeRoutePath(route.path);
+            const rscParams = createRscParams(route.query);
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            refetch(rscPath, rscParams);
+        };`
+const wakuRouterHmrRefetchPatchedCode = `        const refetchRoute = ()=>{
+            staticPathSetRef.current.clear();
+            cachedIdSetRef.current.clear();
+            const rscPath = encodeRoutePath(route.path);
+            const rscParams = createRscParams(route.query);
+            const hmrRefetchEnhancer = (fetchFn)=>(input, init = {})=>{
+                init.cache = 'no-store';
+                return fetchFn(input, init);
+            };
+            delete globalThis.__WAKU_PREFETCHED__?.[rscPath];
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            refetch(rscPath, rscParams, (store)=>withEnhanceFetchFn(hmrRefetchEnhancer)(store));
+        };`
 
 const wakuClientPrefetchKeysCode = `const KEY_RESPONSE = 'r';
 const KEY_CLOSE = 'x';`
@@ -144,6 +169,18 @@ const wakuClientPrefetchElementsPatchedCode = `    const createElements = ()=>cr
     }
     const elements = prefetchedEntry?.[KEY_ELEMENTS] || createElements();`
 
+const wakuBrowserRscUpdateCode = 'globalThis.__WAKU_RSC_RELOAD_LISTENERS__?.forEach((l)=>l());'
+const wakuBrowserRscUpdatePatchedCode = `if (globalThis.__WAKU_REFETCH_ROUTE__) {
+            globalThis.__WAKU_REFETCH_ROUTE__();
+        } else {
+            globalThis.__WAKU_RSC_RELOAD_LISTENERS__?.forEach((l)=>l());
+        }`
+const wakuBrowserHotStartCode = `if (import.meta.hot) {
+    import.meta.hot.on('rsc:update'`
+const wakuBrowserHotStartPatchedCode = `if (import.meta.hot) {
+    import.meta.hot.accept();
+    import.meta.hot.on('rsc:update'`
+
 export function patchRouterPrefetchCode(code: string, id: string) {
   if (!wakuDefineRouterRegex.test(id)) return
   const patched = code.replace(
@@ -152,6 +189,13 @@ export function patchRouterPrefetchCode(code: string, id: string) {
         path2idxs[path] = pathIds.map((id)=>ids.indexOf(id));
     });`,
   )
+  if (patched === code) return
+  return patched
+}
+
+export function patchRouterHmrRefetchCode(code: string, id: string) {
+  if (!wakuRouterClientRegex.test(id)) return
+  const patched = code.replace(wakuRouterHmrRefetchCode, wakuRouterHmrRefetchPatchedCode)
   if (patched === code) return
   return patched
 }
@@ -166,8 +210,22 @@ export function patchClientRscPrefetchCode(code: string, id: string) {
   return patched
 }
 
+export function patchBrowserRscUpdateCode(code: string, id: string) {
+  if (!wakuBrowserEntryRegex.test(id)) return
+  const patched = code
+    .replace(wakuBrowserHotStartCode, wakuBrowserHotStartPatchedCode)
+    .replace(wakuBrowserRscUpdateCode, wakuBrowserRscUpdatePatchedCode)
+  if (patched === code) return
+  return patched
+}
+
 export function patchWakuPrefetchCode(code: string, id: string) {
-  return patchRouterPrefetchCode(code, id) ?? patchClientRscPrefetchCode(code, id)
+  return (
+    patchRouterPrefetchCode(code, id) ??
+    patchRouterHmrRefetchCode(code, id) ??
+    patchClientRscPrefetchCode(code, id) ??
+    patchBrowserRscUpdateCode(code, id)
+  )
 }
 
 export function patchRouterPrefetch(): Plugin {
@@ -178,6 +236,48 @@ export function patchRouterPrefetch(): Plugin {
       const patched = patchWakuPrefetchCode(code, id)
       if (!patched) return null
       return { code: patched, map: null }
+    },
+  }
+}
+
+export function mdxHmr(): Plugin {
+  const virtualModuleId = 'virtual:vocs/mdx-hmr'
+  const resolvedVirtualModuleId = `\0${virtualModuleId}`
+  let version = 0
+
+  return {
+    name: 'vocs:mdx-hmr',
+    apply: 'serve',
+    async hotUpdate({ file }) {
+      if (!file.endsWith('.md') && !file.endsWith('.mdx')) return
+      if (this.environment.name !== 'client') return
+      version++
+      const mod =
+        this.environment.moduleGraph.getModuleById(resolvedVirtualModuleId) ??
+        (await this.environment.moduleGraph.getModuleByUrl(`/@id/__x00__${virtualModuleId}`))
+      if (!mod) return
+      return [mod]
+    },
+    resolveId(id) {
+      if (id === virtualModuleId) return resolvedVirtualModuleId
+      return
+    },
+    load(id) {
+      if (id !== resolvedVirtualModuleId) return
+      return `\
+const version = ${version};
+
+if (import.meta.hot) {
+  const previousVersion = import.meta.hot.data.version;
+  import.meta.hot.data.version = version;
+  import.meta.hot.accept();
+
+  if (previousVersion !== undefined && previousVersion !== version) {
+    const refetchRoute = globalThis.__WAKU_REFETCH_ROUTE__;
+    if (refetchRoute) refetchRoute();
+  }
+}
+`
     },
   }
 }
@@ -245,6 +345,7 @@ export default adapter(
 import { StrictMode, createElement } from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 import { Router } from 'waku/router/client';
+import 'virtual:vocs/mdx-hmr';
 
 const rootElement = createElement(StrictMode, null, createElement(Router));
 

--- a/src/waku/internal/vite-plugins.ts
+++ b/src/waku/internal/vite-plugins.ts
@@ -101,8 +101,6 @@ await import('./serve-node.js');
 const wakuDefineRouterRegex = /[/\\]waku[/\\]dist[/\\]router[/\\]define-router\.js(?:\?.*)?$/
 const wakuRouterClientRegex = /[/\\]waku[/\\]dist[/\\]router[/\\]client\.js(?:\?.*)?$/
 const wakuMinimalClientRegex = /[/\\]waku[/\\]dist[/\\]minimal[/\\]client\.js(?:\?.*)?$/
-const wakuBrowserEntryRegex =
-  /[/\\]waku[/\\]dist[/\\]lib[/\\]vite-entries[/\\]entry\.browser\.js(?:\?.*)?$/
 
 // TODO: Remove these Waku prefetch patches once https://github.com/wakujs/waku/issues/2099 is fixed.
 const wakuRouterPrefetchCodeRegex =
@@ -169,18 +167,6 @@ const wakuClientPrefetchElementsPatchedCode = `    const createElements = ()=>cr
     }
     const elements = prefetchedEntry?.[KEY_ELEMENTS] || createElements();`
 
-const wakuBrowserRscUpdateCode = 'globalThis.__WAKU_RSC_RELOAD_LISTENERS__?.forEach((l)=>l());'
-const wakuBrowserRscUpdatePatchedCode = `if (globalThis.__WAKU_REFETCH_ROUTE__) {
-            globalThis.__WAKU_REFETCH_ROUTE__();
-        } else {
-            globalThis.__WAKU_RSC_RELOAD_LISTENERS__?.forEach((l)=>l());
-        }`
-const wakuBrowserHotStartCode = `if (import.meta.hot) {
-    import.meta.hot.on('rsc:update'`
-const wakuBrowserHotStartPatchedCode = `if (import.meta.hot) {
-    import.meta.hot.accept();
-    import.meta.hot.on('rsc:update'`
-
 export function patchRouterPrefetchCode(code: string, id: string) {
   if (!wakuDefineRouterRegex.test(id)) return
   const patched = code.replace(
@@ -210,21 +196,11 @@ export function patchClientRscPrefetchCode(code: string, id: string) {
   return patched
 }
 
-export function patchBrowserRscUpdateCode(code: string, id: string) {
-  if (!wakuBrowserEntryRegex.test(id)) return
-  const patched = code
-    .replace(wakuBrowserHotStartCode, wakuBrowserHotStartPatchedCode)
-    .replace(wakuBrowserRscUpdateCode, wakuBrowserRscUpdatePatchedCode)
-  if (patched === code) return
-  return patched
-}
-
 export function patchWakuPrefetchCode(code: string, id: string) {
   return (
     patchRouterPrefetchCode(code, id) ??
     patchRouterHmrRefetchCode(code, id) ??
-    patchClientRscPrefetchCode(code, id) ??
-    patchBrowserRscUpdateCode(code, id)
+    patchClientRscPrefetchCode(code, id)
   )
 }
 

--- a/src/waku/internal/vite-plugins.ts
+++ b/src/waku/internal/vite-plugins.ts
@@ -220,10 +220,13 @@ export function mdxHmr(): Plugin {
   const virtualModuleId = 'virtual:vocs/mdx-hmr'
   const resolvedVirtualModuleId = `\0${virtualModuleId}`
   let version = 0
+  let isBuild = false
 
   return {
     name: 'vocs:mdx-hmr',
-    apply: 'serve',
+    configResolved(config) {
+      isBuild = config.command === 'build'
+    },
     async hotUpdate({ file }) {
       if (!file.endsWith('.md') && !file.endsWith('.mdx')) return
       if (this.environment.name !== 'client') return
@@ -240,6 +243,7 @@ export function mdxHmr(): Plugin {
     },
     load(id) {
       if (id !== resolvedVirtualModuleId) return
+      if (isBuild) return ''
       return `\
 const version = ${version};
 

--- a/src/waku/vite.ts
+++ b/src/waku/vite.ts
@@ -41,6 +41,7 @@ export async function vocs(options: vocs.Options = {}): Promise<PluginOption[]> 
       useBuildAppHook: true,
       clientChunks: (meta) => meta.serverChunk,
     }),
+    Plugins.mdxHmr(),
     Plugins.buildId(),
     Plugins.environments(wakuConfig),
     Plugins.userEntries(wakuConfig, config),


### PR DESCRIPTION
Improves dev updates for MD/MDX pages after the Waku beta migration. MDX edits now invalidate a small client HMR sentinel that refetches the active Waku route, avoids stale prefetched or cached RSC payloads, and skips `pages.gen.ts` writes when route shape has not changed.

Search index refreshes now run after the page HMR path and coalesce rapid saves, preventing search work from blocking the visible page update.
