### PR TITLE
fix(waku): respect dynamic route rendering

### DIFF
--- a/.changeset/fix-dynamic-route-rendering.md
+++ b/.changeset/fix-dynamic-route-rendering.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed dynamic rendering so generated docs routes no longer defaulted to static rendering.

--- a/src/waku/internal/patches/render-strategy.test.ts
+++ b/src/waku/internal/patches/render-strategy.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { getDefaultRouteRender } from './render-strategy.js'
+
+describe('getDefaultRouteRender', () => {
+  it('uses dynamic routes for dynamic rendering', () => {
+    expect(getDefaultRouteRender('dynamic')).toBe('dynamic')
+  })
+
+  it('uses static routes for static rendering strategies', () => {
+    expect(getDefaultRouteRender('partial-static')).toBe('static')
+    expect(getDefaultRouteRender('full-static')).toBe('static')
+  })
+})

--- a/src/waku/internal/patches/render-strategy.ts
+++ b/src/waku/internal/patches/render-strategy.ts
@@ -1,0 +1,9 @@
+import type * as VocsConfig from '../../../internal/config.js'
+
+export type RouteRender = 'static' | 'dynamic'
+
+export function getDefaultRouteRender(
+  renderStrategy: VocsConfig.Config['renderStrategy'],
+): RouteRender {
+  return renderStrategy === 'dynamic' ? 'dynamic' : 'static'
+}

--- a/src/waku/internal/patches/router-render-strategy.test.ts
+++ b/src/waku/internal/patches/router-render-strategy.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+type RenderStrategy = 'full-static' | 'partial-static' | 'dynamic'
+
+type CapturedRoute = {
+  kind: 'api' | 'layout' | 'page' | 'root' | 'slice'
+  value: { path?: string; render?: 'static' | 'dynamic'; id?: string }
+}
+
+const state = vi.hoisted(() => ({
+  config: { renderStrategy: 'dynamic' as RenderStrategy },
+  createPagesFn: undefined as
+    | undefined
+    | ((fns: {
+        createApi: (value: CapturedRoute['value']) => void
+        createLayout: (value: CapturedRoute['value']) => void
+        createPage: (value: CapturedRoute['value']) => void
+        createRoot: (value: CapturedRoute['value']) => void
+        createSlice: (value: CapturedRoute['value']) => void
+      }) => Promise<unknown>),
+}))
+
+vi.mock('virtual:vocs/config', () => ({
+  config: state.config,
+}))
+
+vi.mock('waku/router/server', () => ({
+  createPages: (fn: typeof state.createPagesFn) => {
+    state.createPagesFn = fn
+    return {
+      handleBuild: async () => {},
+      handleRequest: async () => {},
+    }
+  },
+}))
+
+beforeEach(() => {
+  state.config.renderStrategy = 'dynamic'
+  state.createPagesFn = undefined
+})
+
+async function collectRoutes(renderStrategy: RenderStrategy) {
+  state.config.renderStrategy = renderStrategy
+
+  const { router } = await import('./router.js')
+  router({
+    './pages/404.tsx': async () => ({ default: function NotFound() {} }),
+    './pages/_root.tsx': async () => ({ default: function Root() {} }),
+    './pages/docs/_layout.tsx': async () => ({ default: function Layout() {} }),
+    './pages/docs/index.mdx': async () => ({ Page: function Page() {} }),
+    './pages/_slices/toc.tsx': async () => ({ default: function Slice() {} }),
+    './pages/explicit-static.tsx': async () => ({
+      default: function ExplicitStatic() {},
+      getConfig: () => ({ render: 'static' }),
+    }),
+  })
+
+  const captured: CapturedRoute[] = []
+  await state.createPagesFn?.({
+    createApi: (value) => captured.push({ kind: 'api', value }),
+    createLayout: (value) => captured.push({ kind: 'layout', value }),
+    createPage: (value) => captured.push({ kind: 'page', value }),
+    createRoot: (value) => captured.push({ kind: 'root', value }),
+    createSlice: (value) => captured.push({ kind: 'slice', value }),
+  })
+
+  return captured
+}
+
+describe('router render strategy', () => {
+  it('uses dynamic routes when renderStrategy is dynamic', async () => {
+    const captured = await collectRoutes('dynamic')
+
+    expect(captured).toContainEqual(
+      expect.objectContaining({
+        kind: 'root',
+        value: expect.objectContaining({ render: 'dynamic' }),
+      }),
+    )
+    expect(captured).toContainEqual(
+      expect.objectContaining({
+        kind: 'layout',
+        value: expect.objectContaining({ path: '/docs', render: 'dynamic' }),
+      }),
+    )
+    expect(captured).toContainEqual(
+      expect.objectContaining({
+        kind: 'page',
+        value: expect.objectContaining({ path: '/docs', render: 'dynamic' }),
+      }),
+    )
+    expect(captured).toContainEqual(
+      expect.objectContaining({
+        kind: 'slice',
+        value: expect.objectContaining({ id: 'toc', render: 'dynamic' }),
+      }),
+    )
+    expect(captured).toContainEqual(
+      expect.objectContaining({
+        kind: 'page',
+        value: expect.objectContaining({ path: '/explicit-static', render: 'static' }),
+      }),
+    )
+  })
+
+  it('uses static routes when renderStrategy is partial-static', async () => {
+    const captured = await collectRoutes('partial-static')
+
+    expect(captured).toContainEqual(
+      expect.objectContaining({
+        kind: 'page',
+        value: expect.objectContaining({ path: '/docs', render: 'static' }),
+      }),
+    )
+    expect(captured).toContainEqual(
+      expect.objectContaining({
+        kind: 'layout',
+        value: expect.objectContaining({ path: '/docs', render: 'static' }),
+      }),
+    )
+    expect(captured).toContainEqual(
+      expect.objectContaining({
+        kind: 'slice',
+        value: expect.objectContaining({ id: 'toc', render: 'static' }),
+      }),
+    )
+  })
+})

