### PR TITLE
fix(twoslash): correct inline cache for included/imported snippets

### DIFF
--- a/.changeset/fix-inline-cache-includes.md
+++ b/.changeset/fix-inline-cache-includes.md
@@ -2,4 +2,4 @@
 "vocs": patch
 ---
 
-Fixed the experimental Twoslash inline cache (`twoslash.inlineCache`) producing permanent cache misses and duplicate `// @twoslash-cache: ...` comments for code blocks that import or `[!include]` virtual files. The included file's own cache comment is now stripped before injection so the host block reads its own cache, the cache key is hashed against the normalized code on both read and write, and an existing cache comment is replaced in place rather than appended.
+Fixed the experimental Twoslash inline cache producing permanent misses and duplicate comments for code blocks that import or `[!include]` virtual files.

--- a/.changeset/fix-inline-cache-includes.md
+++ b/.changeset/fix-inline-cache-includes.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed the experimental Twoslash inline cache (`twoslash.inlineCache`) producing permanent cache misses and duplicate `// @twoslash-cache: ...` comments for code blocks that import or `[!include]` virtual files. The included file's own cache comment is now stripped before injection so the host block reads its own cache, the cache key is hashed against the normalized code on both read and write, and an existing cache comment is replaced in place rather than appended.

--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -1118,7 +1118,10 @@ function getVirtualFiles(codeNodes: MdAst.Code[]): Map<string, string> {
   for (const node of codeNodes) {
     const fileName = getCodeFileName(node)
     if (!fileName) continue
-    virtualFiles.set(fileName, node.value)
+    // Strip any inline twoslash cache comment so it isn't inlined ahead of a
+    // host block's code when this virtual file is imported/included. The
+    // original node keeps its comment for its own rendering.
+    virtualFiles.set(fileName, InlineCache.stripInlineCacheComments(node.value))
   }
   return virtualFiles
 }

--- a/src/internal/shiki-transformers.ts
+++ b/src/internal/shiki-transformers.ts
@@ -307,8 +307,13 @@ export function twoslash(options: twoslash.Options): ShikiTransformer {
           executeOptions?: Parameters<TwoslashInstance>[2],
           meta?: Parameters<NonNullable<typeof typesCache.preprocess>>[3],
         ) {
-          const preprocessed = typesCache.preprocess?.(code, lang, executeOptions, meta)
-          return Renderer.normalizeCustomTagBlocks(preprocessed ?? code)
+          // Normalize before the inner preprocess so the cache key hashed on
+          // read matches the code hashed on write (which runs against the
+          // normalized output). Without this, snippets containing consecutive
+          // custom tag lines (`@log`/`@error`/`@warn`/`@annotate`) would never
+          // hit the cache.
+          const normalized = Renderer.normalizeCustomTagBlocks(code)
+          return typesCache.preprocess?.(normalized, lang, executeOptions, meta) ?? normalized
         },
       }
     : undefined

--- a/src/internal/twoslash/inline-cache.test.ts
+++ b/src/internal/twoslash/inline-cache.test.ts
@@ -6,6 +6,7 @@ import {
   createInlineTypesCache,
   extractSourceMapComment,
   injectSourceMapComment,
+  stripInlineCacheComments,
 } from './inline-cache.js'
 
 describe('source map codec', () => {
@@ -23,6 +24,21 @@ describe('source map codec', () => {
     const result = extractSourceMapComment('const a = 1')
     expect(result.code).toBe('const a = 1')
     expect(result.sourceMap).toBeNull()
+  })
+})
+
+describe('stripInlineCacheComments', () => {
+  it('removes all cache comments', () => {
+    const code = [
+      '// @twoslash-cache: {"v":1,"hash":"abc","data":"x"}',
+      'export const client = 1',
+    ].join('\n')
+    expect(stripInlineCacheComments(code)).toBe('export const client = 1')
+  })
+
+  it('leaves code without cache comments untouched', () => {
+    const code = 'export const client = 1\nconst a = 2'
+    expect(stripInlineCacheComments(code)).toBe(code)
   })
 })
 
