### PR TITLE
feat(openapi): add `resource` prop to `OpenApi.Endpoints`

### DIFF
--- a/.changeset/openapi-endpoints-resource.md
+++ b/.changeset/openapi-endpoints-resource.md
@@ -1,0 +1,5 @@
+---
+"vocs": minor
+---
+
+Added a `resource` prop to `<OpenApi.Endpoints />` that renders a flat list of all endpoints for a single resource (e.g. `<OpenApi.Endpoints resource="rpc" />`).

--- a/.changeset/openapi-endpoints-resource.md
+++ b/.changeset/openapi-endpoints-resource.md
@@ -1,5 +1,5 @@
 ---
-"vocs": minor
+"vocs": patch
 ---
 
 Added a `resource` prop to `<OpenApi.Endpoints />` that renders a flat list of all endpoints for a single resource (e.g. `<OpenApi.Endpoints resource="rpc" />`).

--- a/playground/src/pages/api.mdx
+++ b/playground/src/pages/api.mdx
@@ -11,3 +11,10 @@ replaces the auto-generated spec title/description. The domain list below is
 opt-in — rendered via the `<OpenApi.Endpoints />` component.
 
 <OpenApi.Endpoints />
+
+## RPC endpoints
+
+A flat list of all endpoints for the `rpc` resource, via
+`<OpenApi.Endpoints resource="rpc" />`:
+
+<OpenApi.Endpoints resource="rpc" />

--- a/src/internal/openapi/app.ts
+++ b/src/internal/openapi/app.ts
@@ -19,7 +19,7 @@ import type { Ir } from './parser.js'
  */
 export type PageBlock =
   | { type: 'html'; html: string }
-  | { type: 'endpoints'; path?: string | undefined }
+  | { type: 'endpoints'; path?: string | undefined; resource?: string | undefined }
 
 /**
  * A compiled consumer-authored page, keyed by its section-relative route.

--- a/src/openapi-app/blocks.tsx
+++ b/src/openapi-app/blocks.tsx
@@ -17,7 +17,7 @@ function Block(props: { block: PageBlock }) {
   const { block } = props
   // `<OpenApi.Endpoints />` blocks rehydrate as the real component (resolves the
   // spec from `virtual:vocs/openapi`); everything else is server-compiled HTML.
-  if (block.type === 'endpoints') return <Endpoints path={block.path} />
+  if (block.type === 'endpoints') return <Endpoints path={block.path} resource={block.resource} />
   // Render as a genuine Vocs content article so the compiled markdown elements
   // are direct children of `[data-v-content]` — this is what the markdown
   // typography rules (heading borders/padding, `space-y-6` base rhythm) target.

--- a/src/react/internal/openapi/Endpoints.tsx
+++ b/src/react/internal/openapi/Endpoints.tsx
@@ -37,6 +37,7 @@ export function Endpoints(props: Endpoints.Props) {
   return (
     <EndpointsView
       ir={ir}
+      resource={props.resource}
       href={(to) => to}
       Link={({ href, children, ...rest }) => (
         <Link to={href ?? ''} {...rest}>
@@ -54,5 +55,11 @@ export declare namespace Endpoints {
      * Optional when only one spec is configured.
      */
     path?: string | undefined
+    /**
+     * Renders a flat list of all operations for a single resource (category)
+     * instead of the full accordion. Matches a category by its `id`, or
+     * case-insensitively by `name` (e.g. `resource="rpc"`).
+     */
+    resource?: string | undefined
   }
 }

--- a/src/react/internal/openapi/EndpointsView.test.tsx
+++ b/src/react/internal/openapi/EndpointsView.test.tsx
@@ -1,0 +1,58 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, test } from 'vitest'
+import type { Ir } from '../../../internal/openapi/parser.js'
+import { EndpointsView } from './EndpointsView.js'
+
+const ir = {
+  path: '/api',
+  groups: [
+    {
+      id: 'rpc',
+      name: 'RPC',
+      operations: [
+        { id: 'eth_blocknumber', method: 'POST', path: '/', summary: 'eth_blockNumber' },
+        { id: 'eth_call', method: 'POST', path: '/', summary: 'eth_call' },
+      ],
+    },
+    {
+      id: 'admin',
+      name: 'Admin',
+      operations: [{ id: 'admin_peers', method: 'POST', path: '/', summary: 'admin_peers' }],
+    },
+  ],
+} as unknown as Ir
+
+describe('EndpointsView', () => {
+  test('renders the accordion of all categories by default', () => {
+    const html = renderToStaticMarkup(<EndpointsView ir={ir} href={(to) => to} />)
+    expect(html).toContain('data-v-openapi-overview')
+    expect(html).toContain('eth_blockNumber')
+    expect(html).toContain('admin_peers')
+  })
+
+  test('resource renders a single category as a flat list', () => {
+    const html = renderToStaticMarkup(<EndpointsView ir={ir} href={(to) => to} resource="rpc" />)
+    expect(html).toContain('data-v-openapi-overview-resource')
+    // Operations of the matched resource are listed...
+    expect(html).toContain('eth_blockNumber')
+    expect(html).toContain('eth_call')
+    expect(html).toContain('href="/api/rpc#eth_blocknumber"')
+    // ...and other categories are excluded.
+    expect(html).not.toContain('admin_peers')
+    // No accordion wrapper is rendered.
+    expect(html).not.toContain('data-v-openapi-overview-category')
+  })
+
+  test('resource matches case-insensitively by name', () => {
+    const html = renderToStaticMarkup(<EndpointsView ir={ir} href={(to) => to} resource="admin" />)
+    expect(html).toContain('admin_peers')
+    expect(html).not.toContain('eth_blockNumber')
+  })
+
+  test('resource reports when no category matches', () => {
+    const html = renderToStaticMarkup(
+      <EndpointsView ir={ir} href={(to) => to} resource="missing" />,
+    )
+    expect(html).toContain('No resource named')
+  })
+})

