### PR TITLE
fix: apply user-configured `remarkPlugins` in llms and search compilation

### DIFF
--- a/.changeset/markdown-plugins-llms-search.md
+++ b/.changeset/markdown-plugins-llms-search.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed user-configured `remarkPlugins` (e.g. `remark-math`) not being applied during llms and search compilation.

--- a/src/internal/mdx.test.ts
+++ b/src/internal/mdx.test.ts
@@ -295,6 +295,17 @@ describe('getCompileOptions', () => {
     expect(codeNode.lang).toBe('ts')
     expect(codeNode.meta).toBe('[example.ts]')
   })
+
+  it('threads user-configured remark plugins into the txt profile', () => {
+    function userRemarkPlugin() {}
+    const config = Config.define({
+      markdown: { remarkPlugins: [userRemarkPlugin] },
+      rootDir: process.cwd(),
+    })
+
+    expect(getCompileOptions('txt', config).remarkPlugins).toContain(userRemarkPlugin)
+    expect(getCompileOptions('react', config).remarkPlugins).toContain(userRemarkPlugin)
+  })
 })
 
 describe('remarkRestoreUnknownTextDirectives', () => {

--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -213,6 +213,9 @@ export function getCompileOptions(
           remarkStripFrontmatter,
           remarkStripJs,
           remarkStripInlineCache,
+          // User plugins extend the parser (e.g. `remark-math`) so syntax
+          // recognized in the React build also parses for llms/search.
+          ...(markdown?.remarkPlugins ?? []),
         ],
       }
     if (type === 'react')

--- a/src/internal/search.test.ts
+++ b/src/internal/search.test.ts
@@ -1,3 +1,4 @@
+import type * as MdAst from 'mdast'
 import { describe, expect, it } from 'vitest'
 import * as Config from './config.js'
 import * as Search from './search.js'
@@ -836,6 +837,25 @@ Some content here.
         },
       ]
     `)
+  })
+
+  it('applies user-configured remark plugins from config', () => {
+    function remarkUppercaseHeadings() {
+      return (tree: MdAst.Root) => {
+        for (const node of tree.children) {
+          if (node.type !== 'heading') continue
+          for (const child of node.children)
+            if (child.type === 'text') child.value = child.value.toUpperCase()
+        }
+      }
+    }
+
+    const customConfig = Config.define({
+      markdown: { remarkPlugins: [remarkUppercaseHeadings] },
+    })
+
+    const { sections } = Search.extract('# hello world\n\nSome text.', customConfig)
+    expect(sections[0]?.title).toBe('HELLO WORLD')
   })
 })
 

--- a/src/internal/search.ts
+++ b/src/internal/search.ts
@@ -311,13 +311,16 @@ type Section = {
  * - `content`: raw markdown (sliced from source) for rendering in search UI
  * - `text`: stripped plain text (directives/JSX removed) for search indexing
  */
-export function extract(source: string, _config: Config.Config): extract.ReturnType {
+export function extract(source: string, config: Config.Config): extract.ReturnType {
   const remarkPlugins = [
     remarkFrontmatter,
     remarkDirective,
     remarkGfm,
     remarkStripJsx,
     remarkStripDirectives,
+    // User plugins extend the parser (e.g. `remark-math`) so syntax
+    // recognized in the React build also parses during indexing.
+    ...(config.markdown?.remarkPlugins ?? []),
   ]
 
   // Extract frontmatter with regex (avoids extra parse)


### PR DESCRIPTION
User-configured `remarkPlugins` were only applied during React compilation. The `getCompileOptions('txt')` profile (llms.txt) and the search `extract()` function used hardcoded plugin lists, so parser-extending plugins like `remark-math` were absent there.

Math syntax that rendered fine in the React build crashed llms/search compilation with `Could not parse expression with acorn`, breaking the whole build. Both pipelines now thread `markdown.remarkPlugins` through, matching the React profile.

Closes https://github.com/wevm/vocs/issues/480
