### PR TITLE
fix(mcp): ack JSON-RPC notifications with `202` instead of hanging

### DIFF
--- a/.changeset/fix-mcp-notification-hang.md
+++ b/.changeset/fix-mcp-notification-hang.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed the MCP Streamable HTTP endpoint hanging on JSON-RPC notifications (e.g. `notifications/initialized`) by acking payloads that contain no requests with `202 Accepted`.

--- a/src/internal/mcp-transport.test.ts
+++ b/src/internal/mcp-transport.test.ts
@@ -1,0 +1,132 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import {
+  isJSONRPCRequest,
+  type JSONRPCMessage,
+  type JSONRPCNotification,
+  type JSONRPCRequest,
+} from '@modelcontextprotocol/sdk/types.js'
+import { describe, expect, it } from 'vitest'
+import { WebStreamableHTTPServerTransport } from './mcp-transport.js'
+
+const notification: JSONRPCNotification = {
+  jsonrpc: '2.0',
+  method: 'notifications/initialized',
+}
+
+function request(id: number, method: string): JSONRPCRequest {
+  return { jsonrpc: '2.0', id, method }
+}
+
+function replyOnRequest(transport: WebStreamableHTTPServerTransport) {
+  transport.onmessage = (message) => {
+    if (isJSONRPCRequest(message)) transport.send({ jsonrpc: '2.0', id: message.id, result: {} })
+  }
+}
+
+describe('WebStreamableHTTPServerTransport', () => {
+  it('acks a notification with 202 without hanging', async () => {
+    const transport = new WebStreamableHTTPServerTransport()
+    const received: JSONRPCMessage[] = []
+    transport.onmessage = (message) => received.push(message)
+
+    const response = await transport.handleRequest(notification)
+
+    expect(response.status).toBe(202)
+    expect(await response.text()).toBe('')
+    expect(received).toEqual([notification])
+  })
+
+  it('acks a batch of only notifications with 202', async () => {
+    const transport = new WebStreamableHTTPServerTransport()
+    const received: JSONRPCMessage[] = []
+    transport.onmessage = (message) => received.push(message)
+
+    const response = await transport.handleRequest([notification, notification])
+
+    expect(response.status).toBe(202)
+    expect(received).toHaveLength(2)
+  })
+
+  it('streams an SSE response for a request', async () => {
+    const transport = new WebStreamableHTTPServerTransport()
+    replyOnRequest(transport)
+
+    const response = await transport.handleRequest(request(1, 'tools/list'), true)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('text/event-stream')
+    expect(await response.text()).toContain('"id":1')
+  })
+
+  it('resolves a JSON response for a request', async () => {
+    const transport = new WebStreamableHTTPServerTransport()
+    replyOnRequest(transport)
+
+    const response = await transport.handleRequest(request(1, 'tools/list'), false)
+
+    expect(response.headers.get('content-type')).toContain('application/json')
+    expect(await response.json()).toEqual({ jsonrpc: '2.0', id: 1, result: {} })
+  })
+
+  it('still replies to a request mixed into a notification batch', async () => {
+    const transport = new WebStreamableHTTPServerTransport()
+    const received: JSONRPCMessage[] = []
+    transport.onmessage = (message) => {
+      received.push(message)
+      if (isJSONRPCRequest(message)) transport.send({ jsonrpc: '2.0', id: message.id, result: {} })
+    }
+
+    const response = await transport.handleRequest([notification, request(1, 'tools/list')], false)
+
+    expect(await response.json()).toEqual({ jsonrpc: '2.0', id: 1, result: {} })
+    expect(received).toHaveLength(2)
+  })
+
+  it('assigns a session id on initialize and echoes it on the ack', async () => {
+    const transport = new WebStreamableHTTPServerTransport({
+      sessionIdGenerator: () => 'session-1',
+    })
+    replyOnRequest(transport)
+
+    await transport.handleRequest(request(1, 'initialize'), false)
+    expect(transport.sessionId).toBe('session-1')
+
+    const ack = await transport.handleRequest(notification)
+    expect(ack.status).toBe(202)
+    expect(ack.headers.get('mcp-session-id')).toBe('session-1')
+  })
+})
+
+describe('WebStreamableHTTPServerTransport with a real McpServer', () => {
+  it('does not hang on `notifications/initialized` (#484)', async () => {
+    const transport = new WebStreamableHTTPServerTransport({
+      sessionIdGenerator: () => 'session-1',
+    })
+    const server = new McpServer({ name: 'test', version: '1.0.0' })
+    await server.connect(transport as never)
+
+    const init = await transport.handleRequest(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-06-18',
+          capabilities: {},
+          clientInfo: { name: 'repro', version: '0.1.0' },
+        },
+      },
+      false,
+    )
+    const initBody = await init.json()
+    expect(initBody.id).toBe(1)
+    expect(initBody.result).toBeDefined()
+
+    // The server never replies to this notification, so the transport must ack
+    // it itself. Awaiting the JSON-mode promise would hang forever otherwise.
+    const ack = await transport.handleRequest(notification, false)
+    expect(ack.status).toBe(202)
+
+    await server.close()
+  })
+})