--- a/src/react/internal/openapi/EndpointsView.tsx
+++ b/src/react/internal/openapi/EndpointsView.tsx
@@ -16,10 +16,37 @@ import { Disclosure } from './Disclosure.client.js'
  * client).
  */
 export function EndpointsView(props: EndpointsView.Props) {
-  const { ir, href, Link = DefaultLink } = props
+  const { ir, href, Link = DefaultLink, resource } = props
   // Root-mounted specs have `ir.path === '/'`; collapse it to '' so links read
   // `/group#op` instead of `//group#op` (which the browser treats as a host).
   const base = ir.path === '/' ? '' : ir.path.replace(/\/$/, '')
+
+  // `resource` renders a single category's operations as a flat list (no
+  // accordion). Match by stable `id` first, then case-insensitively by `name`.
+  if (resource !== undefined) {
+    const category = ir.groups.find(
+      (group) => group.id === resource || group.name.toLowerCase() === resource.toLowerCase(),
+    )
+    if (!category)
+      return (
+        <p>
+          No resource named <code>{resource}</code> found.
+        </p>
+      )
+    return (
+      <ul data-v-openapi-overview-endpoints data-v-openapi-overview-resource>
+        {category.operations.map((operation) => (
+          <EndpointItem
+            key={operation.id}
+            Link={Link}
+            href={href(`${base}/${category.id}#${operation.id}`)}
+            operation={operation}
+          />
+        ))}
+      </ul>
+    )
+  }
+
   return (
     <div data-v-openapi-overview>
       {ir.groups.map((category) => (
@@ -39,24 +66,35 @@ export function EndpointsView(props: EndpointsView.Props) {
           >
             <ul data-v-openapi-overview-endpoints>
               {category.operations.map((operation) => (
-                <li key={operation.id}>
-                  <Link
-                    href={href(`${base}/${category.id}#${operation.id}`)}
-                    data-v-openapi-overview-endpoint
-                  >
-                    <Badge variant={methodVariant(operation.method)}>{operation.method}</Badge>
-                    <span data-v-openapi-overview-endpoint-title>
-                      {operation.summary || operation.path}
-                    </span>
-                    <LucideChevronRight data-v-openapi-overview-endpoint-chevron />
-                  </Link>
-                </li>
+                <EndpointItem
+                  key={operation.id}
+                  Link={Link}
+                  href={href(`${base}/${category.id}#${operation.id}`)}
+                  operation={operation}
+                />
               ))}
             </ul>
           </Disclosure>
         </div>
       ))}
     </div>
+  )
+}
+
+function EndpointItem(props: {
+  Link: ComponentType<React.ComponentProps<'a'>>
+  href: string
+  operation: Ir['groups'][number]['operations'][number]
+}) {
+  const { Link, href, operation } = props
+  return (
+    <li>
+      <Link href={href} data-v-openapi-overview-endpoint>
+        <Badge variant={methodVariant(operation.method)}>{operation.method}</Badge>
+        <span data-v-openapi-overview-endpoint-title>{operation.summary || operation.path}</span>
+        <LucideChevronRight data-v-openapi-overview-endpoint-chevron />
+      </Link>
+    </li>
   )
 }
 
@@ -72,5 +110,10 @@ export declare namespace EndpointsView {
     href: (to: string) => string
     /** Link component. Defaults to a plain anchor. */
     Link?: ComponentType<React.ComponentProps<'a'>> | undefined
+    /**
+     * Renders a single category's operations as a flat list (no accordion).
+     * Matches a category by its `id`, or case-insensitively by `name`.
+     */
+    resource?: string | undefined
   }
 }