@@ -85,6 +101,44 @@ describe('inline types cache', () => {
       const cached = typesCache.read(body, 'ts', {}, meta)
       expect(cached).toEqual(data)
     }
+  })
+
+  it('replaces an existing cache comment in place instead of appending a duplicate', () => {
+    const code = 'const a: string = "x"'
+    const { file, from, to } = createMarkdown(code)
+    const data = { nodes: [], code: 'compiled-output' }
+
+    // --- Pass 1: cold write ---
+    {
+      const { typesCache, patcher } = createInlineTypesCache()
+      const meta = { sourceMap: { path: file, from, to } } as never
+      typesCache.preprocess?.(code, 'ts', {}, meta)
+      typesCache.write(code, data as never, 'ts', {}, meta)
+      patcher.patch(file)
+    }
+
+    const cacheLines = () =>
+      fs
+        .readFileSync(file, 'utf-8')
+        .split('\n')
+        .filter((l) => l.includes('// @twoslash-cache:'))
+    expect(cacheLines()).toHaveLength(1)
+
+    // --- Pass 2: a writer with stale in-memory code (no cache comment, so the
+    // existing comment can't be located via `search`) must still replace the
+    // on-disk comment rather than append a second one. ---
+    {
+      const content = fs.readFileSync(file, 'utf-8')
+      const currentTo = content.lastIndexOf('\n```')
+      const { typesCache, patcher } = createInlineTypesCache()
+      const meta = { sourceMap: { path: file, from, to: currentTo } } as never
+      // Pass the original (comment-free) code to simulate a stale read.
+      typesCache.preprocess?.(code, 'ts', {}, meta)
+      typesCache.write(code, data as never, 'ts', {}, meta)
+      patcher.patch(file)
+    }
+
+    expect(cacheLines()).toHaveLength(1)
   })
 
   it('invalidates the cache when the hash no longer matches', () => {

--- a/src/internal/twoslash/inline-cache.ts
+++ b/src/internal/twoslash/inline-cache.ts
@@ -75,6 +75,21 @@ type CachePayload = {
 
 const CODE_INLINE_CACHE_KEY = '@twoslash-cache'
 const CODE_INLINE_CACHE_REGEX = new RegExp(`// ${CODE_INLINE_CACHE_KEY}: (.*)(?:\n|$)`, 'g')
+/** Matches a cache comment anchored to the start of a code block body. */
+const CODE_INLINE_CACHE_LINE_REGEX = new RegExp(`^// ${CODE_INLINE_CACHE_KEY}: .*(?:\n|$)`)
+
+/**
+ * Remove all `// @twoslash-cache: ...` comments from a code string.
+ *
+ * Used when a virtual file's content is injected into another twoslash block
+ * (via `[!include]` or `import` resolution). Without stripping, the included
+ * file's own cache comment would be inlined ahead of the host block's code and
+ * picked up as the host's cache, causing a permanent hash mismatch (and a
+ * spurious cache comment to be re-appended on every build).
+ */
+export function stripInlineCacheComments(code: string): string {
+  return code.replace(CODE_INLINE_CACHE_REGEX, '')
+}
 
 export function createInlineTypesCache(
   options: { remove?: boolean | undefined; ignoreCache?: boolean | undefined } = {},
@@ -148,12 +163,28 @@ export function createInlineTypesCache(
     const range: { from: number; to?: number } = { from: source.from }
     let linebreak = true
 
+    let located = false
     if (search) {
       const cachePos = file.content.indexOf(search, source.from)
       if (cachePos !== -1 && cachePos < source.to) {
         range.from = cachePos
         range.to = cachePos + search.length
         linebreak = search.endsWith('\n')
+        located = true
+      }
+    }
+
+    // Fallback: if the existing cache comment wasn't located via `search` (e.g.
+    // a concurrent build environment already wrote one, or the in-memory code
+    // was stale), detect a cache comment at the block body start and replace it
+    // in place rather than appending a duplicate.
+    if (!located) {
+      const body = file.content.slice(source.from, source.to)
+      const match = body.match(CODE_INLINE_CACHE_LINE_REGEX)
+      if (match) {
+        range.from = source.from
+        range.to = source.from + match[0].length
+        linebreak = match[0].endsWith('\n')
       }
     }
 


### PR DESCRIPTION
## Problem

The experimental Twoslash inline cache (`twoslash.inlineCache`, shipped in `2.0.7`) is only partially effective on docs sites that share setup via `[!include]` / virtual-file `import`s (e.g. viem). Measured on viem's docs:

- **~45% permanent cache misses** that never converge — every build re-runs twoslash for those snippets.
- **Duplicate `// @twoslash-cache:` comments** re-appended on every build (289/351 files), producing churny diffs.

## Root cause

`remarkFilename` (and the `notationInclude` shiki transformer) inline a virtual file's content — **including that file's own `@twoslash-cache` comment** — *ahead* of the host block's code. The reader (`typesCache.preprocess`) keeps the **first** cache comment it finds, so the host block validates its code against the *dependency's* cache hash → permanent mismatch. When the miss triggers a re-write, the patcher can't locate the (foreign) comment via `search`, so it appends a new one → duplicates.

A secondary issue: the read hash was computed on pre-`normalizeCustomTagBlocks` code while the write hash used the normalized output, so snippets with consecutive `@log`/`@error`/`@warn`/`@annotate` lines also missed.

## Fix

1. **Strip a virtual file's own `@twoslash-cache` comment before injecting it** into a host block (`getVirtualFiles` → new `stripInlineCacheComments`). The original node keeps its comment for its own rendering.
2. **Normalize before the inner preprocess** so read and write hash the same code form.
3. **Replace an existing cache comment in place** when it can't be located via `search` (concurrent/stale writers), instead of appending a duplicate.

## Validation

End-to-end on viem's docs (~1800 twoslash snippets):

| | before | after |
|---|---|---|
| cold-seed misses | 1486 | **0** |
| cold-seed duplicate files | 289 | **0** |
| warm rebuild | hit 1812 / miss 1486 / write 1484 | **hit 1797 / miss 0 / write 0** |

Warm rebuilds now skip twoslash entirely and make no source edits. Added unit tests for `stripInlineCacheComments` and the in-place (no-duplicate) write path; existing inline-cache tests still pass.
