### PR TITLE
fix(openapi): resolve remote relative servers

### DIFF
--- a/.changeset/openapi-remote-server.md
+++ b/.changeset/openapi-remote-server.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed OpenAPI playground requests for remote specs with relative server URLs.

--- a/src/internal/openapi/parser.test.ts
+++ b/src/internal/openapi/parser.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import * as OpenApi from './openapi.js'
 import { parse } from './parser.js'
 
@@ -186,6 +186,45 @@ describe('parse', () => {
     const ir = await parse(OpenApi.from({ spec, path: '/api' }))
     const fallback = ir.groups.find((group) => group.name === 'default')
     expect(fallback?.operations.map((op) => op.id)).toEqual(['health'])
+  })
+
+  test('inlines remote specs with relative servers for the API client', async () => {
+    const fetch_ = globalThis.fetch
+    const remoteSpec = {
+      openapi: '3.1.0',
+      info: { title: 'Remote API', version: '1.0.0' },
+      servers: [{ url: '/', description: 'Relative to the spec host' }],
+      paths: {
+        '/health': {
+          get: { operationId: 'health', summary: 'Health check', responses: { '200': {} } },
+        },
+      },
+    }
+    globalThis.fetch = vi.fn(async () => new Response(JSON.stringify(remoteSpec))) as never
+    try {
+      const ir = await parse(
+        OpenApi.from({ spec: 'https://api.example.com/openapi.json', path: '/api' }),
+      )
+
+      expect(ir.servers).toEqual([
+        {
+          url: 'https://api.example.com',
+          description: 'Relative to the spec host',
+        },
+      ])
+      expect(ir.client).toEqual({
+        content: expect.objectContaining({
+          servers: [
+            {
+              url: 'https://api.example.com',
+              description: 'Relative to the spec host',
+            },
+          ],
+        }),
+      })
+    } finally {
+      globalThis.fetch = fetch_
+    }
   })
 })
 

--- a/src/internal/openapi/parser.ts
+++ b/src/internal/openapi/parser.ts
@@ -270,7 +270,13 @@ export async function parse(config: OpenApi.Config, options: parse.Options = {})
   // (the request origin in the standalone server handler).
   const openrpcBaseUrl = specUrl ?? options.baseUrl
 
-  const servers = (document.servers ?? [])
+  const serverEntries =
+    document.servers && document.servers.length > 0
+      ? document.servers
+      : specUrl
+        ? [{ url: '/' }]
+        : []
+  const servers = serverEntries
     .map((server) => ({
       url: resolveServerUrl(server.url ?? '', specUrl),
       description: server.description,
@@ -289,8 +295,12 @@ export async function parse(config: OpenApi.Config, options: parse.Options = {})
   for (const injection of injections)
     injectRpcExamples(specification as Record<string, unknown>, injection)
 
+  const shouldInlineClientSpec =
+    injections.length > 0 || (isUrl && shouldNormalizeClientServers(document, servers))
+  if (shouldInlineClientSpec) setClientServers(specification as Record<string, unknown>, servers)
+
   const client =
-    isUrl && injections.length === 0
+    isUrl && !shouldInlineClientSpec
       ? { url: spec as string }
       : { content: specification as Record<string, unknown> }
 
@@ -385,6 +395,29 @@ function resolveServerUrl(url: string, specUrl: string | undefined): string {
   } catch {
     return url
   }
+}
+
+/**
+ * Scalar resolves relative server URLs against the docs app origin when it
+ * fetches a remote spec by URL. Inline the normalized spec instead so `Try`
+ * targets the host that served the OpenAPI document.
+ */
+function shouldNormalizeClientServers(document: Document, servers: IrServer[]): boolean {
+  if (servers.length === 0) return false
+  if (!document.servers || document.servers.length === 0) return true
+  return document.servers.some((server) => {
+    const url = server.url ?? ''
+    return !url || !/^https?:\/\//.test(url)
+  })
+}
+
+/** Writes resolved server URLs into the spec handed to the API client. */
+function setClientServers(specification: Record<string, unknown>, servers: IrServer[]): void {
+  if (servers.length === 0) return
+  specification['servers'] = servers.map((server) => ({
+    url: server.url,
+    ...(server.description ? { description: server.description } : {}),
+  }))
 }
 
 /** Resolves a spec input to a raw definition (object or string content). */


### PR DESCRIPTION
Remote OpenAPI specs that declare relative servers now get normalized before they are handed to the interactive playground. This keeps Scalar's Try requests pointed at the spec host instead of the local docs dev server.

Specs without an explicit server also default to the remote spec origin for the client document, matching the rendered code samples.