--- a/src/server/openapi/pages.test.ts
+++ b/src/server/openapi/pages.test.ts
@@ -76,6 +76,12 @@ describe('compileSource', () => {
     expect(page.blocks.some((b) => b.type === 'html' && b.html.includes('import'))).toBe(false)
   })
 
+  test('parses an Endpoints resource attribute', () => {
+    const page = compileSource('/', '<OpenApi.Endpoints path="/api" resource="rpc" />')
+    const endpoints = page.blocks.find((block) => block.type === 'endpoints')
+    expect(endpoints).toMatchObject({ type: 'endpoints', path: '/api', resource: 'rpc' })
+  })
+
   test('normalizes the route path', () => {
     expect(compileSource('auth/', 'x').path).toBe('/auth')
   })

--- a/src/server/openapi/pages.ts
+++ b/src/server/openapi/pages.ts
@@ -95,7 +95,11 @@ export function compileSource(routePath: string, source: string): CompiledPage {
     const index = match.index ?? 0
     const before = body.slice(lastIndex, index)
     pushHtml(blocks, before)
-    blocks.push({ type: 'endpoints', path: parsePath(match[1] ?? '') })
+    blocks.push({
+      type: 'endpoints',
+      path: parseAttr(match[1] ?? '', 'path'),
+      resource: parseAttr(match[1] ?? '', 'resource'),
+    })
     lastIndex = index + match[0].length
   }
   pushHtml(blocks, body.slice(lastIndex))
@@ -120,9 +124,9 @@ function pushHtml(blocks: PageBlock[], markdown: string): void {
   blocks.push({ type: 'html', html: Markdown.toHtml(cleaned) })
 }
 
-/** Extracts the `path="..."` attribute from an `<Endpoints>` tag, if present. */
-function parsePath(attrs: string): string | undefined {
-  const match = attrs.match(/\bpath\s*=\s*["']([^"']*)["']/)
+/** Extracts a named string attribute from an `<Endpoints>` tag, if present. */
+function parseAttr(attrs: string, name: string): string | undefined {
+  const match = attrs.match(new RegExp(`\\b${name}\\s*=\\s*["']([^"']*)["']`))
   return match?.[1]
 }
 

--- a/src/styles/openapi.css
+++ b/src/styles/openapi.css
@@ -95,6 +95,15 @@
 [data-v-openapi-overview-endpoints] {
   @apply vocs:flex vocs:flex-col vocs:gap-2;
 }
+/* Flat `resource` variant renders the endpoint list on its own (no enclosing
+   accordion card), so reset the default list inset/marker it would otherwise
+   inherit from markdown typography. */
+[data-v-openapi-overview-resource] {
+  @apply vocs:list-none vocs:p-0 vocs:m-0;
+}
+[data-v-openapi-overview-resource] > li {
+  @apply vocs:p-0 vocs:m-0;
+}
 [data-v-openapi-overview-endpoint] {
   @apply vocs:flex vocs:items-center vocs:gap-3 vocs:bg-primary vocs:border vocs:border-primary vocs:rounded-lg vocs:px-3 vocs:py-2;
 }


### PR DESCRIPTION
## Overview

Adds a `resource` prop to `<OpenApi.Endpoints />` that renders a **flat list of all endpoints for a single resource** (category), instead of the full accordion of every category.

```mdx
<OpenApi.Endpoints resource="rpc" />
```

The resource is matched against a category's stable `id` first, then case-insensitively by `name`. If no category matches, a small "No resource named …" message is rendered.

## Changes

- **`EndpointsView.tsx`** — when `resource` is set, renders the matched category's operations as a flat `<ul>` (no `Disclosure`). Extracted a shared `EndpointItem` to avoid duplicating endpoint markup between the accordion and flat variants.
- **`Endpoints.tsx`** — new `resource` prop, forwarded to `EndpointsView`.
- **Standalone OpenAPI app** — `PageBlock` (`app.ts`) carries `resource`; `pages.ts` parses the `resource="…"` attribute (generalized `parsePath` → `parseAttr`); `blocks.tsx` forwards it.
- **`openapi.css`** — resets default list inset/markers for the standalone flat variant (`data-v-openapi-overview-resource`).

## Tests

- `EndpointsView.test.tsx` (new) — covers accordion default, flat `resource` rendering, case-insensitive name match, link hrefs, and the unmatched-resource message.
- `pages.test.ts` — parses the `resource` attribute on `<OpenApi.Endpoints />`.

## Verification

Verified end-to-end in the playground at `/api` against the Cadent spec: `resource="rpc"` renders the flat RPC method list (`admin_validatorKey`, `consensus_*`, `eth_*`, …) each linking to `/api/rpc#<method>`, filtered to just the RPC resource.

`pnpm check`, `pnpm check:types`, and the openapi test suites all pass.