### PR TITLE
docs: update setup and customization guides

### DIFF
--- a/site/src/pages.gen.ts
+++ b/site/src/pages.gen.ts
@@ -16,10 +16,12 @@ type Page =
   | { path: '/features/mcp-server'; render: 'static' }
   | { path: '/features/navigation'; render: 'static' }
   | { path: '/features/redirects'; render: 'static' }
+  | { path: '/features/rehype-and-remark'; render: 'static' }
   | { path: '/features/search'; render: 'static' }
   | { path: '/features/slots'; render: 'static' }
   | { path: '/features/tailwind'; render: 'static' }
   | { path: '/features/theming'; render: 'static' }
+  | { path: '/features/vite'; render: 'static' }
   | { path: '/'; render: 'static' }
   | { path: '/introduction/getting-started'; render: 'static' }
   | { path: '/introduction/project-structure'; render: 'static' }

--- a/site/src/pages/features/rehype-and-remark.mdx
+++ b/site/src/pages/features/rehype-and-remark.mdx
@@ -1,0 +1,151 @@
+# Rehype & Remark [Customize the Markdown and HTML pipeline]
+
+Vocs compiles Markdown and MDX through the unified ecosystem. Add remark plugins when you want to transform Markdown before it becomes HTML. Add rehype plugins when you want to transform HTML before it is rendered.
+
+Use `vocs.config.ts` for Markdown behavior. You only need `vite.config.ts` when you are changing Vite itself.
+
+## Quick Prompt
+
+Ask your AI agent to add a Markdown pipeline plugin to your Vocs project:
+
+```txt
+Read https://vocs.dev/features/rehype-and-remark and add a remark or rehype plugin to my Vocs project.
+```
+
+## Steps
+
+::::steps
+
+### Install Plugins
+
+Install the remark or rehype plugins you want to use.
+
+:::code-group
+
+```bash [npm]
+npm install rehype-external-links
+```
+
+```bash [pnpm]
+pnpm add rehype-external-links
+```
+
+```bash [yarn]
+yarn add rehype-external-links
+```
+
+```bash [bun]
+bun add rehype-external-links
+```
+
+:::
+
+### Add to Vocs Config
+
+Add plugins to the `markdown` option in `vocs.config.ts`.
+
+```ts [vocs.config.ts]
+import rehypeExternalLinks from 'rehype-external-links'
+import { defineConfig } from 'vocs/config'
+
+export default defineConfig({
+  markdown: {
+    rehypePlugins: [[rehypeExternalLinks, { target: '_blank' }]]
+  }
+})
+```
+
+:::note
+
+Vocs already includes plugins for callouts, code groups, frontmatter, Mermaid, snippets, file trees, steps, syntax highlighting, heading anchors, and image sizing. Add custom plugins when your project needs behavior outside the built-in Markdown extensions.
+
+:::
+
+### Run Dev Server
+
+Start the development server and open a page that uses the affected Markdown.
+
+:::code-group
+
+```bash [npm]
+npm run dev
+```
+
+```bash [pnpm]
+pnpm dev
+```
+
+```bash [yarn]
+yarn dev
+```
+
+```bash [bun]
+bun run dev
+```
+
+:::
+
+::::
+
+## Add Remark Plugins
+
+Use `remarkPlugins` for transforms that work on Markdown syntax, such as adding custom directives, rewriting headings, or changing code block metadata before HTML is generated.
+
+```ts [vocs.config.ts]
+import remarkGemoji from 'remark-gemoji'
+import { defineConfig } from 'vocs/config'
+
+export default defineConfig({
+  markdown: {
+    remarkPlugins: [remarkGemoji]
+  }
+})
+```
+
+## Add Rehype Plugins
+
+Use `rehypePlugins` for transforms that work on HTML, such as adding attributes to links, rewriting elements, or integrating HTML-focused plugins.
+
+```ts [vocs.config.ts]
+import rehypeExternalLinks from 'rehype-external-links'
+import { defineConfig } from 'vocs/config'
+
+export default defineConfig({
+  markdown: {
+    rehypePlugins: [
+      [
+        rehypeExternalLinks,
+        {
+          rel: ['noopener', 'noreferrer'],
+          target: '_blank'
+        }
+      ]
+    ]
+  }
+})
+```
+
+## Add Recma Plugins
+
+Use `recmaPlugins` only when you need to transform the JavaScript module produced by MDX.
+
+```ts [vocs.config.ts]
+import recmaExportFilepath from 'recma-export-filepath'
+import { defineConfig } from 'vocs/config'
+
+export default defineConfig({
+  markdown: {
+    recmaPlugins: [recmaExportFilepath]
+  }
+})
+```
+
+Most projects should prefer remark or rehype plugins. Recma plugins operate later in the pipeline and are easier to make dependent on MDX internals.
+
+## Plugin Order
+
+Vocs runs its built-in Markdown plugins first, then runs plugins from your `markdown` config.
+
+Custom rehype plugins run after syntax highlighting and heading anchors, then Vocs finishes link and image processing.
+
+See also: [Markdown Extensions](/writing/markdown-extensions), [Site Configuration](/reference/site-config#markdown), [Vite](/features/vite)

--- a/site/src/pages/features/vite.mdx
+++ b/site/src/pages/features/vite.mdx
@@ -1,0 +1,101 @@
+# Vite [Customize the Vite config that powers Vocs]
+
+Vocs uses Vite under the hood. Most projects can use Vocs without a `vite.config.ts`, but you can switch to Vite directly when you need Vite-level control such as aliases, dev server options, build options, or extra plugins.
+
+The `vocs` CLI creates its own internal Vite config and does not load `vite.config.ts`. Keep site content, navigation, redirects, search, and theme options in `vocs.config.ts`. Use `vite.config.ts` for Vite behavior.
+
+## Quick Prompt
+
+Ask your AI agent to add a Vite config to your Vocs project:
+
+```txt
+Read https://vocs.dev/features/vite and configure Vite for my Vocs project.
+```
+
+## Steps
+
+::::steps
+
+### Create Vite Config
+
+Create `vite.config.ts` at the project root and add the React and Vocs Vite plugins.
+
+```ts [vite.config.ts]
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+import { vocs } from 'vocs/vite'
+
+export default defineConfig({
+  plugins: [react(), vocs()]
+})
+```
+
+:::note
+
+The `vocs` CLI adds `@vitejs/plugin-react` internally. When you run Vite directly, add it to your custom Vite config. Projects created with `create-vocs` already include this dependency.
+
+Vocs still reads `vocs.config.ts` for docs-specific configuration. The Vite config controls the Vite server and build pipeline.
+
+:::
+
+### Switch package.json Scripts
+
+Switch your scripts from `vocs` to `vite` so Vite loads your `vite.config.ts`. If your scripts already use `vite`, leave them as-is.
+
+```diff [package.json]
+{
+  "scripts": {
+-    "dev": "vocs dev",
+-    "build": "vocs build",
+-    "preview": "vocs preview"
++    "dev": "vite dev",
++    "build": "vite build",
++    "preview": "vite preview"
+  }
+}
+```
+
+### Run Dev Server
+
+Start the development server with your package manager.
+
+:::code-group
+
+```bash [npm]
+npm run dev
+```
+
+```bash [pnpm]
+pnpm dev
+```
+
+```bash [yarn]
+yarn dev
+```
+
+```bash [bun]
+bun run dev
+```
+
+:::
+
+::::
+
+## Add Vite Plugins
+
+Add extra Vite plugins next to `vocs()`.
+
+```ts [vite.config.ts]
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+import Inspect from 'vite-plugin-inspect'
+import { vocs } from 'vocs/vite'
+
+export default defineConfig({
+  plugins: [react(), Inspect(), vocs()]
+})
+```
+
+Install any plugin you import from `vite.config.ts` in your project.
+
+See also: [Site Configuration](/reference/site-config), [Tailwind CSS](/features/tailwind)

--- a/site/src/pages/introduction/getting-started.mdx
+++ b/site/src/pages/introduction/getting-started.mdx
@@ -52,11 +52,35 @@ You can also add Vocs to an existing project. The example below matches the curr
 
 ::::steps
 
-### Add Vocs to an Existing App
+### Install Dependencies
 
-If you already have a React + Vite project, you can merge these entries into your existing `package.json`.
+Install Vocs, Waku, and Vite in your project.
 
 If you are starting from scratch, prefer the CLI above.
+
+:::code-group
+
+```bash [npm]
+npm install vocs waku vite
+```
+
+```bash [pnpm]
+pnpm add vocs waku vite
+```
+
+```bash [yarn]
+yarn add vocs waku vite
+```
+
+```bash [bun]
+bun add vocs waku vite
+```
+
+:::
+
+### Add to package.json
+
+Add the Vocs scripts to your `package.json`.
 
 ```json [package.json]
 {
@@ -64,10 +88,6 @@ If you are starting from scratch, prefer the CLI above.
     "dev": "vocs dev",
     "build": "vocs build",
     "preview": "vocs preview"
-  },
-  "dependencies": {
-    "vocs": "latest",
-    "waku": "^1.0.0-beta.0"
   }
 }
 ```

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -130,6 +130,8 @@ export default defineConfig({
         { text: 'Ask AI', link: '/features/ask-ai' },
         { text: 'MCP Server', link: '/features/mcp-server' },
         { text: 'Changelog Generation', link: '/features/changelog-generation' },
+        { text: 'Rehype & Remark', link: '/features/rehype-and-remark' },
+        { text: 'Vite', link: '/features/vite' },
       ],
     },
     {


### PR DESCRIPTION
Updates the getting started manual installation path to match the current dependency and script shape.

Adds Customization guides for Vite config and the Rehype/Remark pipeline. The Vite guide clarifies when to switch from the `vocs` CLI to direct Vite scripts, while the Markdown pipeline guide shows where remark, rehype, and recma plugins belong.
