### PR TITLE
feat: add dead anchor checking

### DIFF
--- a/.changeset/check-dead-anchors.md
+++ b/.changeset/check-dead-anchors.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Added a `checkDeadAnchors` config option to validate internal fragment links (e.g. `/page#section`) against page anchors during production builds.

--- a/site/src/pages/reference/site-config.mdx
+++ b/site/src/pages/reference/site-config.mdx
@@ -163,6 +163,25 @@ Controls dead link validation.
 - `false` disables checking.
 - `'warn'` reports dead links without failing the build.
 
+### `checkDeadAnchors`
+
+- **Type:** `boolean | 'warn'`
+- **Default:** `false`
+
+Controls dead anchor validation for internal fragment links.
+
+- `true` throws when an internal link points to a missing anchor.
+- `false` disables checking.
+- `'warn'` reports dead anchors without failing the build.
+
+Vocs checks anchors generated from headings and explicit `id` attributes in MDX pages. It validates Markdown links, rendered `<a href>` links, and MDX JSX `href`/`to` props such as cards that link to sections.
+
+```ts
+export default defineConfig({
+  checkDeadAnchors: true,
+})
+```
+
 ## Branding And Theme
 
 ### `logoUrl`

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -105,6 +105,16 @@ export type Config<partial extends boolean = false> = MaybePartial<
      */
     checkDeadlinks: boolean | 'warn'
     /**
+     * Whether or not to check for dead anchor links in the documentation.
+     *
+     * - `true`: Enable dead anchor checking and throw errors on dead anchors.
+     * - `false`: Disable dead anchor checking.
+     * - `"warn"`: Enable dead anchor checking but only warn instead of throwing errors.
+     *
+     * @default false
+     */
+    checkDeadAnchors: boolean | 'warn'
+    /**
      * Code highlight configuration.
      */
     codeHighlight: MaybePartial<partial, UnionOmit<Mdx.rehypeShiki.Options, 'twoslash'>>