--- a/src/internal/mcp-transport.ts
+++ b/src/internal/mcp-transport.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js'
+import { isJSONRPCRequest, type JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js'
 
 /**
  * SSE Server Transport for Web APIs (Request/Response).
@@ -67,31 +67,20 @@ export class WebSSEServerTransport {
    * Returns the response to send back.
    */
   async handlePostMessage(body: unknown): Promise<Response> {
-    console.log('[MCP:SSE] handlePostMessage', JSON.stringify(body))
-    if (!this._writer) {
-      console.log('[MCP:SSE] No writer - SSE connection not established')
-      return new Response('SSE connection not established', { status: 500 })
-    }
+    if (!this._writer) return new Response('SSE connection not established', { status: 500 })
 
     try {
-      const message = body as JSONRPCMessage
-      this.onmessage?.(message)
-      console.log('[MCP:SSE] Message dispatched, returning 202')
+      this.onmessage?.(body as JSONRPCMessage)
       return new Response('Accepted', { status: 202 })
     } catch (error) {
-      console.error('[MCP:SSE] Error handling message:', error)
       this.onerror?.(error as Error)
       return new Response(`Invalid message: ${String(error)}`, { status: 400 })
     }
   }
 
   async send(message: JSONRPCMessage): Promise<void> {
-    console.log('[MCP:SSE] send', JSON.stringify(message).slice(0, 200))
-    if (!this._writer) {
-      throw new Error('Not connected')
-    }
+    if (!this._writer) throw new Error('Not connected')
     await this._write(`event: message\ndata: ${JSON.stringify(message)}\n\n`)
-    console.log('[MCP:SSE] Message sent to SSE stream')
   }
 
   async close(): Promise<void> {
@@ -136,33 +125,37 @@ export class WebStreamableHTTPServerTransport {
    * Handle a POST request. Returns a Response (either SSE stream or JSON).
    */
   async handleRequest(body: unknown, useSSE = true): Promise<Response> {
-    console.log('[MCP:HTTP] handleRequest', { useSSE, body: JSON.stringify(body).slice(0, 200) })
-    const message = body as JSONRPCMessage
+    const messages = Array.isArray(body) ? (body as JSONRPCMessage[]) : [body as JSONRPCMessage]
 
-    if (!this.sessionId && 'method' in message && message.method === 'initialize') {
+    const isInitialize = messages.some(
+      (message) => 'method' in message && message.method === 'initialize',
+    )
+    if (!this.sessionId && isInitialize) {
       this.sessionId = this._options.sessionIdGenerator?.() ?? randomUUID()
-      console.log('[MCP:HTTP] Session initialized:', this.sessionId)
       this._options.onsessioninitialized?.(this.sessionId)
     }
 
+    // Notifications/responses get no JSON-RPC reply -- ack with 202 instead of hanging.
+    if (!messages.some(isJSONRPCRequest)) {
+      for (const message of messages) this.onmessage?.(message)
+      return new Response(null, {
+        status: 202,
+        headers: this.sessionId ? { 'mcp-session-id': this.sessionId } : {},
+      })
+    }
+
     if (useSSE) {
-      console.log('[MCP:HTTP] Using SSE response mode')
       const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>()
       this._responseWriter = writable.getWriter()
 
       this._pendingResponse = async (response) => {
-        console.log(
-          '[MCP:HTTP] SSE pending response received',
-          JSON.stringify(response).slice(0, 200),
-        )
         await this._write(`event: message\ndata: ${JSON.stringify(response)}\n\n`)
         try {
           await this._responseWriter?.close()
         } catch {}
       }
 
-      this.onmessage?.(message)
-      console.log('[MCP:HTTP] Message dispatched, returning SSE stream')
+      for (const message of messages) this.onmessage?.(message)
 
       return new Response(readable, {
         headers: {
@@ -173,21 +166,15 @@ export class WebStreamableHTTPServerTransport {
       })
     }
 
-    console.log('[MCP:HTTP] Using JSON response mode')
     return new Promise((resolve) => {
       this._pendingResponse = (response) => {
-        console.log(
-          '[MCP:HTTP] JSON pending response received',
-          JSON.stringify(response).slice(0, 200),
-        )
         resolve(
           Response.json(response, {
             headers: this.sessionId ? { 'mcp-session-id': this.sessionId } : {},
           }),
         )
       }
-      this.onmessage?.(message)
-      console.log('[MCP:HTTP] Message dispatched, waiting for response')
+      for (const message of messages) this.onmessage?.(message)
     })
   }
 


### PR DESCRIPTION
The streamable HTTP transport set a pending-response callback for every POST and waited for the SDK to reply. JSON-RPC notifications such as `notifications/initialized` never get a reply, so the request hung: SSE responses stayed open and JSON responses never resolved, breaking MCP clients mid-handshake.

`handleRequest` now detects payloads with no requests (notifications and/or responses, including all-notification batches), dispatches them, and returns `202 Accepted` immediately per the Streamable HTTP spec. Mixed batches still follow normal request/response behavior.

Also drops the leftover `[MCP:...]` debug logging from the transport.

Closes https://github.com/wevm/vocs/issues/484
