### PR TITLE
fix: hide `@twoslash-cache` comments in snippets

### DIFF
--- a/.changeset/olive-terms-act.md
+++ b/.changeset/olive-terms-act.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed inline Twoslash cache comments leaking into rendered code snippets.

--- a/src/internal/shiki-transformers.test.ts
+++ b/src/internal/shiki-transformers.test.ts
@@ -241,6 +241,28 @@ const element = <div />`,
     highlighter.dispose()
   })
 
+  it('should hide committed inline cache comments when inline cache is disabled', async () => {
+    const highlighter = await createHighlighter({
+      themes: ['github-dark'],
+      langs: ['typescript'],
+    })
+
+    const html = highlighter.codeToHtml(
+      `// @twoslash-cache: {"v":1,"hash":"old","data":"x"}
+const value = 1`,
+      {
+        lang: 'typescript',
+        theme: 'github-dark',
+        transformers: [twoslash({ explicitTrigger: false })],
+      },
+    )
+
+    expect(html).toContain('const')
+    expect(html).not.toContain('twoslash-cache')
+
+    highlighter.dispose()
+  })
+
   it('should typecheck virtual json files in check-only mode', async () => {
     const highlighter = await createHighlighter({
       themes: ['github-dark'],

--- a/src/internal/shiki-transformers.ts
+++ b/src/internal/shiki-transformers.ts
@@ -253,16 +253,22 @@ export function twoslash(options: twoslash.Options): ShikiTransformer {
     renderer = Renderer.rich(),
     throws = true,
     twoslashOptions,
-    typesCache = InlineCache.enabled(inlineCache)
-      ? InlineCache.getOrCreate().typesCache
-      : TypesCache.fs({ dir: cacheDir ? path.join(cacheDir, 'twoslash') : undefined }),
+    typesCache: configuredTypesCache,
   } = options
+  const inlineCacheStore = InlineCache.enabled(inlineCache) ? InlineCache.getOrCreate() : undefined
+  const typesCache =
+    configuredTypesCache ??
+    inlineCacheStore?.typesCache ??
+    TypesCache.fs({ dir: cacheDir ? path.join(cacheDir, 'twoslash') : undefined })
+  const shouldStripInlineCache = typesCache !== inlineCacheStore?.typesCache
 
   const lazyTwoslasher = (
     code: string,
     lang?: string,
     executeOptions?: Parameters<TwoslashInstance>[2],
   ) => {
+    code = InlineCache.stripInlineCacheComments(code)
+
     if (!twoslasher) {
       const tsModule = twoslashOptions?.tsModule ?? getTypeScript()
 
@@ -312,7 +318,10 @@ export function twoslash(options: twoslash.Options): ShikiTransformer {
           // normalized output). Without this, snippets containing consecutive
           // custom tag lines (`@log`/`@error`/`@warn`/`@annotate`) would never
           // hit the cache.
-          const normalized = Renderer.normalizeCustomTagBlocks(code)
+          const stripped = shouldStripInlineCache
+            ? InlineCache.stripInlineCacheComments(code)
+            : code
+          const normalized = Renderer.normalizeCustomTagBlocks(stripped)
           return typesCache.preprocess?.(normalized, lang, executeOptions, meta) ?? normalized
         },
       }
@@ -393,6 +402,8 @@ function checkOnlyTwoslasher(options: {
     executeOptions?: Parameters<TwoslashInstance>[2],
     meta?: { __raw?: string | undefined },
   ) => {
+    code = InlineCache.stripInlineCacheComments(code)
+
     const twoslashOptions = {
       ...options.twoslashOptions,
       ...executeOptions,

--- a/src/internal/twoslash/inline-cache.test.ts
+++ b/src/internal/twoslash/inline-cache.test.ts
@@ -36,6 +36,14 @@ describe('stripInlineCacheComments', () => {
     expect(stripInlineCacheComments(code)).toBe('export const client = 1')
   })
 
+  it('removes cache comments without a space after the colon', () => {
+    const code = [
+      '// @twoslash-cache:{"v":1,"hash":"abc","data":"x"}',
+      'export const client = 1',
+    ].join('\n')
+    expect(stripInlineCacheComments(code)).toBe('export const client = 1')
+  })
+
   it('leaves code without cache comments untouched', () => {
     const code = 'export const client = 1\nconst a = 2'
     expect(stripInlineCacheComments(code)).toBe(code)
@@ -187,6 +195,38 @@ describe('inline types cache', () => {
       const meta = { sourceMap: { path: file, from, to } } as never
       // The body still has the old cache line, but we validate against new code.
       typesCache.preprocess?.(`${body}\nconst b = 2`, 'ts', {}, meta)
+      expect(typesCache.read(body, 'ts', {}, meta)).toBeNull()
+    }
+  })
+
+  it('invalidates cached results that would render the cache comment', () => {
+    const code = 'const a: string = "x"'
+    const { file, from, to } = createMarkdown(code)
+
+    {
+      const { typesCache, patcher } = createInlineTypesCache()
+      const meta = { sourceMap: { path: file, from, to } } as never
+      typesCache.preprocess?.(code, 'ts', {}, meta)
+      typesCache.write(
+        code,
+        {
+          nodes: [],
+          code: `// @twoslash-cache: {"v":1,"hash":"old","data":"x"}\n${code}`,
+        } as never,
+        'ts',
+        {},
+        meta,
+      )
+      patcher.patch(file)
+    }
+
+    {
+      const { typesCache } = createInlineTypesCache()
+      const body = readBody(file, from)
+      const meta = { sourceMap: { path: file, from, to } } as never
+
+      const preprocessed = typesCache.preprocess?.(body, 'ts', {}, meta)
+      expect(preprocessed).toBe(code)
       expect(typesCache.read(body, 'ts', {}, meta)).toBeNull()
     }
   })