--- a/src/waku/internal/patches/router.ts
+++ b/src/waku/internal/patches/router.ts
@@ -1,3 +1,4 @@
+import { config as vocsConfig } from 'virtual:vocs/config'
 import { type FunctionComponent, lazy, type ReactNode } from 'react'
 import { createPages } from 'waku/router/server'
 import * as DedupeHead from '../dedupe-head.js'
@@ -7,6 +8,7 @@ import {
   getApiHandlers,
   hasInvalidStaticApiExports,
 } from './api-routes.js'
+import { getDefaultRouteRender } from './render-strategy.js'
 import { isIgnoredPath } from './utils/fs-router.js'
 
 type Pages = ReturnType<typeof createPages>
@@ -111,6 +113,7 @@ export function router(
   }
 
   const allModules = { ...defaultPages, ...modules }
+  const defaultRender = getDefaultRouteRender(vocsConfig.renderStrategy)
 
   return wrapPages(
     createPages(
@@ -161,21 +164,21 @@ export function router(
             } else if (pathItems.at(0) === slicesDir) {
               createSlice({
                 component,
-                render: 'static',
+                render: defaultRender,
                 id: pathItems.slice(1).join('/'),
                 ...sourceFileProperty,
               } as never)
             } else if (pathItems.at(-1) === '_root') {
               createRoot({
                 component,
-                render: 'static',
+                render: defaultRender,
                 ...sourceFileProperty,
               })
             } else {
               createPage({
                 path,
                 component,
-                render: 'static',
+                render: defaultRender,
                 ...sourceFileProperty,
               } as never)
             }
@@ -184,18 +187,18 @@ export function router(
 
           const mod = (await importFn()) as RouteModule
 
-          const config = await mod.getConfig?.()
+          const routeConfig = await mod.getConfig?.()
           if (pathItems.at(0) === apiDir) {
             // Strip the apiDir prefix from the path (e.g., _api/hello.txt -> hello.txt)
             const apiPath = '/' + pathItems.slice(1).join('/')
-            if (config?.render === 'static') {
+            if (routeConfig?.render === 'static') {
               if (hasInvalidStaticApiExports(mod) || !mod.GET) {
                 console.warn(
                   `API ${path} is invalid. For static API routes, only a single GET handler is supported.`,
                 )
               }
               createApi({
-                ...config,
+                ...routeConfig,
                 path: apiPath,
                 render: 'static',
                 method: 'GET',
@@ -220,32 +223,32 @@ export function router(
           } else if (pathItems.at(0) === slicesDir) {
             createSlice({
               component: mod.default,
-              render: 'static',
+              render: defaultRender,
               id: pathItems.slice(1).join('/'),
-              ...config,
+              ...routeConfig,
               ...sourceFileProperty,
             } as never) // FIXME avoid as never
           } else if (pathItems.at(-1) === '_layout') {
             createLayout({
               path,
               component: mod.default,
-              render: 'static',
-              ...config,
+              render: defaultRender,
+              ...routeConfig,
               ...sourceFileProperty,
             })
           } else if (pathItems.at(-1) === '_root') {
             createRoot({
               component: mod.default,
-              render: 'static',
-              ...config,
+              render: defaultRender,
+              ...routeConfig,
               ...sourceFileProperty,
             })
           } else {
             createPage({
               path,
               component: mod.default,
-              render: 'static',
-              ...config,
+              render: defaultRender,
+              ...routeConfig,
               ...sourceFileProperty,
             } as never) // FIXME avoid as never
           }

--- a/src/waku/internal/patches/vite-plugins/fs-router-typegen.test.ts
+++ b/src/waku/internal/patches/vite-plugins/fs-router-typegen.test.ts
@@ -1,0 +1,49 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { generateFsRouterTypes } from './fs-router-typegen.js'
+
+let tempDir: string | undefined
+
+afterEach(() => {
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true })
+  tempDir = undefined
+})
+
+function createPages(files: Record<string, string>) {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-router-types-'))
+  const pagesDir = path.join(tempDir, 'pages')
+  for (const [file, contents] of Object.entries(files)) {
+    const filePath = path.join(pagesDir, file)
+    fs.mkdirSync(path.dirname(filePath), { recursive: true })
+    fs.writeFileSync(filePath, contents)
+  }
+  return pagesDir
+}
+
+describe('generateFsRouterTypes', () => {
+  it('uses dynamic as the default render mode', async () => {
+    const pagesDir = createPages({
+      'index.mdx': '# Home',
+      'docs/intro.tsx': 'export default function Page() { return null }',
+    })
+
+    const result = await generateFsRouterTypes(pagesDir)
+
+    expect(result).toContain("{ path: '/'; render: 'dynamic' }")
+    expect(result).toContain("{ path: '/docs/intro'; render: 'dynamic' }")
+  })
+
+  it('uses the configured default render mode', async () => {
+    const pagesDir = createPages({
+      'index.mdx': '# Home',
+      'docs/intro.tsx': 'export default function Page() { return null }',
+    })
+
+    const result = await generateFsRouterTypes(pagesDir, { defaultRender: 'static' })
+
+    expect(result).toContain("{ path: '/'; render: 'static' }")
+    expect(result).toContain("{ path: '/docs/intro'; render: 'static' }")
+  })
+})

--- a/src/waku/internal/patches/vite-plugins/fs-router-typegen.ts
+++ b/src/waku/internal/patches/vite-plugins/fs-router-typegen.ts
@@ -6,7 +6,9 @@ import { existsSync, readFileSync } from 'node:fs'
 import { readdir, readFile, writeFile } from 'node:fs/promises'
 import type { ParseResult, Plugin } from 'vite'
 import { parse, transformWithOxc } from 'vite'
+import type * as VocsConfig from '../../../../internal/config.js'
 import { EXTENSIONS, SRC_PAGES, SRC_SERVER_ENTRY } from '../constants.js'
+import { getDefaultRouteRender, type RouteRender } from '../render-strategy.js'
 import { getGrouplessPath } from '../utils/create-pages.js'
 import { isIgnoredPath } from '../utils/fs-router.js'
 import { joinPath } from '../utils/path.js'
@@ -97,7 +99,10 @@ const getExportedName = (specifier: ExportSpecifier) =>
     ? specifier.exported.name
     : String(specifier.exported.value)
 
-export const fsRouterTypegenPlugin = (opts: { srcDir: string }): Plugin => {
+export const fsRouterTypegenPlugin = (opts: {
+  renderStrategy: VocsConfig.Config['renderStrategy']
+  srcDir: string
+}): Plugin => {
   return {
     name: 'waku:vite-plugins:fs-router-typegen',
     apply: 'serve',
@@ -115,7 +120,9 @@ export const fsRouterTypegenPlugin = (opts: { srcDir: string }): Plugin => {
         if (!existsSync(pagesDir) || !(await detectFsRouterUsage(srcDir))) {
           return
         }
-        const generation = await generateFsRouterTypes(pagesDir)
+        const generation = await generateFsRouterTypes(pagesDir, {
+          defaultRender: getDefaultRouteRender(opts.renderStrategy),
+        })
         if (!generation) {
           // skip failures
           return
@@ -183,7 +190,11 @@ export async function detectFsRouterUsage(srcDir: string): Promise<boolean> {
   }
 }
 
-export async function generateFsRouterTypes(pagesDir: string) {
+export async function generateFsRouterTypes(
+  pagesDir: string,
+  options: generateFsRouterTypes.Options = {},
+) {
+  const { defaultRender = 'dynamic' } = options
   const PAGE_EXTENSIONS = ['.tsx', '.mdx', '.md']
 
   // Recursively collect page files in the given directory
@@ -310,7 +321,7 @@ export async function generateFsRouterTypes(pagesDir: string) {
           `  | ({ path: '${file.path}' } & GetConfigResponse<typeof ${moduleName}_getConfig>)`,
         )
       } else {
-        lines.push(`  | { path: '${file.path}'; render: 'static' }`)
+        lines.push(`  | { path: '${file.path}'; render: '${defaultRender}' }`)
       }
     }
 
@@ -339,4 +350,10 @@ export async function generateFsRouterTypes(pagesDir: string) {
   }
   const generation = await generateFile(files)
   return generation
+}
+
+export declare namespace generateFsRouterTypes {
+  type Options = {
+    defaultRender?: RouteRender | undefined
+  }
 }

--- a/src/waku/vite.ts
+++ b/src/waku/vite.ts
@@ -55,7 +55,10 @@ export async function vocs(options: vocs.Options = {}): Promise<PluginOption[]> 
     Plugins.staticBuild(wakuConfig),
     Plugins.privateDir(wakuConfig),
     Plugins.htmlShell(),
-    Plugins.fsRouterTypegen(wakuConfig),
+    Plugins.fsRouterTypegen({
+      renderStrategy: config.renderStrategy,
+      srcDir,
+    }),
     Plugins.preview(),
     Plugins.vocsConfig(config),
   ]


### PR DESCRIPTION
Generated Vocs docs routes now inherit the configured default route render mode instead of always registering as static routes.

This makes the default `renderStrategy: 'dynamic'` effective for Markdown, MDX, layout, root, and slice routes while preserving explicit per-route `getConfig()` overrides. Route type generation now follows the same default render mode.