### PR TITLE
fix: handle inline markup in heading subtext

### DIFF
--- a/.changeset/heading-subtext-inline-markup.md
+++ b/.changeset/heading-subtext-inline-markup.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed heading subtext breaking when its description contained inline markdown such as inline code or emphasis.

--- a/src/internal/mdx.test.ts
+++ b/src/internal/mdx.test.ts
@@ -1,13 +1,19 @@
+import type * as MdAst from 'mdast'
+import remarkFrontmatter from 'remark-frontmatter'
+import remarkParse from 'remark-parse'
 import ruby from 'shiki/langs/ruby.mjs'
+import { unified } from 'unified'
 import { describe, expect, it } from 'vitest'
 import * as Config from './config.js'
 import {
   getCompileOptions,
   remarkCodeTitle,
+  remarkDefaultFrontmatter,
   remarkFilename,
   remarkFileTree,
   remarkLangCommaAttrs,
   remarkRestoreUnknownTextDirectives,
+  remarkSubheading,
 } from './mdx.js'
 
 type CodeNode = {
@@ -60,6 +66,72 @@ function transformCodeNode(
   remarkCodeTitle(getCodeTitlePlugin(config))(tree as never)
 
   return tree.children[0] as CodeNode
+}
+
+describe('remarkDefaultFrontmatter', () => {
+  it('infers title and description from heading subtext with inline code', async () => {
+    const tree = await runRemark(
+      '# Common Package [How `packages/common` is structured, why it exists]',
+      [remarkDefaultFrontmatter],
+    )
+    const frontmatter = tree.children[0]
+
+    expect(frontmatter).toMatchObject({
+      type: 'yaml',
+      value:
+        'title: "Common Package"\ndescription: "How packages/common is structured, why it exists"',
+    })
+  })
+})
+
+describe('remarkSubheading', () => {
+  it('extracts heading subtext with inline markdown nodes', async () => {
+    const tree = await runRemark(
+      [
+        '---',
+        'title: Test',
+        '---',
+        '',
+        '# **Common** Package [How `packages/common` is *structured*]',
+      ].join('\n'),
+      [remarkFrontmatter, remarkSubheading],
+    )
+    const hgroup = tree.children[1] as MdAst.Paragraph
+    const heading = hgroup.children[0] as unknown as MdAst.Heading
+    const subheading = hgroup.children[1] as unknown as MdAst.Paragraph
+
+    expect(stripPositions(heading.children)).toEqual([
+      {
+        type: 'strong',
+        children: [{ type: 'text', value: 'Common' }],
+      },
+      { type: 'text', value: ' Package' },
+    ])
+    expect(stripPositions(subheading.children)).toEqual([
+      { type: 'text', value: 'How ' },
+      { type: 'inlineCode', value: 'packages/common' },
+      { type: 'text', value: ' is ' },
+      {
+        type: 'emphasis',
+        children: [{ type: 'text', value: 'structured' }],
+      },
+    ])
+  })
+})
+
+async function runRemark(markdown: string, plugins: unknown[]) {
+  const processor = unified().use(remarkParse)
+  for (const plugin of plugins) processor.use(plugin as never)
+  const tree = processor.parse(markdown) as MdAst.Root
+  await processor.run(tree)
+  return tree
+}
+
+function stripPositions(children: MdAst.PhrasingContent[]): unknown[] {
+  return children.map(({ position: _, ...child }) => {
+    if ('children' in child) return { ...child, children: stripPositions(child.children) }
+    return child
+  })
 }
 
 describe('remarkFilename', () => {

--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -809,17 +809,15 @@ export function remarkDefaultFrontmatter() {
     const heading = (tree.children.find(
       (node) => node.type === 'heading' && (node as { depth: number }).depth === 1,
     ) ?? tree.children.find((node) => node.type === 'heading')) as
-      | { type: 'heading'; children: { type: string; value?: string }[] }
+      | { type: 'heading'; children: MdAst.PhrasingContent[] }
       | undefined
     if (!heading) return
 
-    // Extract text content
-    const textContent = heading.children.map((child) => child.value ?? '').join('')
-
-    // Parse title and description: "My Title [Description here]"
-    const match = textContent.match(/^(.+?)\s*\[(.+)\]$/)
-    const title = match?.[1]?.trim() ?? textContent.trim()
-    const description = match?.[2]?.trim()
+    const subheading = extractSubheading(heading.children)
+    const title = getPhrasingContentText(subheading?.headingChildren ?? heading.children).trim()
+    const description = subheading
+      ? getPhrasingContentText(subheading.subheadingChildren).trim()
+      : undefined
 
     // Build new frontmatter
     const newLines: string[] = []
@@ -1035,25 +1033,15 @@ export function remarkStripFrontmatter() {
  * Converts `# Title [Subheading text]` into a `<header>` with both title and subtitle.
  */
 export function remarkSubheading() {
-  const subheadingRegex = / \[(.*)\]$/
-
   return (tree: MdAst.Root) => {
     UnistUtil.visit(tree, 'heading', (node, index, parent) => {
       if (index === undefined || !parent) return
       if (node.depth !== 1) return
       if (node.children.length === 0) return
 
-      // Find child with subheading pattern
-      const textChild = node.children.find(
-        (child): child is MdAst.Text => child.type === 'text' && subheadingRegex.test(child.value),
-      )
-      if (!textChild) return
-
-      // Extract and remove subheading from text
-      const match = textChild.value.match(subheadingRegex)
-      if (!match) return
-      const subheading = match[1]
-      textChild.value = textChild.value.replace(match[0], '')
+      const subheading = extractSubheading(node.children)
+      if (!subheading) return
+      node.children = subheading.headingChildren
 
       // Build hgroup wrapper with h1 and optional subtitle (p)
       const hgroup = {
@@ -1061,12 +1049,12 @@ export function remarkSubheading() {
         data: { hName: 'hgroup' },
         children: [
           node as unknown as MdAst.PhrasingContent,
-          ...(subheading
+          ...(subheading.subheadingChildren.length > 0
             ? [
                 {
                   type: 'paragraph',
                   data: { hName: 'p' },
-                  children: [{ type: 'text', value: subheading }],
+                  children: subheading.subheadingChildren,
                 } as unknown as MdAst.PhrasingContent,
               ]
             : []),
@@ -1078,6 +1066,64 @@ export function remarkSubheading() {
       return UnistUtil.SKIP
     })
   }
+}
+
+type Subheading = {
+  headingChildren: MdAst.PhrasingContent[]
+  subheadingChildren: MdAst.PhrasingContent[]
+}
+
+export function extractSubheading(children: MdAst.PhrasingContent[]): Subheading | undefined {
+  const lastChild = children[children.length - 1]
+  if (!isText(lastChild) || !lastChild.value.endsWith(']')) return
+
+  for (let index = children.length - 1; index >= 0; index--) {
+    const child = children[index]
+    if (!isText(child)) continue
+
+    const openIndex = child.value.lastIndexOf(' [')
+    if (openIndex === -1) continue
+
+    const headingChildren = clonePhrasingContent(children.slice(0, index))
+    const headingText = child.value.slice(0, openIndex)
+    if (headingText) headingChildren.push({ ...child, value: headingText })
+
+    const subheadingChildren = clonePhrasingContent(children.slice(index + 1))
+    const subheadingText = child.value.slice(openIndex + 2)
+    if (subheadingText) subheadingChildren.unshift({ ...child, value: subheadingText })
+
+    const finalChild = subheadingChildren[subheadingChildren.length - 1]
+    if (!isText(finalChild)) return
+    finalChild.value = finalChild.value.slice(0, -1)
+
+    return {
+      headingChildren,
+      subheadingChildren: subheadingChildren.filter(
+        (child) => !isText(child) || child.value.length > 0,
+      ),
+    }
+  }
+
+  return undefined
+}
+
+export function getPhrasingContentText(children: MdAst.PhrasingContent[]): string {
+  return children.map(getPhrasingNodeText).join('')
+}
+
+function clonePhrasingContent(children: MdAst.PhrasingContent[]) {
+  return children.map((child) => structuredClone(child))
+}
+
+function getPhrasingNodeText(child: MdAst.PhrasingContent): string {
+  if ('value' in child && typeof child.value === 'string') return child.value
+  if ('children' in child) return getPhrasingContentText(child.children)
+  if ('alt' in child && typeof child.alt === 'string') return child.alt
+  return ''
+}
+
+function isText(child: MdAst.PhrasingContent | undefined): child is MdAst.Text {
+  return child?.type === 'text'
 }
 
 const filenameRegex = /filename=["']([^"']+)["']/

--- a/src/internal/search.test.ts
+++ b/src/internal/search.test.ts
@@ -746,6 +746,26 @@ Some content.
     `)
   })
 
+  it('handles title descriptions with inline code', () => {
+    const content = `
+# Common Package [How \`packages/common\` is structured, why it exists]
+
+Some content.
+`
+    expect(Search.extract(content, config).sections).toMatchInlineSnapshot(`
+      [
+        {
+          "anchor": "common-package",
+          "isPage": true,
+          "subtitle": "How packages/common is structured, why it exists",
+          "text": " Some content.",
+          "title": "Common Package",
+          "titles": [],
+        },
+      ]
+    `)
+  })
+
   it('includes JSX text content', () => {
     const content = `
 # Title

--- a/src/internal/search.ts
+++ b/src/internal/search.ts
@@ -14,6 +14,7 @@ import { unified } from 'unified'
 import * as UnistUtil from 'unist-util-visit'
 import * as yaml from 'yaml'
 import type * as Config from './config.js'
+import { extractSubheading, getPhrasingContentText } from './mdx.js'
 import * as Path from './path.js'
 import { searchFields, storeFields, tokenize } from './search.client.js'
 import * as Sidebar from './sidebar.js'
@@ -337,14 +338,17 @@ export function extract(source: string, _config: Config.Config): extract.ReturnT
   const headingPositions = tree.children
     .filter((node): node is MdAst.Heading => node.type === 'heading')
     .map((heading) => {
-      const rawTitle = mdastToString(heading).trim()
-      const subtitleMatch = rawTitle.match(/ \[(.+)\]$/)
+      const subheading = extractSubheading(heading.children)
+      const title = getPhrasingContentText(subheading?.headingChildren ?? heading.children).trim()
+      const subtitle = subheading
+        ? getPhrasingContentText(subheading.subheadingChildren).trim()
+        : ''
       return {
         depth: heading.depth,
         endOffset: heading.position?.end.offset ?? 0,
         startOffset: heading.position?.start.offset ?? 0,
-        subtitle: subtitleMatch?.[1] ?? '',
-        title: subtitleMatch ? rawTitle.replace(/ \[.+\]$/, '') : rawTitle,
+        subtitle,
+        title,
       }
     })
 


### PR DESCRIPTION
## Summary

- Preserve inline markdown nodes when extracting heading subtext.
- Reuse subtext extraction for inferred frontmatter metadata.
- Add regression coverage for https://github.com/wevm/vocs/issues/473.