### PR TITLE
fix(openapi): mute disabled scalar values

### DIFF
--- a/.changeset/mute-scalar-disabled-values.md
+++ b/.changeset/mute-scalar-disabled-values.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Muted disabled Scalar modal request values.

--- a/src/styles/openapi-playground.css
+++ b/src/styles/openapi-playground.css
@@ -78,3 +78,14 @@
 .scalar-app input[type="checkbox"].peer:not(:checked) ~ div svg {
   color: transparent;
 }
+
+/*
+ * Disabled request parameters keep their value visible, but they should recede
+ * from active rows. Scalar renders the checkbox inside the first cell and the
+ * value inside the third cell.
+ */
+.scalar-app[data-v-openapi-playground-root] tr:has(input[type="checkbox"].peer:not(:checked))
+  > td:nth-child(3)
+  :is(.code-input-lite__editor, [data-testid="code-input-lite-disabled"], .text-c-1) {
+  color: var(--scalar-color-3);
+}


### PR DESCRIPTION
Unchecked request parameter rows in the Scalar modal now render value text with the muted Scalar text token. The key column stays unchanged, preserving row labels while making inactive values recede.

This matches the Vocs OpenAPI modal styling more closely and makes disabled parameter values easier to distinguish from active inputs.
