### PR TITLE
fix: skip `mdRouter` twin resolution for static assets

### DIFF
--- a/.changeset/md-router-static-assets.md
+++ b/.changeset/md-router-static-assets.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed multi-second latency when CLI and AI-agent user-agents request static assets (`.json`, `.svg`, etc.) by skipping markdown twin resolution for non-page requests.

--- a/src/waku/internal/middleware/md-router.test.ts
+++ b/src/waku/internal/middleware/md-router.test.ts
@@ -137,4 +137,89 @@ describe('middleware', () => {
     expect(await response.text()).toBe('# Hello from disk')
     expect(readFile).toHaveBeenCalledOnce()
   })
+
+  it('passes static assets through for AI agents without resolving a twin', async () => {
+    process.env['NODE_ENV'] = 'production'
+
+    const { readFile } = await import('node:fs/promises')
+    const fetchSpy = vi.fn()
+    globalThis.fetch = fetchSpy
+
+    const response = await request('http://localhost/specs/v0.1/openapi.json', {
+      'user-agent': 'Mozilla/5.0 (compatible; ClaudeBot/1.0; +claudebot@anthropic.com)',
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('text/html')
+    expect(await response.text()).toBe('<p>ok</p>')
+    expect(readFile).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('passes static assets through for terminal user-agents', async () => {
+    process.env['NODE_ENV'] = 'production'
+
+    const { readFile } = await import('node:fs/promises')
+    const fetchSpy = vi.fn()
+    globalThis.fetch = fetchSpy
+
+    const response = await request('http://localhost/specs/v0.1/openapi.json', {
+      'user-agent': 'curl/8.7.1',
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('<p>ok</p>')
+    expect(readFile).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('passes static assets through even when text/markdown is accepted', async () => {
+    process.env['NODE_ENV'] = 'production'
+
+    const { readFile } = await import('node:fs/promises')
+    const fetchSpy = vi.fn()
+    globalThis.fetch = fetchSpy
+
+    const response = await request('http://localhost/specs/openapi.json', {
+      accept: 'text/markdown',
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('<p>ok</p>')
+    expect(readFile).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('passes generated markdown twins through without re-resolving', async () => {
+    process.env['NODE_ENV'] = 'production'
+
+    const { readFile } = await import('node:fs/promises')
+    const fetchSpy = vi.fn()
+    globalThis.fetch = fetchSpy
+
+    const response = await request('http://localhost/assets/md/docs.md', {
+      'user-agent': 'Mozilla/5.0 (compatible; GPTBot/1.0; +https://openai.com/gptbot)',
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('<p>ok</p>')
+    expect(readFile).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('serves markdown for clean routes whose parent segments contain dots', async () => {
+    process.env['NODE_ENV'] = 'production'
+
+    const { readFile } = await import('node:fs/promises')
+    vi.mocked(readFile).mockResolvedValue('# Hello from disk')
+
+    const response = await request('http://localhost/docs/v2.0/intro', {
+      'user-agent': 'Mozilla/5.0 (compatible; GPTBot/1.0; +https://openai.com/gptbot)',
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('text/markdown; charset=utf-8')
+    expect(await response.text()).toBe('# Hello from disk')
+    expect(readFile).toHaveBeenCalledOnce()
+  })
 })

--- a/src/waku/internal/middleware/md-router.ts
+++ b/src/waku/internal/middleware/md-router.ts
@@ -97,6 +97,10 @@ export function middleware(): MiddlewareHandler {
   return async (context, next) => {
     const url = new URL(context.req.url)
 
+    // Generated markdown twins are static output; routing them back through
+    // twin resolution would trigger a recursive self-fetch.
+    if (url.pathname.startsWith('/assets/md/')) return next()
+
     const userAgent = context.req.header('user-agent') ?? ''
     const isOgBot = ogBotUserAgents.some((agent) => userAgent.includes(agent))
     if (isOgBot) return next()
@@ -126,6 +130,12 @@ export function middleware(): MiddlewareHandler {
     }
 
     const isMarkdownRequest = url.pathname.endsWith('.md')
+
+    // Static assets (`.json`, `.svg`, `.png`, ...) have no markdown twin. Skip
+    // twin resolution so a disk miss never falls back to a slow self-fetch.
+    const filename = url.pathname.split('/').pop() ?? ''
+    if (!isMarkdownRequest && filename.includes('.')) return next()
+
     if (!isMarkdownRequest && (isSearchEngine || (!isAiAgent && !isTerminal && !acceptsMarkdown)))
       return next()
 
@@ -148,7 +158,7 @@ export function middleware(): MiddlewareHandler {
 
     context.res = new Response(text, {
       headers: {
-        'Content-Type': `${url.pathname.endsWith('.txt') ? 'text/plain' : 'text/markdown'}; charset=utf-8`,
+        'Content-Type': 'text/markdown; charset=utf-8',
       },
     })
     return


### PR DESCRIPTION
`mdRouter` tried to serve a Markdown twin for every request from CLI, AI-agent, or `text/markdown` user-agents, including static assets like `.json`, `.svg`, and `.png`.

When no twin existed on disk it fell back to an HTTP self-fetch meant for auth-protected deployments. For the generated `/assets/md/*.md` twins that self-fetch re-entered the middleware and recursed, adding multiple seconds of latency before the real asset was served.

Static assets (any non-`.md` path with a file extension) and generated `/assets/md/` twins now pass straight through without twin resolution. Only the final path segment is inspected, so clean routes with dots in parent segments still negotiate Markdown.

The guards live in the middleware itself, since the production `serve-node` runtime never had the `/assets/` guard the build adapter applies only at build time.

Fixes https://github.com/wevm/vocs/issues/479