@@ -407,6 +417,7 @@ export function define(config: define.Options = {}): Config {
     basePath = '/',
     cacheDir,
     changelog,
+    checkDeadAnchors = false,
     checkDeadlinks = true,
     codeHighlight,
     colorScheme = 'light dark',
@@ -454,6 +465,7 @@ export function define(config: define.Options = {}): Config {
     basePath,
     cacheDir: path.resolve(rootDir, cacheDir ?? '.vocs/cache'),
     changelog,
+    checkDeadAnchors,
     checkDeadlinks,
     codeHighlight: {
       ...codeHighlight,

--- a/src/internal/mdx.test.ts
+++ b/src/internal/mdx.test.ts
@@ -1,7 +1,24 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import type * as HAst from 'hast'
+import type * as MdAst from 'mdast'
 import ruby from 'shiki/langs/ruby.mjs'
-import { describe, expect, it } from 'vitest'
+import type { VFile } from 'vfile'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as Config from './config.js'
-import { getCompileOptions, remarkCodeTitle, remarkLangCommaAttrs } from './mdx.js'
+import {
+  anchorLinks,
+  anchors,
+  deadLinks,
+  getCompileOptions,
+  getDeadAnchorLinks,
+  rehypeLinks,
+  remarkAnchorLinks,
+  remarkCodeTitle,
+  remarkLangCommaAttrs,
+} from './mdx.js'
+import { mdx as viteMdx } from './vite-plugins.js'
 
 type CodeNode = {
   type: 'code'
@@ -47,6 +64,47 @@ function transformCodeNode(
   remarkCodeTitle(getCodeTitlePlugin(config))(tree as never)
 
   return tree.children[0]
+}
+
+function createTestConfig(rootDir: string): Config.Config {
+  return Config.define({
+    checkDeadAnchors: true,
+    checkDeadlinks: true,
+    rootDir,
+    srcDir: 'src',
+  })
+}
+
+function createPage(rootDir: string, route: string) {
+  const file = path.join(rootDir, 'src/pages', `${route}.mdx`)
+  fs.mkdirSync(path.dirname(file), { recursive: true })
+  fs.writeFileSync(file, '')
+  return file
+}
+
+function runRehypeLinks(config: Config.Config, file: string, tree: HAst.Root) {
+  const plugin = rehypeLinks(config)()
+  plugin(tree, {
+    path: file,
+    dirname: path.dirname(file),
+  } as VFile)
+}
+
+function runRemarkAnchorLinks(config: Config.Config, file: string, tree: MdAst.Root) {
+  const plugin = remarkAnchorLinks(config)()
+  plugin(tree, {
+    path: file,
+    dirname: path.dirname(file),
+  } as VFile)
+}
+
+function runBuildEnd(config: Config.Config) {
+  const plugin = viteMdx(config) as unknown as {
+    buildEnd: () => void
+    configResolved: (config: { command: 'build' | 'serve' }) => void
+  }
+  plugin.configResolved({ command: 'build' })
+  plugin.buildEnd()
 }
 
 describe('getCompileOptions', () => {
@@ -127,5 +185,322 @@ describe('getCompileOptions', () => {
 
     expect(codeNode.lang).toBe('ts')
     expect(codeNode.meta).toBe('[example.ts]')
+  })
+})
+
+describe('anchor link checking', () => {
+  beforeEach(() => {
+    anchors.clear()
+    anchorLinks.clear()
+    deadLinks.clear()
+  })
+
+  it('reports dead hash-only links against anchors in the current page', () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-test-'))
+    const file = createPage(rootDir, 'index')
+    const config = createTestConfig(rootDir)
+
+    runRehypeLinks(config, file, {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'h2',
+          properties: { id: 'existing' },
+          children: [],
+        },
+        {
+          type: 'element',
+          tagName: 'a',
+          properties: { href: '#missing' },
+          children: [],
+        },
+      ],
+    })
+
+    expect([...(anchors.get(file) ?? [])]).toEqual(['existing'])
+    expect(getDeadAnchorLinks().get(file)).toMatchObject([{ href: '#missing', anchor: 'missing' }])
+
+    fs.rmSync(rootDir, { recursive: true })
+  })
+
+  it('reports dead anchors across pages', () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-test-'))
+    const indexFile = createPage(rootDir, 'index')
+    const targetFile = createPage(rootDir, 'target')
+    const config = createTestConfig(rootDir)
+
+    runRehypeLinks(config, targetFile, {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'h2',
+          properties: { id: 'target-section' },
+          children: [],
+        },
+      ],
+    })
+    runRehypeLinks(config, indexFile, {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'a',
+          properties: { href: '/target#target-section' },
+          children: [],
+        },
+        {
+          type: 'element',
+          tagName: 'a',
+          properties: { href: '/target#missing-section' },
+          children: [],
+        },
+      ],
+    })
+
+    expect(getDeadAnchorLinks().get(indexFile)).toMatchObject([
+      { href: '/target#missing-section', anchor: 'missing-section' },
+    ])
+
+    fs.rmSync(rootDir, { recursive: true })
+  })
+
+  it('does not report valid same-page, cross-page, or index-route anchors', () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-test-'))
+    const indexFile = createPage(rootDir, 'index')
+    const targetFile = createPage(rootDir, 'target')
+    const guideIndexFile = createPage(rootDir, 'guide/index')
+    const config = createTestConfig(rootDir)
+
+    runRehypeLinks(config, targetFile, {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'h2',
+          properties: { id: 'target-section' },
+          children: [],
+        },
+      ],
+    })
+    runRehypeLinks(config, guideIndexFile, {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'h2',
+          properties: { id: 'guide-section' },
+          children: [],
+        },
+      ],
+    })
+    runRemarkAnchorLinks(config, indexFile, {
+      type: 'root',
+      children: [
+        {
+          type: 'mdxJsxFlowElement',
+          name: 'Card',
+          attributes: [{ type: 'mdxJsxAttribute', name: 'to', value: '#local-section' }],
+          children: [],
+        },
+      ],
+    } as MdAst.Root)
+    runRehypeLinks(config, indexFile, {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'h2',
+          properties: { id: 'local-section' },
+          children: [],
+        },
+        {
+          type: 'element',
+          tagName: 'a',
+          properties: { href: '/target#target-section' },
+          children: [],
+        },
+        {
+          type: 'element',
+          tagName: 'a',
+          properties: { href: '/guide#guide-section' },
+          children: [],
+        },
+      ],
+    })
+
+    expect(getDeadAnchorLinks().size).toBe(0)
+
+    fs.rmSync(rootDir, { recursive: true })
+  })
+
+  it('collects anchor links from MDX JSX href and to props', () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-test-'))
+    const indexFile = createPage(rootDir, 'index')
+    const targetFile = createPage(rootDir, 'target')
+    const config = createTestConfig(rootDir)
+
+    runRemarkAnchorLinks(config, indexFile, {
+      type: 'root',
+      children: [
+        {
+          type: 'mdxJsxFlowElement',
+          name: 'Card',
+          attributes: [
+            { type: 'mdxJsxAttribute', name: 'to', value: '#local-missing' },
+            { type: 'mdxJsxAttribute', name: 'href', value: '/target#target-missing' },
+          ],
+          children: [],
+        },
+      ],
+    } as MdAst.Root)
+    runRehypeLinks(config, indexFile, {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'h2',
+          properties: { id: 'local-existing' },
+          children: [],
+        },
+      ],
+    })
+    runRehypeLinks(config, targetFile, {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'h2',
+          properties: { id: 'target-existing' },
+          children: [],
+        },
+      ],
+    })
+
+    expect(getDeadAnchorLinks().get(indexFile)).toMatchObject([
+      { href: '#local-missing', anchor: 'local-missing' },
+      { href: '/target#target-missing', anchor: 'target-missing' },
+    ])
+
+    fs.rmSync(rootDir, { recursive: true })
+  })
+
+  it('does not collect anchor links when checkDeadAnchors is disabled', () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-test-'))
+    const file = createPage(rootDir, 'index')
+    const config = {
+      ...createTestConfig(rootDir),
+      checkDeadAnchors: false,
+    }
+
+    runRemarkAnchorLinks(config, file, {
+      type: 'root',
+      children: [
+        {
+          type: 'mdxJsxFlowElement',
+          name: 'Card',
+          attributes: [{ type: 'mdxJsxAttribute', name: 'to', value: '#missing' }],
+          children: [],
+        },
+      ],
+    } as MdAst.Root)
+    runRehypeLinks(config, file, {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'a',
+          properties: { href: '#missing' },
+          children: [],
+        },
+      ],
+    })
+
+    expect(anchorLinks.get(file)).toBeUndefined()
+    expect(getDeadAnchorLinks().size).toBe(0)
+
+    fs.rmSync(rootDir, { recursive: true })
+  })
+
+  it('leaves missing target pages to dead-link checking instead of anchor checking', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-test-'))
+    const file = createPage(rootDir, 'index')
+    const config = createTestConfig(rootDir)
+
+    runRehypeLinks(config, file, {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'a',
+          properties: { href: '/missing#anchor' },
+          children: [],
+        },
+      ],
+    })
+
+    expect(anchorLinks.get(file)).toBeUndefined()
+    expect(getDeadAnchorLinks().size).toBe(0)
+    expect(deadLinks.get(file)).toEqual(['/missing#anchor'])
+
+    consoleError.mockRestore()
+    fs.rmSync(rootDir, { recursive: true })
+  })
+
+  it('throws during production builds when checkDeadAnchors is true', () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-test-'))
+    const file = createPage(rootDir, 'index')
+    const config = createTestConfig(rootDir)
+
+    runRehypeLinks(config, file, {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'h2',
+          properties: { id: 'existing' },
+          children: [],
+        },
+        {
+          type: 'element',
+          tagName: 'a',
+          properties: { href: '#missing' },
+          children: [],
+        },
+      ],
+    })
+
+    expect(() => runBuildEnd(config)).toThrow(/Found dead anchors:[\s\S]*#missing/)
+
+    fs.rmSync(rootDir, { recursive: true })
+  })
+
+  it('does not throw during production builds when checkDeadAnchors is warn', () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-test-'))
+    const file = createPage(rootDir, 'index')
+    const config = {
+      ...createTestConfig(rootDir),
+      checkDeadAnchors: 'warn',
+    } as Config.Config
+
+    runRehypeLinks(config, file, {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'a',
+          properties: { href: '#missing' },
+          children: [],
+        },
+      ],
+    })
+
+    expect(() => runBuildEnd(config)).not.toThrow()
+
+    consoleWarn.mockRestore()
+    fs.rmSync(rootDir, { recursive: true })
   })
 })

