### PR TITLE
fix: strip twoslash cache comments and sitemap from markdown pages

### DIFF
--- a/.changeset/twoslash-cache-markdown.md
+++ b/.changeset/twoslash-cache-markdown.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Stripped inline Twoslash cache comments and the sitemap from markdown (`.md`/llms) pages.

--- a/src/internal/llms.test.ts
+++ b/src/internal/llms.test.ts
@@ -5,6 +5,7 @@ import {
   remarkExtractFrontmatter,
   remarkFrontmatter,
   remarkStripFrontmatter,
+  remarkStripInlineCache,
   remarkStripJs,
 } from './mdx.js'
 
@@ -16,6 +17,7 @@ const plugins = {
     remarkExtractFrontmatter,
     remarkStripFrontmatter,
     remarkStripJs,
+    remarkStripInlineCache,
   ],
 }
 
@@ -335,12 +337,7 @@ This is the home page.`,
       "
     `)
     expect(result.results[0]?.content).toMatchInlineSnapshot(`
-      "<!--
-      Sitemap:
-      - [Page](/page)
-      -->
-
-      Content.
+      "Content.
       "
     `)
   })
@@ -405,6 +402,33 @@ title: Component
       -->
 
       <Component />
+      "
+    `)
+  })
+
+  test('strips inline twoslash cache comments from code blocks', async () => {
+    const result = await buildLlmsContent({
+      pages: [
+        {
+          path: '/code',
+          content: `---
+title: Code
+---
+
+\`\`\`ts
+// @twoslash-cache: {"v":1,"hash":"abc","data":"xyz"}
+const a = 1
+\`\`\``,
+        },
+      ],
+      title: 'My Docs',
+      ...plugins,
+    })
+
+    expect(result.results[0]?.content).toMatchInlineSnapshot(`
+      "\`\`\`ts
+      const a = 1
+      \`\`\`
       "
     `)
   })

--- a/src/internal/llms.ts
+++ b/src/internal/llms.ts
@@ -52,9 +52,7 @@ export async function buildLlmsContent(options: buildLlmsContent.Options) {
   const short = [...llmsTxtContent, ...nav]
   const full = [...llmsTxtContent, sitemap, ...results.map((r) => r.content)]
 
-  const resultsWithSitemap = results.map((r) => ({ ...r, content: `${sitemap}\n${r.content}` }))
-
-  return { full: full.join('\n'), results: resultsWithSitemap, short: short.join('\n') }
+  return { full: full.join('\n'), results, short: short.join('\n') }
 }
 
 export declare namespace buildLlmsContent {

--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -212,6 +212,7 @@ export function getCompileOptions(
           remarkExtractFrontmatter,
           remarkStripFrontmatter,
           remarkStripJs,
+          remarkStripInlineCache,
         ],
       }
     if (type === 'react')
@@ -1002,6 +1003,19 @@ export function remarkStripJs() {
     })
     UnistUtil.visit(tree, 'mdxFlowExpression', (node) => {
       tree.children.splice(tree.children.indexOf(node), 1)
+    })
+  }
+}
+
+/**
+ * Remark plugin that strips inline twoslash cache comments
+ * (`// @twoslash-cache: ...`) from code blocks. Used for the markdown
+ * (`.md`/llms) output so the persisted cache never leaks into rendered pages.
+ */
+export function remarkStripInlineCache() {
+  return (tree: MdAst.Root) => {
+    UnistUtil.visit(tree, 'code', (node) => {
+      node.value = InlineCache.stripInlineCacheComments(node.value)
     })
   }
 }


### PR DESCRIPTION
## Overview

Markdown versions of pages (`.md` / `llms.txt`, served by `md-router` and written by the `vocs:llms` Vite plugin) read the raw `.mdx` source. Two things were leaking into that output:

1. **Inline Twoslash cache comments** (`// @twoslash-cache: ...`) persisted inside fenced code blocks.
2. **The sitemap** (`<!-- Sitemap: ... -->`) prepended to every individual `.md` page.

## Changes

- Added `remarkStripInlineCache` in `internal/mdx.ts` (reuses `InlineCache.stripInlineCacheComments`) and wired it into the `txt` compile pipeline, so both markdown callers are covered.
- Removed the per-page sitemap prepend in `buildLlmsContent`. `llms-full.txt` still includes the sitemap once at the top.
- Added/updated tests in `llms.test.ts`.

## Verification

- `pnpm vitest run` for `llms`, `mdx`, `md-router`, `inline-cache`, `shiki-transformers` — all pass.
- `pnpm check:types` and `pnpm check` pass.
- The only full-suite failures are the pre-existing `experimental_rust` tests that require a local Rust binary, unrelated to this change.