### PR TITLE
fix(waku): bundle `react-server-dom-webpack` in server environments

### DIFF
--- a/.changeset/rsdw-no-external.md
+++ b/.changeset/rsdw-no-external.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed `vocs dev` crashing on fresh npm/bun installs with a missing `react-server` condition error by keeping `react-server-dom-webpack` bundled in the RSC server environments.

--- a/src/waku/internal/vite-plugins.ts
+++ b/src/waku/internal/vite-plugins.ts
@@ -45,6 +45,27 @@ export function buildId(): Plugin {
 }
 
 /**
+ * Keeps `react-server-dom-webpack` bundled in the server environments so Waku's rsdw
+ * patch can redirect it to plugin-rsc's vendored build. npm and bun auto-install the
+ * peer, which would otherwise load natively with `react` missing the `react-server`
+ * condition and crash the dev server.
+ */
+export function rsdwNoExternal(): Plugin {
+  const rsdw = 'react-server-dom-webpack'
+  return {
+    name: 'vocs:rsdw-no-external',
+    config() {
+      return {
+        environments: {
+          rsc: { resolve: { noExternal: [rsdw] } },
+          ssr: { resolve: { noExternal: [rsdw] } },
+        },
+      }
+    },
+  }
+}
+
+/**
  * Builds a script to preview the build output.
  */
 export function preview(): Plugin {

--- a/src/waku/vite.ts
+++ b/src/waku/vite.ts
@@ -35,6 +35,7 @@ export async function vocs(options: vocs.Options = {}): Promise<PluginOption[]> 
 
   return [
     vocs_core(),
+    Plugins.rsdwNoExternal(),
     Plugins.allowServer(),
     PluginRsc({
       serverHandler: false,


### PR DESCRIPTION
Fresh projects (`bun create vocs`, then `npm`/`bun install`) crash on `vocs dev` with `The "react" package in this environment is not configured correctly. The "react-server" condition must be enabled...`.

`npm` and `bun` auto-install `react-server-dom-webpack` as a peer, but `@vitejs/plugin-rsc`'s framework crawl only inspects `dependencies` and never detects it, so it falls back to its vendored React Server DOM build.

Waku's runtime still imports the real `react-server-dom-webpack/server.edge`, which the module runner externalizes and Node loads natively, resolving `react` without the `react-server` condition and crashing the dev server.

Adding `react-server-dom-webpack` to the `rsc` and `ssr` environments' `noExternal` keeps it inside Vite's pipeline, where Waku's existing patch redirects it to the vendored build. `pnpm` setups (where the package is absent) are unaffected.

Fixes https://github.com/wevm/vocs/issues/450
