### PR TITLE
feat: allow configuring MCP URL

### DIFF
--- a/.changeset/lucky-mayflies-walk.md
+++ b/.changeset/lucky-mayflies-walk.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Added support for configuring the MCP URL copied by the Ask AI menu.

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -215,6 +215,12 @@ export type Config<partial extends boolean = false> = MaybePartial<
       | {
           /** Enable MCP server endpoint at `/api/mcp`. */
           enabled?: boolean | undefined
+          /**
+           * MCP server URL copied by the Ask AI menu.
+           *
+           * Defaults to the same-origin `/api/mcp` endpoint.
+           */
+          url?: string | undefined
           /** Source code adapters for navigating codebases. */
           sources?: readonly McpSource.Adapter[] | undefined
         }

--- a/src/internal/mcp.ts
+++ b/src/internal/mcp.ts
@@ -17,6 +17,12 @@ export type McpConfig = {
    */
   enabled?: boolean | undefined
   /**
+   * MCP server URL copied by the Ask AI menu.
+   *
+   * Defaults to the same-origin `/api/mcp` endpoint.
+   */
+  url?: string | undefined
+  /**
    * Source code adapters for navigating codebases.
    * Use `McpSource.github()` to fetch from GitHub.
    *

--- a/src/react/internal/AskAi.tsx
+++ b/src/react/internal/AskAi.tsx
@@ -10,6 +10,7 @@ import SimpleIconsClaude from '~icons/simple-icons/claude'
 import SimpleIconsModelcontextprotocol from '~icons/simple-icons/modelcontextprotocol'
 import SimpleIconsOpenai from '~icons/simple-icons/openai'
 import { useConfig } from '../useConfig.js'
+import { resolveMcpUrl } from './resolveMcpUrl.js'
 
 export function AskAi(props: AskAi.Props) {
   const { className } = props
@@ -100,8 +101,8 @@ export function AskAi(props: AskAi.Props) {
 
   const mcpUrl = React.useMemo(() => {
     if (typeof window === 'undefined') return ''
-    return `${window.location.origin}/api/mcp`
-  }, [])
+    return resolveMcpUrl(mcp, window.location.origin)
+  }, [mcp])
 
   return (
     <Menu.Root open={menuOpen} onOpenChange={setMenuOpen}>

--- a/src/react/internal/resolveMcpUrl.test.ts
+++ b/src/react/internal/resolveMcpUrl.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'vitest'
+import { resolveMcpUrl } from './resolveMcpUrl.js'
+
+describe('resolveMcpUrl', () => {
+  test('defaults to the same-origin MCP endpoint', () => {
+    expect(resolveMcpUrl({ enabled: true }, 'https://vocs.dev')).toBe('https://vocs.dev/api/mcp')
+  })
+
+  test('uses the configured MCP URL', () => {
+    expect(
+      resolveMcpUrl({ enabled: true, url: 'https://mcp.example.com/mcp' }, 'https://vocs.dev'),
+    ).toBe('https://mcp.example.com/mcp')
+  })
+})

--- a/src/react/internal/resolveMcpUrl.ts
+++ b/src/react/internal/resolveMcpUrl.ts
@@ -1,0 +1,5 @@
+import type * as Config from '../../internal/config.js'
+
+export function resolveMcpUrl(mcp: Config.Config['mcp'], origin: string) {
+  return mcp?.url || `${origin}/api/mcp`
+}


### PR DESCRIPTION
## Summary

Adds an optional `mcp.url` config value for the Ask AI menu's "Copy MCP URL" action.

When `mcp.url` is not configured, the menu keeps the existing behavior and copies `${origin}/api/mcp`. Static deployments that serve MCP somewhere else can now keep `mcp.enabled` on while advertising the correct endpoint.

## Why

Some static deployments pair a fully static Vocs build with a separate or custom MCP endpoint, for example a Cloudflare Pages `_worker.js` serving `/mcp` or `/api/mcp`. This lets those deployments expose the right MCP URL without patching `AskAi` locally.

## Validation

- `pnpm vitest src/react/internal/resolveMcpUrl.test.ts --run`
- `pnpm check:types`
- `pnpm check`
- `pnpm test`