--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -127,6 +127,78 @@ const logger = createLogger(undefined, { allowClearScreen: false, prefix: '[vocs
 /** Collection of dead links across files. */
 export const deadLinks = new Map<string, string[]>()
 
+/** Collection of heading and explicit id anchors across files. */
+export const anchors = new Map<string, Set<string>>()
+
+/** Collection of anchor links across files. */
+export const anchorLinks = new Map<string, AnchorLink[]>()
+
+export type AnchorLink = {
+  anchor: string
+  href: string
+  targetFile: string
+}
+
+export function remarkAnchorLinks(config: Config.Config) {
+  const { checkDeadAnchors, rootDir, srcDir, pagesDir } = config
+  const pagesDirPath = path.join(rootDir, srcDir, pagesDir)
+
+  return () => (tree: MdAst.Root, vfile: VFile) => {
+    if (checkDeadAnchors === false) return
+
+    const file = vfile.path ?? 'unknown'
+    const links: AnchorLink[] = []
+
+    UnistUtil.visit(tree, (node) => {
+      if (!('attributes' in node) || !Array.isArray(node.attributes)) return
+
+      for (const attribute of node.attributes) {
+        if (
+          !attribute ||
+          typeof attribute !== 'object' ||
+          !('type' in attribute) ||
+          attribute.type !== 'mdxJsxAttribute' ||
+          !('name' in attribute) ||
+          (attribute.name !== 'href' && attribute.name !== 'to') ||
+          !('value' in attribute) ||
+          typeof attribute.value !== 'string'
+        )
+          continue
+
+        const anchorLink = createAnchorLink({
+          currentDir: vfile.dirname ?? pagesDirPath,
+          file,
+          href: attribute.value,
+          pagesDirPath,
+        })
+        if (anchorLink) links.push(anchorLink)
+      }
+    })
+
+    if (links.length > 0) {
+      anchorLinks.set(file, links)
+    } else {
+      anchorLinks.delete(file)
+    }
+  }
+}
+
+export function getDeadAnchorLinks() {
+  const deadAnchors = new Map<string, AnchorLink[]>()
+
+  for (const [file, links] of anchorLinks) {
+    const deadLinks = links.filter((link) => {
+      const targetAnchors = anchors.get(link.targetFile)
+      if (!targetAnchors) return false
+      return !targetAnchors.has(link.anchor)
+    })
+
+    if (deadLinks.length > 0) deadAnchors.set(file, deadLinks)
+  }
+
+  return deadAnchors
+}
+
 export function getCompileOptions(
   type: 'txt' | 'react',
   config: Config.Config,
@@ -245,6 +317,7 @@ export function getCompileOptions(
           remarkSteps,
           remarkTerminal,
           remarkSubheading,
+          [remarkAnchorLinks, config] as Pluggable,
           remarkVocsScope,
           ...(markdown?.remarkPlugins ?? []),
         ],
@@ -368,11 +441,20 @@ export function rehypeCodeInLink() {
  * - Collects dead links for reporting at build end
  */
 export function rehypeLinks(config: Config.Config) {
-  const { checkDeadlinks, rootDir, srcDir, pagesDir } = config
+  const { checkDeadAnchors, checkDeadlinks, rootDir, srcDir, pagesDir } = config
   const pagesDirPath = path.join(rootDir, srcDir, pagesDir)
 
   return () => (tree: HAst.Root, vfile: VFile) => {
     const links: string[] = []
+    const file = vfile.path ?? 'unknown'
+    const ids = new Set<string>()
+    const linksToAnchors: AnchorLink[] = []
+
+    UnistUtil.visit(tree, 'element', (node) => {
+      const element = node as HAst.Element
+      const id = element.properties?.['id']
+      if (typeof id === 'string') ids.add(id)
+    })
 
     UnistUtil.visit(tree, 'element', (node) => {
       const element = node as HAst.Element
@@ -381,38 +463,43 @@ export function rehypeLinks(config: Config.Config) {
       const href = element.properties?.['href']
       if (typeof href !== 'string') return
 
-      // Skip external links and hash-only links
-      if (href.match(/^(https?:\/\/|mailto:|tel:|#)/)) return
+      // Skip external links
+      if (href.match(/^(https?:\/\/|mailto:|tel:)/)) return
 
       // Skip URL-encoded backtick paths (e.g., %60Context%60 from Rust Twoslash type hints)
       if (href.includes('%60')) return
 
+      const currentDir = vfile.dirname ?? pagesDirPath
+      const [linkPath = '', hash] = href.split('#')
+      if (checkDeadAnchors !== false) {
+        const anchorLink = createAnchorLink({
+          currentDir,
+          file,
+          href,
+          pagesDirPath,
+        })
+        if (anchorLink) linksToAnchors.push(anchorLink)
+      }
+
+      // Skip hash-only links after collecting anchor links
+      if (href.startsWith('#')) return
+
       // Check if link has .md/.mdx extension to process
-      const hasExtension = extensions.some((ext) => href.endsWith(ext))
+      const hasExtension = extensions.some((ext) => linkPath.endsWith(ext))
 
       // Strip extension and /index
       if (hasExtension) {
         const extPattern = extensions.map((ext) => ext.slice(1)).join('|')
-        const cleanHref = href
+        const cleanLinkPath = linkPath
           .replace(new RegExp(`\\.(${extPattern})$`), '') // remove extension
           .replace(/\/index$/, '') // remove /index
-        element.properties['href'] = cleanHref
+        element.properties['href'] = hash ? `${cleanLinkPath}#${hash}` : cleanLinkPath
       }
 
-      // Check if internal link exists in filesystem
-      const currentDir = vfile.dirname ?? pagesDirPath
-      const [linkPath] = href.split('#')
-      // For absolute paths (starting with /), resolve from pagesDirPath
-      // For relative paths, resolve from current file's directory
-      const resolvedPath = linkPath?.startsWith('/')
-        ? path.join(pagesDirPath, linkPath)
-        : path.resolve(currentDir, linkPath ?? '')
-
       // Check for file existence (try with extensions if not present)
-      const exists =
-        fs.existsSync(resolvedPath) ||
-        extensions.some((ext) => fs.existsSync(`${resolvedPath}${ext}`)) ||
-        extensions.some((ext) => fs.existsSync(`${resolvedPath}/index${ext}`))
+      const resolvedPath = resolveLinkPath(linkPath, currentDir, pagesDirPath)
+      const existingPath = getExistingPath(resolvedPath)
+      const exists = Boolean(existingPath)
 
       // Allow /TODO links but still style them with squiggly underline
       const isTodoLink = linkPath === '/TODO'
@@ -438,10 +525,80 @@ export function rehypeLinks(config: Config.Config) {
       }
     })
 
-    if (links.length > 0) {
-      const file = vfile.path ?? 'unknown'
-      deadLinks.set(file, links)
+    anchors.set(file, ids)
+
+    const allLinksToAnchors = [...(anchorLinks.get(file) ?? []), ...linksToAnchors]
+    if (allLinksToAnchors.length > 0) {
+      anchorLinks.set(file, allLinksToAnchors)
+    } else {
+      anchorLinks.delete(file)
     }
+
+    if (links.length > 0) {
+      deadLinks.set(file, links)
+    } else {
+      deadLinks.delete(file)
+    }
+  }
+}
+
+function createAnchorLink({
+  currentDir,
+  file,
+  href,
+  pagesDirPath,
+}: {
+  currentDir: string
+  file: string
+  href: string
+  pagesDirPath: string
+}) {
+  if (href.match(/^(https?:\/\/|mailto:|tel:)/)) return undefined
+  if (href.includes('%60')) return undefined
+
+  const [linkPath = '', hash] = href.split('#')
+  if (!hash) return undefined
+
+  const resolvedPath = resolveLinkPath(linkPath, currentDir, pagesDirPath)
+  const targetFile = linkPath ? getExistingPath(resolvedPath) : file
+  if (!targetFile) return undefined
+
+  return {
+    anchor: decodeAnchor(hash),
+    href,
+    targetFile,
+  }
+}
+
+function resolveLinkPath(linkPath: string, currentDir: string, pagesDirPath: string) {
+  if (!linkPath) return currentDir
+  return linkPath.startsWith('/')
+    ? path.join(pagesDirPath, linkPath)
+    : path.resolve(currentDir, linkPath)
+}
+
+function getExistingPath(resolvedPath: string) {
+  if (fs.existsSync(resolvedPath) && fs.statSync(resolvedPath).isFile()) return resolvedPath
+
+  for (const ext of extensions) {
+    const pathWithExtension = `${resolvedPath}${ext}`
+    if (fs.existsSync(pathWithExtension) && fs.statSync(pathWithExtension).isFile())
+      return pathWithExtension
+  }
+
+  for (const ext of extensions) {
+    const indexPath = path.join(resolvedPath, `index${ext}`)
+    if (fs.existsSync(indexPath) && fs.statSync(indexPath).isFile()) return indexPath
+  }
+
+  return undefined
+}
+
+function decodeAnchor(anchor: string) {
+  try {
+    return decodeURIComponent(anchor)
+  } catch {
+    return anchor
   }
 }
 

--- a/src/internal/vite-plugins.ts
+++ b/src/internal/vite-plugins.ts
@@ -240,7 +240,7 @@ export function llms(config: Config.Config): PluginOption {
  * @returns Plugin.
  */
 export function mdx(config: Config.Config): PluginOption {
-  const { checkDeadlinks } = config
+  const { checkDeadAnchors, checkDeadlinks } = config
   const plugin = mdxPlugin(Mdx.getCompileOptions('react', config))
 
   let mode: 'development' | 'production' = 'development'
@@ -301,14 +301,31 @@ export function mdx(config: Config.Config): PluginOption {
       }
 
       // Check for dead links
-      if (Mdx.deadLinks.size === 0) return
-      if (checkDeadlinks === 'warn' || checkDeadlinks === false) return
+      if (Mdx.deadLinks.size > 0 && checkDeadlinks !== 'warn' && checkDeadlinks !== false) {
+        const errors: string[] = []
+        for (const [file, links] of Mdx.deadLinks)
+          errors.push(`${file}:\n${links.map((link) => `  - ${link}`).join('\n')}`)
+
+        throw new Error(`Found dead links:\n\n${errors.join('\n\n')}`)
+      }
+
+      // Check for dead anchors
+      if (checkDeadAnchors === false) return
+
+      const deadAnchorLinks = Mdx.getDeadAnchorLinks()
+      if (deadAnchorLinks.size === 0) return
 
       const errors: string[] = []
-      for (const [file, links] of Mdx.deadLinks)
-        errors.push(`${file}:\n${links.map((link) => `  - ${link}`).join('\n')}`)
+      for (const [file, links] of deadAnchorLinks)
+        errors.push(`${file}:\n${links.map((link) => `  - ${link.href}`).join('\n')}`)
 
-      throw new Error(`Found dead links:\n\n${errors.join('\n\n')}`)
+      const message = `Found dead anchors:\n\n${errors.join('\n\n')}`
+      if (checkDeadAnchors === 'warn') {
+        logger.warn(message, { timestamp: true })
+        return
+      }
+
+      throw new Error(message)
     },
   }
 }


### PR DESCRIPTION
## Summary

- add `checkDeadAnchors` config for build-time fragment validation
- collect anchors from rendered MDX IDs and anchor links from Markdown, rendered anchors, and MDX JSX `href`/`to` props
- report dead anchors during production builds with throw or warn behavior
- add unit coverage for valid, invalid, disabled, warn, index-route, and missing-page cases