### PR TITLE
fix: preserve unknown link label directives

### DIFF
--- a/.changeset/soft-link-label-directives.md
+++ b/.changeset/soft-link-label-directives.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed unhandled text directives inside link labels rendering as empty elements.

--- a/src/internal/mdx.test.ts
+++ b/src/internal/mdx.test.ts
@@ -7,6 +7,7 @@ import {
   remarkFilename,
   remarkFileTree,
   remarkLangCommaAttrs,
+  remarkRestoreUnknownTextDirectives,
 } from './mdx.js'
 
 type CodeNode = {
@@ -221,6 +222,47 @@ describe('getCompileOptions', () => {
 
     expect(codeNode.lang).toBe('ts')
     expect(codeNode.meta).toBe('[example.ts]')
+  })
+})
+
+describe('remarkRestoreUnknownTextDirectives', () => {
+  it('keeps colon text inside link labels as text', () => {
+    const value = '[localhost:3003](http://localhost:3003/)'
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'link',
+              title: null,
+              url: 'http://localhost:3003/',
+              children: [
+                { type: 'text', value: 'localhost' },
+                {
+                  type: 'textDirective',
+                  name: '3003',
+                  attributes: {},
+                  children: [],
+                  position: {
+                    start: { line: 1, column: 11, offset: 10 },
+                    end: { line: 1, column: 16, offset: 15 },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    remarkRestoreUnknownTextDirectives()(tree as never, { value } as never)
+
+    expect(tree.children[0]?.children[0]?.children).toEqual([
+      { type: 'text', value: 'localhost' },
+      { type: 'text', value: ':3003' },
+    ])
   })
 })
 

--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -247,6 +247,7 @@ export function getCompileOptions(
           remarkSubheading,
           remarkVocsScope,
           ...(markdown?.remarkPlugins ?? []),
+          remarkRestoreUnknownTextDirectives,
         ],
         recmaPlugins: [recmaMdxLayout(config), ...(markdown?.recmaPlugins ?? [])],
       }
@@ -616,6 +617,32 @@ export function remarkBadge(): remarkBadge.ReturnType {
 
 export declare namespace remarkBadge {
   type ReturnType = (tree: MdAst.Root) => void
+}
+
+/**
+ * Remark plugin that restores unhandled text directives back to their original Markdown.
+ * This keeps text like `localhost:3003` inside link labels from becoming empty JSX elements.
+ */
+export function remarkRestoreUnknownTextDirectives() {
+  return (tree: MdAst.Root, file: VFile) => {
+    UnistUtil.visit(tree, 'textDirective', (node, index, parent) => {
+      if (index === undefined || !parent) return
+      if (node.data?.hName) return
+
+      parent.children.splice(index, 1, {
+        type: 'text',
+        value: getSourceText(file, node) ?? `:${node.name}`,
+      })
+    })
+  }
+}
+
+function getSourceText(file: VFile, node: MdAst.Nodes) {
+  const source = String(file.value ?? '')
+  const start = node.position?.start.offset
+  const end = node.position?.end.offset
+  if (start === undefined || end === undefined) return undefined
+  return source.slice(start, end)
 }
 
 /**


### PR DESCRIPTION
Preserves unhandled text directives as their original Markdown text after Vocs and user remark plugins run.

This fixes labels like `localhost:3003` being parsed as a directive and rendered as an empty element inside links, which causes invalid HTML and hydration warnings.
