### PR TITLE
fix(twoslash): make inline cache portable across environments

### DIFF
--- a/.changeset/inline-cache-portable.md
+++ b/.changeset/inline-cache-portable.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed the experimental Twoslash inline cache to stay portable across environments with differing local Twoslash options.

--- a/src/internal/twoslash/inline-cache.test.ts
+++ b/src/internal/twoslash/inline-cache.test.ts
@@ -141,6 +141,32 @@ describe('inline types cache', () => {
     expect(cacheLines()).toHaveLength(1)
   })
 
+  it('hits regardless of twoslash options (portable across environments)', () => {
+    const code = 'const a: string = "x"'
+    const { file, from, to } = createMarkdown(code)
+    const data = { nodes: [], code: 'compiled-output' }
+
+    // Seed with one set of options (e.g. machine A, with `paths`).
+    {
+      const { typesCache, patcher } = createInlineTypesCache()
+      const meta = { sourceMap: { path: file, from, to } } as never
+      const options = { compilerOptions: { paths: { foo: ['/abs/a'] } } }
+      typesCache.preprocess?.(code, 'ts', options as never, meta)
+      typesCache.write(code, data as never, 'ts', options as never, meta)
+      patcher.patch(file)
+    }
+
+    // Read with different options (e.g. machine B / Vercel, without `paths`).
+    {
+      const { typesCache } = createInlineTypesCache()
+      const body = readBody(file, from)
+      const meta = { sourceMap: { path: file, from, to } } as never
+      const otherOptions = { compilerOptions: {} }
+      typesCache.preprocess?.(body, 'ts', otherOptions as never, meta)
+      expect(typesCache.read(body, 'ts', otherOptions as never, meta)).toEqual(data)
+    }
+  })
+
   it('invalidates the cache when the hash no longer matches', () => {
     const code = 'const a: string = "x"'
     const { file, from, to } = createMarkdown(code)

--- a/src/internal/twoslash/inline-cache.ts
+++ b/src/internal/twoslash/inline-cache.ts
@@ -73,11 +73,14 @@ type CachePayload = {
 }
 
 /**
- * Cache payload format version. Bumped to `2` when the cache key changed from
- * `optionsHash:lang:code` to `lang:code` (see `cacheHash`); older `v: 1`
- * payloads are ignored and transparently re-seeded.
+ * Cache payload format version. Kept at `1` even though the cache key changed
+ * from `optionsHash:lang:code` to `lang:code` (see `cacheHash`): stale
+ * payloads from the old key naturally fail the hash check on `preprocess` and
+ * are transparently re-seeded on the next write, so a version bump (which
+ * would force a one-shot invalidation of every committed cache comment) is
+ * unnecessary.
  */
-const CACHE_VERSION = 2
+const CACHE_VERSION = 1
 
 const CODE_INLINE_CACHE_KEY = '@twoslash-cache'
 const CODE_INLINE_CACHE_REGEX = new RegExp(`// ${CODE_INLINE_CACHE_KEY}: (.*)(?:\n|$)`, 'g')

--- a/src/internal/twoslash/inline-cache.ts
+++ b/src/internal/twoslash/inline-cache.ts
@@ -1,7 +1,6 @@
 import * as crypto from 'node:crypto'
 import type { TwoslashShikiReturn, TwoslashTypesCache } from '@shikijs/twoslash'
 import LZString from 'lz-string'
-import { getObjectHash, type TwoslashExecuteOptions } from 'twoslash/core'
 import { FilePatcher } from './file-patcher.js'
 
 /**
@@ -73,6 +72,13 @@ type CachePayload = {
   data: string
 }
 
+/**
+ * Cache payload format version. Bumped to `2` when the cache key changed from
+ * `optionsHash:lang:code` to `lang:code` (see `cacheHash`); older `v: 1`
+ * payloads are ignored and transparently re-seeded.
+ */
+const CACHE_VERSION = 2
+
 const CODE_INLINE_CACHE_KEY = '@twoslash-cache'
 const CODE_INLINE_CACHE_REGEX = new RegExp(`// ${CODE_INLINE_CACHE_KEY}: (.*)(?:\n|$)`, 'g')
 /** Matches a cache comment anchored to the start of a code block body. */
@@ -97,32 +103,25 @@ export function createInlineTypesCache(
   const { remove, ignoreCache } = options
   const patcher = new FilePatcher()
 
-  const optionsHashCache = new WeakMap<TwoslashExecuteOptions, string>()
-  function getOptionsHash(options: TwoslashExecuteOptions = {}): string {
-    let hash = optionsHashCache.get(options)
-    if (!hash) {
-      hash = getObjectHash(options)
-      optionsHashCache.set(options, hash)
-    }
-    return hash
-  }
-
-  function cacheHash(code: string, lang?: string, options?: TwoslashExecuteOptions): string {
+  // Key the cache on the (already fully-composed) snippet code and language
+  // only — deliberately NOT on the twoslash options. The whole point of the
+  // inline cache is to travel with the repo across machines and CI, but
+  // `twoslashOptions` frequently contain environment-specific or volatile
+  // values (absolute paths, config that branches on whether built `.d.ts`
+  // files exist, etc). Hashing them in makes the committed cache miss on any
+  // machine other than the one that seeded it. This matches the filesystem
+  // types cache, which also keys on code alone.
+  function cacheHash(code: string, lang?: string): string {
     return crypto
       .createHash('sha256')
-      .update(`${getOptionsHash(options)}:${lang ?? ''}:${code}`)
+      .update(`${lang ?? ''}:${code}`)
       .digest('hex')
   }
 
-  function stringifyCachePayload(
-    data: TwoslashShikiReturn,
-    code: string,
-    lang?: string,
-    options?: TwoslashExecuteOptions,
-  ): string {
+  function stringifyCachePayload(data: TwoslashShikiReturn, code: string, lang?: string): string {
     const payload: CachePayload = {
-      v: 1,
-      hash: cacheHash(code, lang, options),
+      v: CACHE_VERSION,
+      hash: cacheHash(code, lang),
       data: LZString.compressToBase64(JSON.stringify(data)),
     }
     return JSON.stringify(payload)
@@ -135,7 +134,7 @@ export function createInlineTypesCache(
     if (!cache) return null
     try {
       const payload = JSON.parse(cache) as CachePayload
-      if (payload.v === 1) {
+      if (payload.v === CACHE_VERSION) {
         return {
           payload,
           twoslash: () => {
@@ -200,7 +199,7 @@ export function createInlineTypesCache(
   }
 
   const typesCache: TwoslashTypesCache = {
-    preprocess(code, lang, options, meta) {
+    preprocess(code, lang, _options, meta) {
       if (!meta) return
 
       let rawCache = ''
@@ -218,7 +217,7 @@ export function createInlineTypesCache(
       const shouldLoadCache = !ignoreCache && !remove
       if (shouldLoadCache) {
         const cache = resolveCachePayload(cacheString)
-        if (cache?.payload.hash === cacheHash(code, lang, options)) {
+        if (cache?.payload.hash === cacheHash(code, lang)) {
           const twoslash = cache.twoslash()
           if (twoslash) meta.__cache = twoslash
         }
@@ -234,13 +233,13 @@ export function createInlineTypesCache(
     read(_code, _lang, _options, meta) {
       return meta?.__cache ?? null
     },
-    write(code, data, lang, options, meta) {
+    write(code, data, lang, _options, meta) {
       if (remove) {
         meta?.__patch?.('')
         return
       }
       const twoslashShiki = simplifyTwoslashReturn(data)
-      const cacheStr = `// ${CODE_INLINE_CACHE_KEY}: ${stringifyCachePayload(twoslashShiki, code, lang, options)}`
+      const cacheStr = `// ${CODE_INLINE_CACHE_KEY}: ${stringifyCachePayload(twoslashShiki, code, lang)}`
       meta?.__patch?.(cacheStr)
     },
   }


### PR DESCRIPTION
## Problem

The experimental Twoslash **inline** cache (`twoslash.inlineCache`) is designed to *travel with the repo* — cache payloads are committed into the source as `// @twoslash-cache:` comments so that CI/Vercel builds get cache hits without a separate `.cache` directory.

However, it wasn't actually portable. The filesystem types cache keys purely on `md5(code)`, but the inline cache keyed on:

```
sha256(getOptionsHash(options) + ":" + lang + ":" + code)
```

`twoslashOptions` routinely contain environment-specific or volatile values — absolute `compilerOptions.paths`, config that branches on whether built `.d.ts` files exist locally, etc. So a cache seeded on one machine would **miss** on any other machine (or on Vercel) whose options differed, even though the code was identical. This is exactly why filesystem caching worked on Vercel but inline caching didn't.

## Fix

- Key the inline cache on `lang:code` only, matching the filesystem types cache. Options are deliberately excluded.
- Bump the cache payload version to `2` so stale `v: 1` payloads (which baked the options hash into the key) are ignored and transparently re-seeded.
- Drop the now-unused `getObjectHash` / `TwoslashExecuteOptions` import and per-options hash memoization.

## Test

Added `hits regardless of twoslash options (portable across environments)` — seeds the cache with one options object (with `compilerOptions.paths`) and reads it back with different options (empty), expecting a hit.

All inline-cache tests pass; `check:types` clean.