### PR TITLE
fix: render persisted twoslash hovers inline

### DIFF
--- a/.changeset/fix-persisted-twoslash-layout.md
+++ b/.changeset/fix-persisted-twoslash-layout.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed persisted Twoslash hovers and completions overlapping following documentation content.

--- a/site/src/pages/writing/twoslash.mdx
+++ b/site/src/pages/writing/twoslash.mdx
@@ -15,8 +15,7 @@ import { getSingletonHighlighterCore } from 'shiki/core'
 import { createOnigurumaEngine } from 'shiki/engine/oniguruma'
 
 const shiki = await getSingletonHighlighterCore({
-//    ^?
-
+  //  ^?
   engine: createOnigurumaEngine(import('shiki/wasm'))
 })
 ```

--- a/src/react/internal/TwoslashCompletionList.test.tsx
+++ b/src/react/internal/TwoslashCompletionList.test.tsx
@@ -1,0 +1,23 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, test } from 'vitest'
+
+import { TwoslashCompletionList } from './TwoslashCompletionList.js'
+
+describe('TwoslashCompletionList', () => {
+  test('renders completions inline', () => {
+    const html = renderToStaticMarkup(
+      <TwoslashCompletionList className="twoslash-completion-cursor">
+        <ul className="twoslash-completion-list">
+          <li>apple</li>
+        </ul>
+      </TwoslashCompletionList>,
+    )
+
+    expect(html).toContain('twoslash-completion-cursor')
+    expect(html).toContain('data-v-twoslash-completion')
+    expect(html).toContain('data-v-twoslash-completion-cursor')
+    expect(html).toContain('data-v-twoslash-completion-popup')
+    expect(html).toContain('twoslash-completion-list')
+    expect(html).not.toContain('data-base-ui')
+  })
+})

--- a/src/react/internal/TwoslashCompletionList.tsx
+++ b/src/react/internal/TwoslashCompletionList.tsx
@@ -1,19 +1,42 @@
 'use client'
 
-import { Popover } from '@base-ui/react/popover'
+import { useEffect, useState } from 'react'
 
 export function TwoslashCompletionList(props: TwoslashCompletionList.Props) {
+  const { children, className } = props
+  const [list, setList] = useState<HTMLSpanElement | null>(null)
+
+  useEffect(() => {
+    if (!list) return
+    const line = list.closest('.line')
+    if (!(line instanceof HTMLElement)) return
+
+    const update = () => {
+      const lineHeight = Number.parseFloat(getComputedStyle(line).lineHeight)
+      const lineTop = line.getBoundingClientRect().top
+      const listBottom = list.getBoundingClientRect().bottom
+      const padding = Math.max(0, listBottom - lineTop - lineHeight)
+      line.style.setProperty('--vocs-twoslash-popup-height', `${padding}px`)
+    }
+    update()
+
+    const observer = new ResizeObserver(update)
+    observer.observe(list)
+    return () => {
+      observer.disconnect()
+      line.style.removeProperty('--vocs-twoslash-popup-height')
+    }
+  }, [list])
+
   return (
-    <Popover.Root open>
-      <Popover.Trigger className="vocs:animate-blink" disabled tabIndex={-1}>
+    <span className={className} data-v-twoslash-completion>
+      <span className="vocs:animate-blink" data-v-twoslash-completion-cursor>
         |
-      </Popover.Trigger>
-      <Popover.Portal>
-        <Popover.Positioner align="start" collisionAvoidance={{ side: 'none' }} side="bottom">
-          <Popover.Popup initialFocus={false}>{props.children}</Popover.Popup>
-        </Popover.Positioner>
-      </Popover.Portal>
-    </Popover.Root>
+      </span>
+      <span data-v-twoslash-completion-popup ref={setList}>
+        {children}
+      </span>
+    </span>
   )
 }
 

--- a/src/react/internal/TwoslashHover.client.tsx
+++ b/src/react/internal/TwoslashHover.client.tsx
@@ -2,7 +2,7 @@
 
 import { Popover } from '@base-ui/react/popover'
 import type * as React from 'react'
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { prewarm } from './CodeToHtml.client.js'
 
 export function TwoslashHover(props: TwoslashHover.Props) {
@@ -10,7 +10,8 @@ export function TwoslashHover(props: TwoslashHover.Props) {
 
   const { ref } = TwoslashHover.useOverflowFade()
 
-  const open = className?.includes('twoslash-query-persisted')
+  const persisted = className?.includes('twoslash-query-persisted')
+  const [persistedPopup, setPersistedPopup] = useState<HTMLSpanElement | null>(null)
 
   // Warm the highlighter so the code inside the popup highlights as quickly as
   // possible (the popup shows a skeleton placeholder until then).
@@ -18,8 +19,47 @@ export function TwoslashHover(props: TwoslashHover.Props) {
     prewarm()
   }, [])
 
+  useEffect(() => {
+    if (!persistedPopup) return
+    const line = persistedPopup.closest('.line')
+    if (!(line instanceof HTMLElement)) return
+
+    const update = () => {
+      const lineHeight = Number.parseFloat(getComputedStyle(line).lineHeight)
+      const lineTop = line.getBoundingClientRect().top
+      const popupBottom = persistedPopup.getBoundingClientRect().bottom
+      const padding = Math.max(0, popupBottom - lineTop - lineHeight)
+      line.style.setProperty('--vocs-twoslash-popup-height', `${padding}px`)
+    }
+    update()
+
+    const observer = new ResizeObserver(update)
+    observer.observe(persistedPopup)
+    return () => {
+      observer.disconnect()
+      line.style.removeProperty('--vocs-twoslash-popup-height')
+    }
+  }, [persistedPopup])
+
+  if (persisted)
+    return (
+      <span data-v-twoslash-persisted>
+        <span data-v-twoslash-trigger>
+          <span>{trigger}</span>
+        </span>
+        <span className={className} data-v-twoslash-inline-popup ref={setPersistedPopup}>
+          <span data-v-twoslash-inline-arrow>
+            <ArrowSvg />
+          </span>
+          <div data-v-content ref={ref}>
+            {children}
+          </div>
+        </span>
+      </span>
+    )
+
   return (
-    <Popover.Root {...(open ? { open } : {})}>
+    <Popover.Root>
       <Popover.Trigger data-v-twoslash-trigger openOnHover delay={0}>
         <span>{trigger}</span>
       </Popover.Trigger>
@@ -48,7 +88,6 @@ export namespace TwoslashHover {
   export type Props = {
     className?: string | undefined
     children: React.ReactNode
-    open?: boolean | undefined
     trigger: React.ReactNode
   }
 

--- a/src/react/internal/TwoslashHover.test.tsx
+++ b/src/react/internal/TwoslashHover.test.tsx
@@ -1,0 +1,79 @@
+import type React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const popover = vi.hoisted(() => ({
+  Root: vi.fn(({ children }: PopoverProps) => <div data-v-popover-root>{children}</div>),
+  Trigger: vi.fn(({ children }: PopoverProps) => <span data-v-popover-trigger>{children}</span>),
+  Portal: vi.fn(({ children }: PopoverProps) => <>{children}</>),
+  Positioner: vi.fn(({ children }: PopoverProps) => <>{children}</>),
+  Popup: vi.fn(({ children, className }: PopoverProps) => (
+    <div className={className} data-v-popover-popup>
+      {children}
+    </div>
+  )),
+  Arrow: vi.fn(({ children }: PopoverProps) => <span data-v-popover-arrow>{children}</span>),
+}))
+
+type PopoverProps = React.PropsWithChildren<{
+  className?: string | undefined
+  [key: string]: unknown
+}>
+
+vi.mock('./CodeToHtml.client.js', () => ({
+  prewarm: vi.fn(),
+}))
+
+vi.mock('@base-ui/react/popover', () => ({ Popover: popover }))
+
+import { TwoslashHover } from './TwoslashHover.js'
+
+describe('TwoslashHover', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('renders persisted query hovers inline', () => {
+    const html = renderToStaticMarkup(
+      <TwoslashHover className="twoslash-hover twoslash-query-persisted twoslash-popup-container">
+        <span>value</span>
+        <pre>type Value = string</pre>
+      </TwoslashHover>,
+    )
+
+    expect(popover.Root).not.toHaveBeenCalled()
+    expect(popover.Trigger).not.toHaveBeenCalled()
+    expect(popover.Portal).not.toHaveBeenCalled()
+    expect(popover.Positioner).not.toHaveBeenCalled()
+    expect(popover.Popup).not.toHaveBeenCalled()
+    expect(popover.Arrow).not.toHaveBeenCalled()
+
+    expect(html).toContain('data-v-twoslash-persisted')
+    expect(html).toContain('data-v-twoslash-inline-popup')
+    expect(html).toContain('data-v-twoslash-inline-arrow')
+    expect(html).toContain('twoslash-query-persisted')
+    expect(html).toContain('type Value = string')
+    expect(html).not.toContain('data-v-popover-root')
+  })
+
+  test('renders non-persisted hovers as popovers', () => {
+    const html = renderToStaticMarkup(
+      <TwoslashHover className="twoslash-hover twoslash-popup-container">
+        <span>value</span>
+        <pre>type Value = string</pre>
+      </TwoslashHover>,
+    )
+
+    expect(popover.Root).toHaveBeenCalledTimes(1)
+    expect(popover.Trigger).toHaveBeenCalledTimes(1)
+    expect(popover.Portal).toHaveBeenCalledTimes(1)
+    expect(popover.Positioner).toHaveBeenCalledTimes(1)
+    expect(popover.Popup).toHaveBeenCalledTimes(1)
+    expect(popover.Arrow).toHaveBeenCalledTimes(1)
+
+    expect(html).toContain('data-v-popover-root')
+    expect(html).toContain('twoslash-hover twoslash-popup-container')
+    expect(html).toContain('type Value = string')
+    expect(html).not.toContain('data-v-twoslash-inline-popup')
+  })
+})

--- a/src/react/internal/TwoslashHover.tsx
+++ b/src/react/internal/TwoslashHover.tsx
@@ -5,10 +5,9 @@ import { TwoslashHover as TwoslashHover_client } from './TwoslashHover.client.js
 export function TwoslashHover(props: TwoslashHover.Props) {
   const { className = '', children } = props
   const [trigger, ...content] = React.Children.toArray(children)
-  const open = className?.includes('twoslash-query-persisted')
   if (!content) return null
   return (
-    <TwoslashHover_client className={className} open={open} trigger={trigger}>
+    <TwoslashHover_client className={className} trigger={trigger}>
       {content}
     </TwoslashHover_client>
   )

--- a/src/styles/twoslash.css
+++ b/src/styles/twoslash.css
@@ -19,6 +19,16 @@
     position: relative;
     z-index: 50;
   }
+
+  & .line:has([data-v-twoslash-inline-popup]) {
+    @apply vocs:relative;
+    padding-bottom: var(--vocs-twoslash-popup-height, 2.1875rem);
+  }
+
+  & .line:has([data-v-twoslash-completion-popup]) {
+    @apply vocs:relative;
+    padding-bottom: var(--vocs-twoslash-popup-height, 5rem);
+  }
 }
 
 .twoslash-popup-container {
@@ -61,6 +71,31 @@
   & [data-v-content] > *:not(:last-child) {
     @apply vocs:border-b vocs:border-primary;
   }
+}
+
+[data-v-twoslash-persisted] {
+  @apply vocs:relative vocs:inline-block;
+}
+
+.twoslash-query-persisted.twoslash-popup-container[data-v-twoslash-inline-popup] {
+  @apply vocs:absolute vocs:top-[calc(100%+0.25rem)] vocs:left-0 vocs:block vocs:w-max;
+  font-size: 1rem;
+}
+
+[data-v-twoslash-inline-arrow] {
+  @apply vocs:absolute vocs:top-[-9px] vocs:left-3 vocs:block vocs:leading-none;
+}
+
+[data-v-twoslash-inline-arrow] svg {
+  @apply vocs:block;
+}
+
+[data-v-twoslash-completion] {
+  @apply vocs:relative vocs:inline-block;
+}
+
+[data-v-twoslash-completion-popup] {
+  @apply vocs:absolute vocs:top-[calc(100%+0.25rem)] vocs:left-0 vocs:block;
 }
 
 [data-v-code-skeleton] [data-v-skeleton-bar] {


### PR DESCRIPTION
Persisted Twoslash query hovers and completion lists now render inline with measured line spacing instead of as always-open portal popovers, so they occupy document flow and do not overlap following content. The PR adds regression tests for persisted hover rendering and completion list markup.

| Before | After |
|--------|--------|
| <img width="956" height="232" alt="009453_Firefox_2026-06-22-16 13 31@2x" src="https://github.com/user-attachments/assets/352f9e14-d6f4-4f1a-b4cd-07dd77168802" /> | <img width="946" height="242" alt="009451_Firefox_2026-06-22-16 13 06@2x" src="https://github.com/user-attachments/assets/d5a6dc1d-d8c5-4e87-928d-71908bc8f7f3" /> |
| <img width="1002" height="310" alt="009457_Firefox_2026-06-22-16 14 31@2x" src="https://github.com/user-attachments/assets/a2148e99-ea43-4da3-8824-afa39d40c186" /> | <img width="746" height="452" alt="009455_Firefox_2026-06-22-16 14 10@2x" src="https://github.com/user-attachments/assets/3d6bc852-7291-4eac-af9d-7ee232509a52" /> | 