### PR TITLE
fix: skip page layout for external markdown imports

### DIFF
--- a/.changeset/fix-external-markdown-build.md
+++ b/.changeset/fix-external-markdown-build.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed production builds for pages that imported Markdown files from outside `src/pages`.

--- a/src/internal/mdx.test.ts
+++ b/src/internal/mdx.test.ts
@@ -1,3 +1,5 @@
+import * as path from 'node:path'
+import type * as Estree from 'estree'
 import type * as MdAst from 'mdast'
 import remarkFrontmatter from 'remark-frontmatter'
 import remarkParse from 'remark-parse'
@@ -7,6 +9,7 @@ import { describe, expect, it } from 'vitest'
 import * as Config from './config.js'
 import {
   getCompileOptions,
+  recmaMdxLayout,
   remarkCodeTitle,
   remarkDefaultFrontmatter,
   remarkFilename,
@@ -133,6 +136,35 @@ function stripPositions(children: MdAst.PhrasingContent[]): unknown[] {
     return child
   })
 }
+
+function createMdxProgram(): Estree.Program {
+  return {
+    type: 'Program',
+    sourceType: 'module',
+    body: [
+      {
+        type: 'ExportDefaultDeclaration',
+        declaration: { type: 'Identifier', name: 'MDXContent' },
+      },
+    ],
+  }
+}
+
+describe('recmaMdxLayout', () => {
+  it('skips page layout injection for markdown outside the pages directory', () => {
+    const rootDir = path.join(process.cwd(), 'playground')
+    const tree = createMdxProgram()
+    const transform = recmaMdxLayout(Config.define({ rootDir }))()
+
+    transform(tree, {
+      basename: 'notes.md',
+      dirname: rootDir,
+      path: path.join(rootDir, 'notes.md'),
+    } as never)
+
+    expect(tree).toEqual(createMdxProgram())
+  })
+})
 
 describe('remarkFilename', () => {
   it('scopes duplicate code-group filenames to their group', () => {

--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -326,13 +326,18 @@ export function getCompileOptions(
  */
 export function recmaMdxLayout(config: Config.Config) {
   const { rootDir, srcDir, pagesDir } = config
-  const pagesDirPath = path.join(rootDir, srcDir, pagesDir)
+  const pagesDirPath = path.resolve(rootDir, srcDir, pagesDir)
 
   const layoutPaths = new Map<string, string>()
 
   return () => (tree: Estree.Program, vfile: VFile) => {
     const fileName = vfile.basename ?? ''
     if (!fileName.endsWith('.mdx') && !fileName.endsWith('.md')) return
+    if (!vfile.path) return
+
+    const sourcePath = path.resolve(vfile.path)
+    const filePath = path.relative(pagesDirPath, sourcePath)
+    if (filePath.startsWith('..') || path.isAbsolute(filePath)) return
 
     const defaultExportIndex = tree.body.findIndex(
       (node) => node.type === 'ExportDefaultDeclaration',
@@ -349,8 +354,7 @@ export function recmaMdxLayout(config: Config.Config) {
       return `import _Layout from '${layoutPath}';`
     }
 
-    const lastModified = vfile.path ? Git.getLastModified(vfile.path) : undefined
-    const filePath = vfile.path ? path.relative(pagesDirPath, vfile.path) : undefined
+    const lastModified = Git.getLastModified(sourcePath)
 
     const importAst = EstreeUtil.fromJs(
       `import { MdxPageContext as _MdxPageContext } from 'vocs';
@@ -364,7 +368,7 @@ export function recmaMdxLayout(config: Config.Config) {
       `export function Page(props = {}) {
         const _frontmatter = { 
           ...frontmatter, 
-          filePath: ${filePath ? `"${filePath}"` : 'undefined'},
+          filePath: "${filePath}",
           lastModified: ${lastModified ? `"${lastModified}"` : 'undefined'},
         };
         return _createElement(


### PR DESCRIPTION
Markdown and MDX files imported from outside `src/pages` now compile as plain MDX components instead of receiving Vocs page layout wiring.

The crash came from `recmaMdxLayout` searching upward for `_mdx-wrapper.tsx` after transforming non-page Markdown. The transform now exits early unless the source file is inside the configured pages directory.

Fixes https://github.com/wevm/vocs/issues/489
