### PR TITLE
fix: preserve base path root slash

### DIFF
--- a/.changeset/fix-base-path-slash.md
+++ b/.changeset/fix-base-path-slash.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Preserved the configured base path root when normalizing Waku's trailing slash base path.

--- a/src/waku/internal/middleware/trailing-slash.test.ts
+++ b/src/waku/internal/middleware/trailing-slash.test.ts
@@ -6,9 +6,9 @@ import { trailingSlash } from './trailing-slash.js'
  * Creates a Hono app with trailing-slash middleware and a catch-all handler,
  * then sends a request to the given path.
  */
-function request(path: string) {
+function request(path: string, options?: trailingSlash.Options) {
   const app = new Hono()
-  app.use('*', trailingSlash())
+  app.use('*', trailingSlash(options))
   app.get('*', (c) => c.text('ok'))
   return app.request(path)
 }
@@ -28,6 +28,13 @@ describe('trailingSlash', () => {
 
   it('skips root path', async () => {
     const res = await request('http://localhost/')
+    expect(res.status).toBe(200)
+  })
+
+  it('skips configured base path root', async () => {
+    const res = await request('http://localhost/open-source/', {
+      basePath: '/open-source',
+    })
     expect(res.status).toBe(200)
   })
 

--- a/src/waku/internal/middleware/trailing-slash.ts
+++ b/src/waku/internal/middleware/trailing-slash.ts
@@ -1,22 +1,33 @@
 import type { MiddlewareHandler } from 'hono'
+import * as Config from '../../../internal/config.js'
 import { appendSearch } from '../../../internal/redirects.js'
+
+const normalizeBasePath = (basePath: string) => (basePath.endsWith('/') ? basePath : `${basePath}/`)
 
 /**
  * Removes trailing slashes from URLs.
  *
  * Redirects `/about/` → `/about` with a 308 Permanent Redirect.
- * Skips the root path (`/`) and paths with file extensions.
+ * Skips the root path (`/`), configured base path root, and paths with file
+ * extensions.
  *
  * Uses relative Location values so redirects work correctly behind
  * TLS-terminating reverse proxies, where the internal request URL
  * may use `http://`.
  */
-export const trailingSlash = (): MiddlewareHandler => {
+export const trailingSlash = (options: trailingSlash.Options = {}): MiddlewareHandler => {
+  const basePathPromise =
+    options.basePath !== undefined
+      ? Promise.resolve(normalizeBasePath(options.basePath))
+      : Config.resolve({ server: true }).then((config) => normalizeBasePath(config.basePath))
+
   return async (context, next) => {
     const url = new URL(context.req.url)
+    const basePath = await basePathPromise
 
-    // Skip root path and paths with file extensions
-    if (url.pathname === '/' || /\.\w+$/.test(url.pathname)) return next()
+    // Skip root path, base path root, and paths with file extensions
+    if (url.pathname === '/' || url.pathname === basePath || /\.\w+$/.test(url.pathname))
+      return next()
 
     // Redirect trailing slash to non-trailing slash
     if (url.pathname.endsWith('/')) {
@@ -30,3 +41,9 @@ export const trailingSlash = (): MiddlewareHandler => {
 }
 
 export default trailingSlash
+
+export declare namespace trailingSlash {
+  type Options = {
+    basePath?: string | undefined
+  }
+}

--- a/src/waku/vite.ts
+++ b/src/waku/vite.ts
@@ -21,9 +21,10 @@ export async function vocs(options: vocs.Options = {}): Promise<PluginOption[]> 
 
   const config = await Config.resolve()
   const { basePath, srcDir, outDir } = config
+  const wakuBasePath = basePath.endsWith('/') ? basePath : `${basePath}/`
 
   const wakuConfig = {
-    basePath,
+    basePath: wakuBasePath,
     srcDir,
     distDir: outDir,
     privateDir,


### PR DESCRIPTION
Normalizes the base path passed from Vocs to Waku so Waku receives a trailing-slash base even when Vocs config follows the documented `/foo` shape.

Keeps the trailing-slash middleware from stripping the configured base path root, which previously turned `/open-source/` into `/open-source` and left Vite to reject the request against the public base URL.

Repro: https://github.com/jxom/vocs-base-path-vite-config-repro
