### PR TITLE
fix: render OpenAPI root endpoints

### DIFF
--- a/.changeset/silent-apples-promise.md
+++ b/.changeset/silent-apples-promise.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed generated OpenAPI root pages to render endpoint overviews when no custom intro page was provided.

--- a/src/waku/internal/patches/router.ts
+++ b/src/waku/internal/patches/router.ts
@@ -336,7 +336,12 @@ export function router(
             const rootProps = await overrideProps(entry.path)
             createPage({
               path: entry.path,
-              component: () => createElement(OpenApiPage, { mount: entry.path, ...rootProps }),
+              component: () =>
+                createElement(OpenApiPage, {
+                  mount: entry.path,
+                  endpoints: !rootProps.intro,
+                  ...rootProps,
+                }),
               render: 'static',
             } as never)
 


### PR DESCRIPTION
Render generated OpenAPI root pages with the endpoint overview when no consumer override page is present.

This aligns the Waku site integration with the standalone OpenAPI app behavior. Authored override pages still own their own content, so they can opt into the endpoint overview explicitly with `OpenApi.Endpoints`.
