### PR TITLE
fix(mdx): copy heading anchor links

### DIFF
--- a/.changeset/silver-anchors-copy.md
+++ b/.changeset/silver-anchors-copy.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Added copy-to-clipboard behavior for heading anchor links.

--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -224,8 +224,9 @@ export function getCompileOptions(
               behavior: 'append' as const,
               test: ['h2', 'h3', 'h4', 'h5', 'h6'],
               properties: {
-                ariaLabel: 'Link to this section',
+                ariaLabel: 'Copy link and go to this section',
                 className: ['heading-anchor'],
+                title: 'Copy link and go to this section',
               },
               // TODO: use iconify icon data instead of hardcoded paths
               content: {

--- a/src/react/Root.client.tsx
+++ b/src/react/Root.client.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react'
 import { ErrorBoundary } from './internal/ErrorBoundary.client.js'
+import { HeadingAnchors } from './internal/HeadingAnchors.client.js'
 import { NuqsAdapter } from './internal/NuqsAdapter.js'
 import { useConfig } from './useConfig.js'
 
@@ -76,6 +77,7 @@ export function Root_client({ children }: { children: React.ReactNode }) {
 
   return (
     <NuqsAdapter>
+      <HeadingAnchors />
       <ErrorBoundary>{children}</ErrorBoundary>
     </NuqsAdapter>
   )

--- a/src/react/internal/HeadingAnchors.client.tsx
+++ b/src/react/internal/HeadingAnchors.client.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import * as React from 'react'
+
+export function HeadingAnchors() {
+  React.useEffect(() => {
+    async function copyHeadingUrl(anchor: HTMLAnchorElement) {
+      const url = anchor.href
+      if (!url) return
+
+      await navigator.clipboard.writeText(url)
+      anchor.dataset['copied'] = 'true'
+      window.setTimeout(() => {
+        delete anchor.dataset['copied']
+      }, 1000)
+    }
+
+    function onClick(event: MouseEvent) {
+      if (!(event.target instanceof Element)) return
+
+      const anchor = event.target.closest<HTMLAnchorElement>('a.heading-anchor')
+      if (!anchor) return
+
+      void copyHeadingUrl(anchor).catch((error) => {
+        console.error('Failed to copy heading URL:', error)
+      })
+    }
+
+    document.addEventListener('click', onClick)
+    return () => document.removeEventListener('click', onClick)
+  }, [])
+
+  return null
+}

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -56,6 +56,10 @@ h6[data-v] {
   @apply vocs:text-accent7;
 }
 
+.heading-anchor[data-copied="true"] .heading-anchor-icon {
+  @apply vocs:text-success;
+}
+
 strong[data-v] {
   @apply vocs:font-semibold;
 }


### PR DESCRIPTION
## Summary

- Copy the resolved heading anchor URL when users click generated section links.
- Keep the existing hash navigation behavior and update the anchor label/title to describe both actions.
- Add a copied state style for the heading link icon.