### PR TITLE
feat(sidebar): add badge prop to sidebar items

### DIFF
--- a/.changeset/sidebar-badge.md
+++ b/.changeset/sidebar-badge.md
@@ -1,0 +1,5 @@
+---
+"vocs": minor
+---
+
+Added a `badge` field to `SidebarItem`. Pass a string for a default badge, or an object with a `variant` (`note`, `info`, `tip`, `warning`, `danger`, `success`) for a colored variant. Renders to the right of the item text on leaf items and group headers.

--- a/.changeset/sidebar-badge.md
+++ b/.changeset/sidebar-badge.md
@@ -1,5 +1,5 @@
 ---
-"vocs": minor
+"vocs": patch
 ---
 
 Added a `badge` field to `SidebarItem`. Pass a string for a default badge, or an object with a `variant` (`note`, `info`, `tip`, `warning`, `danger`, `success`) for a colored variant. Renders to the right of the item text on leaf items and group headers.

--- a/playground/vocs.config.ts
+++ b/playground/vocs.config.ts
@@ -79,17 +79,22 @@ export default defineConfig({
   sidebar: {
     '/': [
       { text: 'Home', link: '/' },
-      { text: 'Changelog', link: '/changelog' },
+      { text: 'Changelog', link: '/changelog', badge: 'New' },
       { text: 'Kitchen Sink', link: '/kitchen-sink' },
-      { text: 'REPL', link: '/repl' },
+      { text: 'REPL', link: '/repl', badge: { text: 'Beta', variant: 'warning' } },
       { text: 'None' },
       {
         text: 'Concepts',
         collapsed: false,
+        badge: { text: 'v2', variant: 'tip' },
         items: [
           { text: 'Wallet Client', link: '/wallet-client' },
           { text: 'External Link', link: 'https://viem.sh' },
-          { text: 'Tempo Actions', link: '/tempo-actions' },
+          {
+            text: 'Tempo Actions',
+            link: '/tempo-actions',
+            badge: { text: 'Deprecated', variant: 'danger' },
+          },
         ],
       },
       // {

--- a/site/src/pages/reference/site-config.mdx
+++ b/site/src/pages/reference/site-config.mdx
@@ -318,6 +318,13 @@ type SidebarItem = {
   disabled?: boolean
   /** Mark the link as external (opens in a new tab with an icon). */
   external?: boolean
+  /**
+   * Badge rendered to the right of the item text.
+   * Pass a string for a default `info` badge, or an object to pick a variant.
+   */
+  badge?:
+    | string
+    | { text: string; variant?: 'note' | 'info' | 'warning' | 'danger' | 'tip' | 'success' }
 }
 ```
 
@@ -325,6 +332,7 @@ type SidebarItem = {
 export default defineConfig({
   sidebar: [
     { text: 'Getting Started', link: '/introduction/getting-started' },
+    { text: 'Agents SDK', link: '/agents', badge: 'New' }, // [!code hl]
     {
       text: 'Writing',
       collapsed: false,
@@ -333,7 +341,7 @@ export default defineConfig({
         { text: 'Code Snippets', link: '/writing/code-snippets' },
         { text: 'Markdown Snippets', link: '/writing/markdown-snippets' },
         { text: 'Markdown Extensions', link: '/writing/markdown-extensions' },
-        { text: 'Twoslash', link: '/writing/twoslash' }
+        { text: 'Twoslash', link: '/writing/twoslash', badge: { text: 'Beta', variant: 'warning' } } // [!code hl]
       ]
     }
   ]

--- a/src/internal/sidebar.test.ts
+++ b/src/internal/sidebar.test.ts
@@ -130,6 +130,34 @@ describe('flatten', () => {
       ]
     `)
   })
+
+  test('preserves badge on flattened items', () => {
+    expect(
+      flatten([
+        { text: 'A', link: '/a', badge: 'New' },
+        {
+          text: 'Group',
+          items: [{ text: 'B', link: '/b', badge: { text: 'Beta', variant: 'warning' } }],
+        },
+      ]),
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "badge": "New",
+          "link": "/a",
+          "text": "A",
+        },
+        {
+          "badge": {
+            "text": "Beta",
+            "variant": "warning",
+          },
+          "link": "/b",
+          "text": "B",
+        },
+      ]
+    `)
+  })
 })
 
 describe('fromConfig', () => {

--- a/src/internal/sidebar.ts
+++ b/src/internal/sidebar.ts
@@ -1,6 +1,20 @@
 import type { Config } from './config.js'
 
+export type SidebarItemBadge =
+  | string
+  | {
+      /** Text displayed inside the badge. */
+      text: string
+      /** Visual variant. Defaults to `'info'`. */
+      variant?: 'note' | 'info' | 'warning' | 'danger' | 'tip' | 'success' | undefined
+    }
+
 export type SidebarItem<strict extends boolean = false> = {
+  /**
+   * Badge rendered to the right of the item text.
+   * Pass a string for a default `info` badge, or an object to pick a variant.
+   */
+  badge?: SidebarItemBadge | undefined
   /** Whether or not to disable the sidebar item. */
   disabled?: boolean | undefined
   /** Whether to open the link in a new tab. */

--- a/src/react/internal/Sidebar.tsx
+++ b/src/react/internal/Sidebar.tsx
@@ -8,6 +8,7 @@ import LucideArrowUpRight from '~icons/lucide/arrow-up-right'
 import LucideChevronRight from '~icons/lucide/chevron-right'
 import * as Path from '../../internal/path.js'
 import * as Sidebar_core from '../../internal/sidebar.js'
+import { Badge } from '../Badge.js'
 import { Link } from '../Link.js'
 import { useSidebar } from '../useSidebar.js'
 
@@ -68,9 +69,24 @@ export declare namespace Sidebar {
 }
 
 /** @internal */
+function ItemBadge(props: { badge: Sidebar_core.SidebarItemBadge }) {
+  const badge = typeof props.badge === 'string' ? { text: props.badge } : props.badge
+  return (
+    <Badge
+      className="vocs:shrink-0 vocs:ml-2"
+      data-v-sidebar-item-badge
+      variant={badge.variant ?? 'info'}
+    >
+      {badge.text}
+    </Badge>
+  )
+}
+
+/** @internal */
 // biome-ignore lint/correctness/noUnusedVariables: _
 function Item(props: Item.Props) {
   const {
+    badge,
     condensed = false,
     depth = 0,
     disabled,
@@ -133,10 +149,11 @@ function Item(props: Item.Props) {
           rel="noopener noreferrer"
           onClick={onNavigate}
         >
-          <span className="vocs:inline-flex vocs:items-center vocs:gap-1">
+          <span className="vocs:inline-flex vocs:items-center vocs:gap-1 vocs:min-w-0 vocs:truncate">
             {text}
-            <LucideArrowUpRight className="vocs:size-3" />
+            <LucideArrowUpRight className="vocs:size-3 vocs:shrink-0" />
           </span>
+          {badge && <ItemBadge badge={badge} />}
         </a>
       )
     return (
@@ -150,7 +167,8 @@ function Item(props: Item.Props) {
         onClick={onNavigate}
         {...(active && { 'data-active': true })}
       >
-        {text}
+        <span className="vocs:min-w-0 vocs:truncate">{text}</span>
+        {badge && <ItemBadge badge={badge} />}
       </Link>
     )
   }
@@ -163,7 +181,8 @@ function Item(props: Item.Props) {
       data-v-sidebar-item
       ref={itemRef as never}
     >
-      {text}
+      <span className="vocs:min-w-0 vocs:truncate">{text}</span>
+      {badge && <ItemBadge badge={badge} />}
     </div>
   )
 }
@@ -183,7 +202,7 @@ namespace Item {
 /** @internal */
 // biome-ignore lint/correctness/noUnusedVariables: _
 function Section(props: Section.Props) {
-  const { condensed = false, depth = 0, link, items, onNavigate, scrollRef, text } = props
+  const { badge, condensed = false, depth = 0, link, items, onNavigate, scrollRef, text } = props
 
   const { path } = useRouter()
   const groupLinkIsExternal = link ? Path.isExternal(link) : false
@@ -250,6 +269,8 @@ function Section(props: Section.Props) {
                   </span>
                 </Link>
 
+                {badge && <ItemBadge badge={badge} />}
+
                 {collapsable && (
                   <button
                     aria-expanded={!collapsed}
@@ -285,7 +306,10 @@ function Section(props: Section.Props) {
                     }
                   : {})}
               >
-                {text}
+                <span className="vocs:inline-flex vocs:items-center vocs:min-w-0">
+                  <span className="vocs:truncate">{text}</span>
+                  {badge && <ItemBadge badge={badge} />}
+                </span>
 
                 {collapsable && (
                   <div className="vocs:text-secondary/80">


### PR DESCRIPTION
## Summary

Adds an optional `badge` field to `SidebarItem` so sidebar entries can flag status like `New`, `Beta`, or `Deprecated` with a small pill rendered to the right of the item text.

```ts
defineConfig({
  sidebar: [
    { text: 'Getting Started', link: '/introduction/getting-started' },
    { text: 'Agents SDK', link: '/agents', badge: 'New' },                                       // shorthand
    { text: 'Webhooks', link: '/webhooks', badge: { text: 'Beta', variant: 'warning' } },
    { text: 'Legacy API', link: '/legacy', badge: { text: 'Deprecated', variant: 'danger' }, disabled: true },
    {
      text: 'Experimental',
      badge: { text: 'Alpha', variant: 'tip' },                                                  // also on group headers
      items: [{ text: 'Sandbox', link: '/exp/sandbox' }],
    },
  ],
})
```

## API

```ts
type SidebarItem = {
  // ... existing fields
  badge?:
    | string
    | { text: string; variant?: 'note' | 'info' | 'warning' | 'danger' | 'tip' | 'success' }
}
```

- **String shorthand** → `info` variant.
- **Object form** → pick one of the six variants — the same set used by the existing `Badge` component, so colors and theming stay consistent across the design system.
- **Plain JSON** so the value serializes cleanly through `virtual:vocs/config` HMR.

## Implementation notes

- Reuses the existing `Badge` component (`data-v-badge` + `data-v-context` styling) — no new CSS, users can already override via `[data-v-badge]` and the new `[data-v-sidebar-item-badge]` hook.
- Wraps `text + badge` in a flex span inside section headers so the parent's `justify-between` keeps text + badge anchored to the left and the chevron pinned to the right.
- Applies to all three leaf-item render branches (internal link, external link, disabled) and both section-header variants (linked + text-only).
- External-link items keep the `ArrowUpRight` icon adjacent to the text; the badge sits on the far right.

## Validation

- `pnpm check` — clean
- `pnpm test` — 277 passed, 3 skipped (incl. new `flatten` snapshot test asserting badge propagation for both string and object forms)
- Manually verified in `pnpm dev:playground` — added badges to `Changelog`, `REPL`, the `Concepts` group header, and a nested `Tempo Actions` item.