--- a/src/internal/twoslash/inline-cache.ts
+++ b/src/internal/twoslash/inline-cache.ts
@@ -83,9 +83,14 @@ type CachePayload = {
 const CACHE_VERSION = 1
 
 const CODE_INLINE_CACHE_KEY = '@twoslash-cache'
-const CODE_INLINE_CACHE_REGEX = new RegExp(`// ${CODE_INLINE_CACHE_KEY}: (.*)(?:\n|$)`, 'g')
+const CODE_INLINE_CACHE_REGEX = new RegExp(
+  `^// ${CODE_INLINE_CACHE_KEY}:[ \\t]*([^\\r\\n]*)(?:\\r?\\n|$)`,
+  'gm',
+)
 /** Matches a cache comment anchored to the start of a code block body. */
-const CODE_INLINE_CACHE_LINE_REGEX = new RegExp(`^// ${CODE_INLINE_CACHE_KEY}: .*(?:\n|$)`)
+const CODE_INLINE_CACHE_LINE_REGEX = new RegExp(
+  `^// ${CODE_INLINE_CACHE_KEY}:[ \\t]*[^\\r\\n]*(?:\\r?\\n|$)`,
+)
 
 /**
  * Remove all `// @twoslash-cache: ...` comments from a code string.
@@ -142,7 +147,15 @@ export function createInlineTypesCache(
           payload,
           twoslash: () => {
             try {
-              return JSON.parse(LZString.decompressFromBase64(payload.data))
+              const twoslash = JSON.parse(
+                LZString.decompressFromBase64(payload.data),
+              ) as TwoslashShikiReturn
+              if (
+                typeof twoslash.code === 'string' &&
+                stripInlineCacheComments(twoslash.code) !== twoslash.code
+              )
+                return null
+              return twoslash
             } catch {
               return null
             }


### PR DESCRIPTION
Inline Twoslash cache comments are now treated as internal metadata before code highlighting or fallback Twoslash checks run. Cached payloads that would re-render a cache marker are ignored and refreshed.

This fixes docs sites that commit inline cache comments, where stale cached output could surface `@twoslash-cache` as the first visible line in snippets.
