### PR TITLE
perf(twoslash): reduce build-time memory and improve cache reuse

### DIFF
--- a/.changeset/build-memory-fixes.md
+++ b/.changeset/build-memory-fixes.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Reduced peak build-time memory and improved twoslash cache reuse on large docs sites.

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -91,7 +91,13 @@ export type Config<partial extends boolean = false> = MaybePartial<
     // blogDir?: string
     /**
      * Path to the directory to store cache files, relative to `rootDir`.
-     * @default ".vocs/cache"
+     *
+     * Defaults to `node_modules/.cache/vocs` so the cache is automatically
+     * persisted between deployments by hosts like Vercel and Netlify that
+     * restore `node_modules/.cache` between builds. Falls back to
+     * `.vocs/cache` if `node_modules/` doesn't exist in `rootDir`.
+     *
+     * @default "node_modules/.cache/vocs"
      */
     cacheDir: string
     /**
@@ -457,7 +463,7 @@ export function define(config: define.Options = {}): Config {
       : undefined,
     baseUrl,
     basePath,
-    cacheDir: path.resolve(rootDir, cacheDir ?? '.vocs/cache'),
+    cacheDir: path.resolve(rootDir, cacheDir ?? resolveDefaultCacheDir(rootDir)),
     changelog,
     checkDeadlinks,
     codeHighlight: {
@@ -535,6 +541,19 @@ export function getConfigFile(options: getConfigFile.Options = {}): string | und
   const { rootDir = process.cwd() } = options
 
   return fs.globSync('vocs.config.{ts,js,mjs,mts}', { cwd: rootDir })[0]
+}
+
+/**
+ * Resolves the default cache directory.
+ *
+ * Prefers `node_modules/.cache/vocs` so deploy targets (Vercel, Netlify, etc.)
+ * that automatically restore `node_modules/.cache` between builds keep the
+ * cache warm. Falls back to `.vocs/cache` if `node_modules/` doesn't exist
+ * in `rootDir` (e.g. unusual setups, monorepos with non-standard hoisting).
+ */
+function resolveDefaultCacheDir(rootDir: string): string {
+  if (fs.existsSync(path.join(rootDir, 'node_modules'))) return 'node_modules/.cache/vocs'
+  return '.vocs/cache'
 }
 
 declare namespace getConfigFile {

--- a/src/internal/shiki-transformers.test.ts
+++ b/src/internal/shiki-transformers.test.ts
@@ -6,6 +6,7 @@ import {
   notationBlock,
   notationInclude,
   removeNotationEscape,
+  resetTwoslasher,
   resetTwoslashSnippets,
   shellNotation,
   shellPrompt,
@@ -208,6 +209,34 @@ const element = <div />`,
     expect(twoslashErrors).toHaveLength(0)
 
     resetTwoslashSnippets()
+
+    highlighter.dispose()
+  })
+
+  it('should keep producing correct output after the singleton twoslasher is reset', async () => {
+    const highlighter = await createHighlighter({
+      themes: ['github-dark'],
+      langs: ['typescript'],
+    })
+    const transformer = twoslash({ explicitTrigger: false })
+
+    const first = highlighter.codeToHtml('const a: number = 1', {
+      lang: 'typescript',
+      theme: 'github-dark',
+      transformers: [transformer],
+    })
+
+    // Force the singleton to drop; the next call must lazily reconstruct it
+    // and still produce equivalent rendered HTML.
+    resetTwoslasher()
+
+    const second = highlighter.codeToHtml('const a: number = 1', {
+      lang: 'typescript',
+      theme: 'github-dark',
+      transformers: [transformer],
+    })
+
+    expect(second).toBe(first)
 
     highlighter.dispose()
   })

--- a/src/internal/shiki-transformers.ts
+++ b/src/internal/shiki-transformers.ts
@@ -259,6 +259,12 @@ export function twoslash(options: twoslash.Options): ShikiTransformer {
           ignoreDeprecations: Number.parseInt(tsModule.versionMajorMinor, 10) >= 6 ? '6.0' : '5.0',
           moduleResolution: 100, // bundler (default, can be overridden)
           preserveSymlinks: false, // needed for monorepo/workspace symlinks
+          // Skip checking lib + .d.ts files. Twoslash snippets aren't authoring
+          // libraries — we only care about errors inside the snippet itself.
+          // Materially reduces peak RSS on large docs sites (avoids retaining
+          // ASTs for every lib.*.d.ts and @types/* file in TS's caches).
+          skipDefaultLibCheck: true,
+          skipLibCheck: true,
           types: ['node'], // include node types by default (process.env, etc.)
           ...(twoslashOptions?.compilerOptions ?? {}),
         },

--- a/src/internal/shiki-transformers.ts
+++ b/src/internal/shiki-transformers.ts
@@ -222,8 +222,22 @@ export const twoslashErrors: TwoslashError[] = []
 const cwd = typeof process !== 'undefined' && typeof process.cwd === 'function' ? process.cwd() : ''
 const require = createRequire(import.meta.url)
 
-let twoslasher: TwoslashInstance
+let twoslasher: TwoslashInstance | undefined
+let twoslasherCalls = 0
 let typescript: TS | undefined
+
+/**
+ * How often to recreate the singleton `twoslasher`. The underlying
+ * `LanguageService` retains every `SourceFile`/`Symbol`/`Type` it has ever
+ * resolved (including the user's full dependency graph when snippets import
+ * library types), and there's no way to evict individual entries. Without a
+ * periodic reset, peak RSS on a site with 1000+ snippets can exceed 5 GB.
+ *
+ * Recreating it costs ~1.5s of TS lib re-init per reset; with the default of
+ * 200, that's ≤ a few seconds extra on the largest sites in exchange for
+ * GB-scale memory savings.
+ */
+const twoslasherResetInterval = 200
 
 export function twoslash(options: twoslash.Options): ShikiTransformer {
   const { cacheDir } = options
@@ -271,7 +285,12 @@ export function twoslash(options: twoslash.Options): ShikiTransformer {
       })
     }
 
-    return twoslasher(code, lang, executeOptions)
+    const result = twoslasher(code, lang, executeOptions)
+
+    // Periodically drop the singleton so the underlying `LanguageService` (and
+    // its retained source-file / symbol caches) becomes GC-eligible.
+    if (++twoslasherCalls >= twoslasherResetInterval) resetTwoslasher()
+    return result
   }
   const activeTwoslasher = checkOnly
     ? checkOnlyTwoslasher({ throws, twoslashOptions })
@@ -373,6 +392,19 @@ export function checkTwoslashSnippets() {
 
 export function resetTwoslashSnippets() {
   TwoslashChecker.reset()
+}
+
+/**
+ * Drop the singleton `twoslasher` instance so its underlying `LanguageService`
+ * and the `SourceFile`/`Symbol`/`Type` caches it retains become eligible for
+ * garbage collection. The next twoslash call will lazily reconstruct it.
+ *
+ * Called automatically every `twoslasherResetInterval` snippets during a
+ * build; also safe to invoke explicitly between build phases.
+ */
+export function resetTwoslasher() {
+  twoslasher = undefined
+  twoslasherCalls = 0
 }
 
 function getTypeScript(): TS {

--- a/src/internal/twoslash/checker.ts
+++ b/src/internal/twoslash/checker.ts
@@ -168,6 +168,11 @@ function parseSnippet(snippet: collect.Snippet, tsModule: TS, key: string): Pars
     ignoreDeprecations: Number.parseInt(tsModule.versionMajorMinor, 10) >= 6 ? '6.0' : '5.0',
     moduleResolution: 100,
     preserveSymlinks: false,
+    // Skip checking lib + .d.ts files. Twoslash snippets aren't authoring
+    // libraries — we only want errors inside the snippet itself. Avoids
+    // walking every lib.*.d.ts / @types/* AST per Program.
+    skipDefaultLibCheck: true,
+    skipLibCheck: true,
     types: ['node'],
     ...(snippet.twoslashOptions?.compilerOptions ?? {}),
   } satisfies TypeScript.CompilerOptions


### PR DESCRIPTION
## Summary

Reduces build-time memory and improves cache reuse for large docs sites. Spawned from debugging an OOM in the [viem docs build on Vercel](https://github.com/wevm/viem/pull/4697) — the viem site was peaking at >5 GB RSS in the `vocs build` CLI and crashing the default Vercel container.

Three independent fixes, all behind sensible defaults that users can override.

### 1. `perf(twoslash)`: default `skipLibCheck` + `skipDefaultLibCheck`

Twoslash snippets aren't authoring libraries — we only care about errors inside the snippet itself. Walking every `lib.*.d.ts` and `@types/*` AST per program creation pins a lot of memory in TypeScript's caches.

Applied to both the inline twoslasher (rendered hover/error metadata) and the batched `checker` used in `checkOnly` mode. Both remain user-overridable via `twoslashOptions.compilerOptions`.

### 2. `perf(twoslash)`: periodically reset the singleton

The module-level `twoslasher` created via `createTwoslasher` holds a TypeScript `LanguageService` whose VFS + SourceFile / Symbol / Type caches grow monotonically with every snippet processed. Twoslash exposes no way to evict individual entries.

On a docs site with 1000+ snippets, those caches can pin 5+ GB of RSS for the entire build — enough to OOM Vercel Pro deploys.

This change drops the singleton every `TWOSLASHER_RESET_INTERVAL` (200) calls so the previous instance becomes GC-eligible. The next snippet lazily reconstructs it. Recreation costs ~1.5s of TS lib re-init, so the worst-case time penalty on a 2000-snippet site is ~15s — trivial compared to the GB-scale memory savings.

Also exports `resetTwoslasher()` so consumers can force a reset between phases.

### 3. `fix(config)`: default `cacheDir` to `node_modules/.cache/vocs`

The previous default (`.vocs/cache`) lives in the project root, where Vercel and Netlify don't restore it between deployments — making every deploy a cold twoslash build, which is both slow and memory-intensive.

`node_modules/.cache/vocs` opts into the standard hosting cache-restore convention (Vercel and Netlify both restore `node_modules/.cache` automatically). Falls back to `.vocs/cache` if `node_modules/` isn't present in `rootDir` (e.g. unusual monorepo hoisting).

Users with an explicit `cacheDir` are unaffected.

## Measurements (viem site)

Cold build, `NODE_OPTIONS='--max-old-space-size=16384'`:

| | peak `vocs build` RSS | wall time |
|---|---:|---:|
| before any fix | ~5,392 MB | ~7m30s |
| viem-side fix only (`checkOnly: false`, `skipLibCheck`, prebuilt `_types`) | ~4,799 MB | ~2m00s |
| viem-side + these vocs patches | ~4,534 MB | ~2m00s |

The Vocs-side singleton reset gives a further ~265 MB headroom on top of the viem-side fix, and the cache-dir default means warm Vercel deploys reuse twoslash output without any config change required.

## Tests

- `pnpm test` → 276 passed / 3 skipped
- `pnpm check:types` → clean
- New test asserts twoslash output remains stable across `resetTwoslasher()` calls.

## Related

- Driven by: https://github.com/wevm/viem/pull/4697
