### PR TITLE
feat(openapi): add OpenApi.Operation and OpenApi.Playground components

### DIFF
--- a/.changeset/openapi-operation-component.md
+++ b/.changeset/openapi-operation-component.md
@@ -1,0 +1,5 @@
+---
+"vocs": minor
+---
+
+Added the `<OpenApi.Operation />` component for embedding a single OpenAPI operation inline in an authored MDX page — including the sticky request/response code sample and its interactive "Try" playground. Target an operation by `operationId` or by `method` + `path`.

--- a/.changeset/openapi-operation-component.md
+++ b/.changeset/openapi-operation-component.md
@@ -2,4 +2,4 @@
 "vocs": minor
 ---
 
-Added `<OpenApi.Operation />` and `<OpenApi.Playground />` components for embedding OpenAPI endpoints inline in authored MDX pages. `<OpenApi.Operation />` renders the full operation block (title, parameters, responses, and the interactive sample); `<OpenApi.Playground />` renders just the request/response code sample box (Copy, "Try", and per-status tabs). Target an operation by `operationId` or by `method` + `path`.
+Added `<OpenApi.Operation />` and `<OpenApi.Playground />` components for embedding OpenAPI endpoints inline in authored MDX pages. `<OpenApi.Operation />` renders the full operation block (title, parameters, responses, and the interactive sample); `<OpenApi.Playground />` renders just the request/response code sample box (Copy, "Try", and per-status tabs). Target an operation by `operationId` or by `method` + `path`. Both accept `anchors={false}` to disable the clickable schema cross-links and `hideQueryParams` to omit query parameters from the request sample.

--- a/.changeset/openapi-operation-component.md
+++ b/.changeset/openapi-operation-component.md
@@ -2,4 +2,4 @@
 "vocs": minor
 ---
 
-Added the `<OpenApi.Operation />` component for embedding a single OpenAPI operation inline in an authored MDX page — including the sticky request/response code sample and its interactive "Try" playground. Target an operation by `operationId` or by `method` + `path`.
+Added `<OpenApi.Operation />` and `<OpenApi.Playground />` components for embedding OpenAPI endpoints inline in authored MDX pages. `<OpenApi.Operation />` renders the full operation block (title, parameters, responses, and the interactive sample); `<OpenApi.Playground />` renders just the request/response code sample box (Copy, "Try", and per-status tabs). Target an operation by `operationId` or by `method` + `path`.

--- a/.changeset/openapi-operation-component.md
+++ b/.changeset/openapi-operation-component.md
@@ -1,5 +1,5 @@
 ---
-"vocs": minor
+"vocs": patch
 ---
 
-Added `<OpenApi.Operation />` and `<OpenApi.Playground />` components for embedding OpenAPI endpoints inline in authored MDX pages. `<OpenApi.Operation />` renders the full operation block (title, parameters, responses, and the interactive sample); `<OpenApi.Playground />` renders just the request/response code sample box (Copy, "Try", and per-status tabs). Target an operation by `operationId` or by `method` + `path`. Both accept `anchors={false}` to disable the clickable schema cross-links and `hideQueryParams` to omit query parameters from the request sample.
+Added `<OpenApi.Operation />` and `<OpenApi.Playground />` components.

--- a/playground/src/pages/api/auth.mdx
+++ b/playground/src/pages/api/auth.mdx
@@ -23,3 +23,10 @@ targeted by `operationId`:
 And the same component targeted by `method` + `path`:
 
 <OpenApi.Operation method="GET" path="/v1/transactions/{transaction}" />
+
+## Embedded playground
+
+Just the request/response code sample box (Copy + "Try" + status tabs), with no
+surrounding documentation, via `<OpenApi.Playground />`:
+
+<OpenApi.Playground operationId="getBlocks" />

--- a/playground/src/pages/api/auth.mdx
+++ b/playground/src/pages/api/auth.mdx
@@ -30,3 +30,8 @@ Just the request/response code sample box (Copy + "Try" + status tabs), with no
 surrounding documentation, via `<OpenApi.Playground />`:
 
 <OpenApi.Playground operationId="getBlocks" />
+
+A static variant with the clickable cross-links disabled (`anchors={false}`) and
+query parameters hidden from the request (`hideQueryParams`):
+
+<OpenApi.Playground operationId="getBlocks" anchors={false} hideQueryParams />

--- a/playground/src/pages/api/auth.mdx
+++ b/playground/src/pages/api/auth.mdx
@@ -2,6 +2,8 @@
 title: Authentication
 ---
 
+import { OpenApi } from 'vocs'
+
 # Authentication
 
 This is a **consumer-authored guide page** mounted at `/api/auth`, linked from
@@ -9,3 +11,15 @@ the OpenAPI section sidebar via the `openapi[].sidebar.top` config option.
 
 Use it for content that isn't generated from the spec — authentication,
 rate limits, errors, changelogs, etc.
+
+## Embedded operation
+
+A single endpoint embedded inline via `<OpenApi.Operation />`, including the
+sticky request/response code sample and its interactive "Try" playground —
+targeted by `operationId`:
+
+<OpenApi.Operation operationId="getBlocks" />
+
+And the same component targeted by `method` + `path`:
+
+<OpenApi.Operation method="GET" path="/v1/transactions/{transaction}" />

--- a/playground/src/pages/api/auth.mdx
+++ b/playground/src/pages/api/auth.mdx
@@ -35,3 +35,7 @@ A static variant with the clickable cross-links disabled (`anchors={false}`) and
 query parameters hidden from the request (`hideQueryParams`):
 
 <OpenApi.Playground operationId="getBlocks" anchors={false} hideQueryParams />
+
+The address balances operation (`GET /v1/addresses/{address}/balances`):
+
+<OpenApi.Playground operationId="getAddressBalances" />

--- a/site/src/pages.gen.ts
+++ b/site/src/pages.gen.ts
@@ -16,6 +16,7 @@ type Page =
   | { path: '/features/dynamic-og-images'; render: 'static' }
   | { path: '/features/feedback'; render: 'static' }
   | { path: '/features/fonts'; render: 'static' }
+  | { path: '/features/head'; render: 'static' }
   | { path: '/features/layouts'; render: 'static' }
   | { path: '/features/mcp-server'; render: 'static' }
   | { path: '/features/navigation'; render: 'static' }

--- a/site/src/pages/features/openapi.mdx
+++ b/site/src/pages/features/openapi.mdx
@@ -98,6 +98,18 @@ import { OpenApi } from 'vocs'
 
 `operationId` matches the operation's anchor id (the slugified `operationId` from the spec). Pass `spec` to select a spec when multiple `openapi` entries are configured, and `headingLevel` (`2` or `3`) to fit the title into your page's heading hierarchy.
 
+### Embed Just the Playground
+
+The `<OpenApi.Playground />` component renders only the interactive request/response code sample box — Copy, "Try", and per-status tabs — with none of the surrounding documentation. Use it when you want the live endpoint sample inline in your own prose.
+
+```mdx
+import { OpenApi } from 'vocs'
+
+<OpenApi.Playground operationId="getBlocks" /> // [!code focus]
+```
+
+It takes the same targeting props as `<OpenApi.Operation />` (`operationId`, or `method` + `path`, plus `spec`).
+
 ### Mount a Reference on a Server
 
 `Handler.openApi` from `vocs/server` builds a standalone reference, rendered entirely client-side by a prebuilt bundle shipped inside Vocs, that mounts onto any Hono server. It accepts the same config as a `vocs.config.ts` `openapi` entry, except `path` is optional (the host server provides the mount location).

--- a/site/src/pages/features/openapi.mdx
+++ b/site/src/pages/features/openapi.mdx
@@ -76,6 +76,28 @@ import { OpenApi } from 'vocs'
 
 `path` identifies which spec to render. It can be omitted when only one `openapi` entry is configured.
 
+### Embed a Single Operation in a Page
+
+The `<OpenApi.Operation />` component renders one endpoint inline — the same block used on the generated reference pages, including the sticky request/response code sample and its interactive "Try" playground. Use it to document a single endpoint inside a guide.
+
+Target the operation by `operationId`:
+
+```mdx [src/pages/api/auth.mdx]
+import { OpenApi } from 'vocs'
+
+# Authentication
+
+<OpenApi.Operation operationId="createSession" /> // [!code focus]
+```
+
+…or by `method` + `path`:
+
+```mdx
+<OpenApi.Operation method="POST" path="/v1/sessions" />
+```
+
+`operationId` matches the operation's anchor id (the slugified `operationId` from the spec). Pass `spec` to select a spec when multiple `openapi` entries are configured, and `headingLevel` (`2` or `3`) to fit the title into your page's heading hierarchy.
+
 ### Mount a Reference on a Server
 
 `Handler.openApi` from `vocs/server` builds a standalone reference, rendered entirely client-side by a prebuilt bundle shipped inside Vocs, that mounts onto any Hono server. It accepts the same config as a `vocs.config.ts` `openapi` entry, except `path` is optional (the host server provides the mount location).

--- a/site/src/pages/features/openapi.mdx
+++ b/site/src/pages/features/openapi.mdx
@@ -110,6 +110,15 @@ import { OpenApi } from 'vocs'
 
 It takes the same targeting props as `<OpenApi.Operation />` (`operationId`, or `method` + `path`, plus `spec`).
 
+Both `<OpenApi.Operation />` and `<OpenApi.Playground />` also accept:
+
+- `anchors={false}` — render a static sample, disabling the hover-highlighted cross-links that jump to a parameter/property row.
+- `hideQueryParams` — omit query parameters from the request sample.
+
+```mdx
+<OpenApi.Playground operationId="getBlocks" anchors={false} hideQueryParams /> // [!code focus]
+```
+
 ### Mount a Reference on a Server
 
 `Handler.openApi` from `vocs/server` builds a standalone reference, rendered entirely client-side by a prebuilt bundle shipped inside Vocs, that mounts onto any Hono server. It accepts the same config as a `vocs.config.ts` `openapi` entry, except `path` is optional (the host server provides the mount location).

--- a/src/internal/openapi/sample.test.ts
+++ b/src/internal/openapi/sample.test.ts
@@ -96,6 +96,19 @@ describe('codeSamples', () => {
     expect(values).toContain('true')
   })
 
+  test('omits query parameters when hideQueryParams is set', () => {
+    const samples = codeSamples(operation, 'https://api.example.com', { hideQueryParams: true })
+    const curl = samples.find((sample) => sample.id === 'shell/curl')
+    // Bare URL: no query string, no per-line query anchors, no "Show more".
+    expect(curl?.code).toContain('https://api.example.com/pets/string')
+    expect(curl?.code).not.toContain('?limit')
+    expect(curl?.code).not.toContain('dryRun')
+    expect(curl?.display).not.toContain('?limit')
+    expect((curl?.lineAnchors ?? []).filter(Boolean)).toEqual([])
+    expect(curl?.collapsed).toBeUndefined()
+    expect(curl?.hiddenQueryCount).toBeUndefined()
+  })
+
   test('places each query parameter on its own line', () => {
     const samples = codeSamples(operation, 'https://api.example.com')
     const curl = samples.find((sample) => sample.id === 'shell/curl')

--- a/src/internal/openapi/sample.ts
+++ b/src/internal/openapi/sample.ts
@@ -79,8 +79,16 @@ const clients = [
  * Builds request code samples for an operation using `@scalar/snippetz` — the
  * same snippet generator Scalar uses. Returns one entry per supported client.
  */
-export function codeSamples(operation: IrOperation, server?: string): CodeSample[] {
+export function codeSamples(
+  operation: IrOperation,
+  server?: string,
+  options?: codeSamples.Options,
+): CodeSample[] {
   const request = harRequest(operation, server)
+  // Drop query parameters from the request sample when requested (the
+  // collapse/"Show more" logic below then sees zero, and `splitQueryLines`
+  // leaves the bare URL untouched).
+  if (options?.hideQueryParams) request.queryString = []
   const generator = snippetz()
   const queryCount = request.queryString?.length ?? 0
   // When there are many query params, also prepare a request limited to the
@@ -121,6 +129,13 @@ export function codeSamples(operation: IrOperation, server?: string): CodeSample
     samples.push(sample)
   }
   return samples
+}
+
+export declare namespace codeSamples {
+  type Options = {
+    /** Omit query parameters from the generated request sample. */
+    hideQueryParams?: boolean | undefined
+  }
 }
 
 /**

--- a/src/react/OpenApi.tsx
+++ b/src/react/OpenApi.tsx
@@ -4,3 +4,4 @@
  */
 export { Endpoints } from './internal/openapi/Endpoints.js'
 export { Operation } from './internal/openapi/OperationStandalone.js'
+export { Playground } from './internal/openapi/PlaygroundStandalone.js'

--- a/src/react/OpenApi.tsx
+++ b/src/react/OpenApi.tsx
@@ -3,3 +3,4 @@
  * `<OpenApi.Endpoints />`).
  */
 export { Endpoints } from './internal/openapi/Endpoints.js'
+export { Operation } from './internal/openapi/OperationStandalone.js'

--- a/src/react/internal/openapi/CodeSample.client.tsx
+++ b/src/react/internal/openapi/CodeSample.client.tsx
@@ -21,7 +21,7 @@ import { registerSampleAnchors, revealAnchor } from './anchor-navigation.client.
  * `data-v-openapi-sample*` attributes below.
  */
 export function CodeSample(props: CodeSample.Props) {
-  const { samples, responses, action } = props
+  const { samples, responses, action, anchors = true } = props
   const [sampleId, setSampleId] = useState(samples[0]?.id)
   const [status, setStatus] = useState(responses[0]?.status)
   // When a request has many query params, the extras collapse by default.
@@ -70,22 +70,20 @@ export function CodeSample(props: CodeSample.Props) {
     return { ids, hiddenIds }
   }, [samples])
 
-  useEffect(
-    () =>
-      registerSampleAnchors({
-        has: (id) =>
-          requestAnchors.ids.has(id) || responseAnchors.some((entry) => entry.ids.has(id)),
-        select: (id) => {
-          const match = responseAnchors.find((entry) => entry.ids.has(id))
-          if (match) {
-            setStatus(match.status)
-            return
-          }
-          if (requestAnchors.hiddenIds.has(id)) setQueryExpanded(true)
-        },
-      }),
-    [responseAnchors, requestAnchors],
-  )
+  useEffect(() => {
+    if (!anchors) return
+    return registerSampleAnchors({
+      has: (id) => requestAnchors.ids.has(id) || responseAnchors.some((entry) => entry.ids.has(id)),
+      select: (id) => {
+        const match = responseAnchors.find((entry) => entry.ids.has(id))
+        if (match) {
+          setStatus(match.status)
+          return
+        }
+        if (requestAnchors.hiddenIds.has(id)) setQueryExpanded(true)
+      },
+    })
+  }, [anchors, responseAnchors, requestAnchors])
 
   // Use the collapsed snippet variant (first few query params) unless expanded.
   const view = sample?.collapsed && !queryExpanded ? sample.collapsed : sample
@@ -107,14 +105,14 @@ export function CodeSample(props: CodeSample.Props) {
           </div>
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: param spans are also reachable via copyable property anchors */}
           {/* biome-ignore lint/a11y/noStaticElementInteractions: progressive enhancement over already-linkable property anchors */}
-          <div data-v-openapi-sample-request-body onClick={onAnchorClick}>
+          <div data-v-openapi-sample-request-body onClick={anchors ? onAnchorClick : undefined}>
             <CodeToHtml
               code={view.display}
               lang={sample.lang}
               shrinkIndent={false}
-              anchorRanges={view.anchors}
+              anchorRanges={anchors ? view.anchors : undefined}
               colorRanges={view.colorRanges}
-              lineAnchors={view.lineAnchors}
+              lineAnchors={anchors ? view.lineAnchors : undefined}
             />
           </div>
           {sample.collapsed && (
@@ -154,15 +152,19 @@ export function CodeSample(props: CodeSample.Props) {
           </div>
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: rows are also reachable via copyable property anchors */}
           {/* biome-ignore lint/a11y/noStaticElementInteractions: progressive enhancement over already-linkable property anchors */}
-          <div data-v-openapi-sample-response-body onClick={onAnchorClick}>
+          <div data-v-openapi-sample-response-body onClick={anchors ? onAnchorClick : undefined}>
             <CodeToHtml
               code={response.code}
               lang={response.lang}
               shrinkIndent={false}
               dimRanges={response.placeholders}
-              lineAnchors={response.linePaths.map((path) =>
-                path ? schemaPropertyId(response.idBase, path) : undefined,
-              )}
+              lineAnchors={
+                anchors
+                  ? response.linePaths.map((path) =>
+                      path ? schemaPropertyId(response.idBase, path) : undefined,
+                    )
+                  : undefined
+              }
             />
           </div>
         </div>
@@ -290,5 +292,13 @@ export declare namespace CodeSample {
     responses: OpenApi.ResponseSample[]
     /** Action slot rendered between the request and response (the test button). */
     action?: React.ReactNode
+    /**
+     * Render the clickable schema cross-links in the request/response samples
+     * (the hover-highlighted spans/lines that jump to a parameter or property
+     * row). Set `false` for a static, non-interactive sample.
+     *
+     * @default true
+     */
+    anchors?: boolean | undefined
   }
 }

--- a/src/react/internal/openapi/Operation.tsx
+++ b/src/react/internal/openapi/Operation.tsx
@@ -37,11 +37,18 @@ const parameterGroups: { in: OpenApi.IrParameter['in']; title: string }[] = [
 ]
 
 export function Operation(props: Operation.Props) {
-  const { operation, server, headingLevel = 3, separator = false } = props
+  const {
+    operation,
+    server,
+    headingLevel = 3,
+    separator = false,
+    anchors = true,
+    hideQueryParams = false,
+  } = props
   const title = operation.summary || `${operation.method} ${operation.path}`
   const Heading = `h${headingLevel}` as 'h2' | 'h3'
 
-  const samples = codeSamples(operation, server)
+  const samples = codeSamples(operation, server, { hideQueryParams })
   const responses = responseSamples(operation)
 
   return (
@@ -104,6 +111,7 @@ export function Operation(props: Operation.Props) {
           <CodeSample
             samples={samples}
             responses={responses}
+            anchors={anchors}
             action={
               <TestRequestButton
                 method={operation.method}
@@ -138,6 +146,19 @@ export declare namespace Operation {
      * @default false
      */
     separator?: boolean | undefined
+    /**
+     * Render the clickable schema cross-links in the request/response code
+     * samples. Set `false` for static, non-interactive samples.
+     *
+     * @default true
+     */
+    anchors?: boolean | undefined
+    /**
+     * Omit query parameters from the generated request code sample.
+     *
+     * @default false
+     */
+    hideQueryParams?: boolean | undefined
   }
 }
 

--- a/src/react/internal/openapi/OperationStandalone.tsx
+++ b/src/react/internal/openapi/OperationStandalone.tsx
@@ -55,6 +55,8 @@ export function Operation(props: Operation.Props) {
           operation={operation}
           server={ir.servers[0]?.url}
           headingLevel={props.headingLevel ?? 2}
+          anchors={props.anchors}
+          hideQueryParams={props.hideQueryParams}
         />
       </PlaygroundProvider>
     </div>
@@ -80,5 +82,19 @@ export declare namespace Operation {
     path?: string | undefined
     /** Heading level for the operation title (`2` or `3`). Defaults to `2`. */
     headingLevel?: 2 | 3 | undefined
+    /**
+     * Render the clickable schema cross-links in the request/response code
+     * samples (the hover-highlighted spans/lines that jump to a parameter or
+     * property row). Set `false` for static, non-interactive samples.
+     *
+     * @default true
+     */
+    anchors?: boolean | undefined
+    /**
+     * Omit query parameters from the generated request code sample.
+     *
+     * @default false
+     */
+    hideQueryParams?: boolean | undefined
   }
 }

--- a/src/react/internal/openapi/OperationStandalone.tsx
+++ b/src/react/internal/openapi/OperationStandalone.tsx
@@ -1,0 +1,84 @@
+import { specs } from 'virtual:vocs/openapi'
+import { findOperation } from './find-operation.js'
+import { Operation as OperationView } from './Operation.js'
+import { PlaygroundProvider } from './Playground.client.js'
+
+/**
+ * Renders a single OpenAPI operation — the same block used on the auto-generated
+ * category pages, including the sticky right-column request/response code sample
+ * and its interactive "Try" playground (Vite/RSC site integration).
+ *
+ * This is an opt-in component for embedding one endpoint inside an authored MDX
+ * page (e.g. a guide). Drop `<OpenApi.Operation operationId="getAddresses" />`
+ * (or target it by `method` + `path`) wherever you want the endpoint to appear.
+ *
+ * The target operation is located by either:
+ * - `operationId` — matched against the operation's anchor id (the slugified
+ *   `operationId` from the spec), or
+ * - `method` + `path` — matched against the HTTP method and templated path
+ *   (e.g. `method="GET" path="/v1/addresses/{address}"`).
+ *
+ * The spec is resolved from `spec` (the OpenAPI mount, e.g. `/api`). When
+ * omitted, it defaults to the only configured spec; if multiple specs exist,
+ * `spec` is required.
+ */
+export function Operation(props: Operation.Props) {
+  const mounts = Object.keys(specs)
+  const mount = props.spec ?? (mounts.length === 1 ? mounts[0] : undefined)
+
+  if (!mount) {
+    if (mounts.length === 0) return <p>No OpenAPI spec is configured.</p>
+    return (
+      <p>
+        Multiple OpenAPI specs are configured. Pass a <code>spec</code> to{' '}
+        <code>&lt;Operation /&gt;</code> (one of: {mounts.join(', ')}).
+      </p>
+    )
+  }
+
+  const ir = specs[mount]
+  if (!ir) return <p>No OpenAPI spec is mounted at {mount}.</p>
+
+  const operation = findOperation(ir, props)
+  if (!operation)
+    return (
+      <p>
+        No matching operation found in the API mounted at {mount}. Pass an <code>operationId</code>,
+        or a <code>method</code> and <code>path</code>.
+      </p>
+    )
+
+  return (
+    <div data-v-openapi>
+      <PlaygroundProvider client={ir.client} mount={ir.path}>
+        <OperationView
+          operation={operation}
+          server={ir.servers[0]?.url}
+          headingLevel={props.headingLevel ?? 2}
+        />
+      </PlaygroundProvider>
+    </div>
+  )
+}
+
+export declare namespace Operation {
+  type Props = {
+    /**
+     * OpenAPI mount path identifying which spec to read (e.g. `/api`).
+     * Optional when only one spec is configured.
+     */
+    spec?: string | undefined
+    /**
+     * Target operation by its anchor id — the slugified `operationId` from the
+     * spec (e.g. `operationId="getAddresses"`). Mutually exclusive with
+     * `method` + `path`.
+     */
+    operationId?: string | undefined
+    /** HTTP method of the target operation (e.g. `GET`). Pairs with `path`. */
+    method?: string | undefined
+    /** Templated path of the target operation (e.g. `/v1/addresses/{address}`). Pairs with `method`. */
+    path?: string | undefined
+    /** Heading level for the operation title (`2` or `3`). Defaults to `2`. */
+    headingLevel?: 2 | 3 | undefined
+  }
+}

--- a/src/react/internal/openapi/PlaygroundStandalone.tsx
+++ b/src/react/internal/openapi/PlaygroundStandalone.tsx
@@ -50,7 +50,9 @@ export function Playground(props: Playground.Props) {
       </p>
     )
 
-  const samples = codeSamples(operation, ir.servers[0]?.url)
+  const samples = codeSamples(operation, ir.servers[0]?.url, {
+    hideQueryParams: props.hideQueryParams,
+  })
   if (samples.length === 0) return null
   const responses = responseSamples(operation)
 
@@ -60,6 +62,7 @@ export function Playground(props: Playground.Props) {
         <CodeSample
           samples={samples}
           responses={responses}
+          anchors={props.anchors}
           action={
             <TestRequestButton
               method={operation.method}
@@ -90,5 +93,19 @@ export declare namespace Playground {
     method?: string | undefined
     /** Templated path of the target operation (e.g. `/v1/blocks`). Pairs with `method`. */
     path?: string | undefined
+    /**
+     * Render the clickable schema cross-links in the request/response sample
+     * (the hover-highlighted spans/lines that jump to a parameter or property
+     * row). Set `false` for a static, non-interactive sample.
+     *
+     * @default true
+     */
+    anchors?: boolean | undefined
+    /**
+     * Omit query parameters from the generated request sample.
+     *
+     * @default false
+     */
+    hideQueryParams?: boolean | undefined
   }
 }

--- a/src/react/internal/openapi/PlaygroundStandalone.tsx
+++ b/src/react/internal/openapi/PlaygroundStandalone.tsx
@@ -1,0 +1,94 @@
+import { specs } from 'virtual:vocs/openapi'
+import { codeSamples, responseSamples } from '../../../internal/openapi/sample.js'
+import { CodeSample } from './CodeSample.client.js'
+import { findOperation } from './find-operation.js'
+import { PlaygroundProvider, TestRequestButton } from './Playground.client.js'
+
+/**
+ * Renders just the interactive request/response code sample for a single
+ * OpenAPI operation — the bordered "playground" box (the cURL/response viewer
+ * with Copy, "Try", and per-status tabs) that normally sits in the right column
+ * of a generated operation page, with none of the surrounding documentation.
+ *
+ * This is an opt-in component for dropping the playground box into an authored
+ * MDX page. For the full operation block (title, parameters, responses, and this
+ * box together) use {@link file://./OperationStandalone.tsx `<OpenApi.Operation />`}.
+ *
+ * The target operation is located by either:
+ * - `operationId` — matched against the operation's anchor id (the slugified
+ *   `operationId` from the spec), or
+ * - `method` + `path` — matched against the HTTP method and templated path
+ *   (e.g. `method="GET" path="/v1/blocks"`).
+ *
+ * The spec is resolved from `spec` (the OpenAPI mount, e.g. `/api`). When
+ * omitted, it defaults to the only configured spec; if multiple specs exist,
+ * `spec` is required.
+ */
+export function Playground(props: Playground.Props) {
+  const mounts = Object.keys(specs)
+  const mount = props.spec ?? (mounts.length === 1 ? mounts[0] : undefined)
+
+  if (!mount) {
+    if (mounts.length === 0) return <p>No OpenAPI spec is configured.</p>
+    return (
+      <p>
+        Multiple OpenAPI specs are configured. Pass a <code>spec</code> to{' '}
+        <code>&lt;Playground /&gt;</code> (one of: {mounts.join(', ')}).
+      </p>
+    )
+  }
+
+  const ir = specs[mount]
+  if (!ir) return <p>No OpenAPI spec is mounted at {mount}.</p>
+
+  const operation = findOperation(ir, props)
+  if (!operation)
+    return (
+      <p>
+        No matching operation found in the API mounted at {mount}. Pass an <code>operationId</code>,
+        or a <code>method</code> and <code>path</code>.
+      </p>
+    )
+
+  const samples = codeSamples(operation, ir.servers[0]?.url)
+  if (samples.length === 0) return null
+  const responses = responseSamples(operation)
+
+  return (
+    <div data-v-openapi>
+      <PlaygroundProvider client={ir.client} mount={ir.path}>
+        <CodeSample
+          samples={samples}
+          responses={responses}
+          action={
+            <TestRequestButton
+              method={operation.method}
+              path={operation.path}
+              example={operation.rpcExample}
+            />
+          }
+        />
+      </PlaygroundProvider>
+    </div>
+  )
+}
+
+export declare namespace Playground {
+  type Props = {
+    /**
+     * OpenAPI mount path identifying which spec to read (e.g. `/api`).
+     * Optional when only one spec is configured.
+     */
+    spec?: string | undefined
+    /**
+     * Target operation by its anchor id — the slugified `operationId` from the
+     * spec (e.g. `operationId="getBlocks"`). Mutually exclusive with
+     * `method` + `path`.
+     */
+    operationId?: string | undefined
+    /** HTTP method of the target operation (e.g. `GET`). Pairs with `path`. */
+    method?: string | undefined
+    /** Templated path of the target operation (e.g. `/v1/blocks`). Pairs with `method`. */
+    path?: string | undefined
+  }
+}

--- a/src/react/internal/openapi/find-operation.test.ts
+++ b/src/react/internal/openapi/find-operation.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'vitest'
+import type { Ir, IrOperation } from '../../../internal/openapi/parser.js'
+import { findOperation } from './find-operation.js'
+
+function operation(partial: Partial<IrOperation> & Pick<IrOperation, 'id' | 'method' | 'path'>) {
+  return { parameters: [], responses: [], ...partial } as IrOperation
+}
+
+const ir = {
+  groups: [
+    {
+      id: 'blocks',
+      name: 'Blocks',
+      operations: [
+        operation({ id: 'getblocks', method: 'GET', path: '/v1/blocks' }),
+        operation({ id: 'getblock', method: 'GET', path: '/v1/blocks/{block}' }),
+      ],
+    },
+    {
+      id: 'transactions',
+      name: 'Transactions',
+      operations: [
+        operation({ id: 'gettransaction', method: 'GET', path: '/v1/transactions/{transaction}' }),
+      ],
+    },
+  ],
+} as unknown as Ir
+
+describe('findOperation', () => {
+  test('matches by exact operation id', () => {
+    expect(findOperation(ir, { operationId: 'getblock' })?.path).toBe('/v1/blocks/{block}')
+  })
+
+  test('matches by slugified operationId (spec camelCase)', () => {
+    expect(findOperation(ir, { operationId: 'getBlocks' })?.id).toBe('getblocks')
+  })
+
+  test('matches by method + path (method case-insensitive)', () => {
+    expect(findOperation(ir, { method: 'get', path: '/v1/transactions/{transaction}' })?.id).toBe(
+      'gettransaction',
+    )
+  })
+
+  test('returns undefined when nothing matches', () => {
+    expect(findOperation(ir, { operationId: 'nope' })).toBeUndefined()
+    expect(findOperation(ir, { method: 'GET', path: '/missing' })).toBeUndefined()
+    expect(findOperation(ir, {})).toBeUndefined()
+  })
+})

--- a/src/react/internal/openapi/find-operation.ts
+++ b/src/react/internal/openapi/find-operation.ts
@@ -1,0 +1,38 @@
+import { slug } from '../../../internal/openapi/anchors.js'
+import type { Ir, IrOperation } from '../../../internal/openapi/parser.js'
+
+/**
+ * Locates a single operation within a parsed {@link Ir}, by either its
+ * `operationId` (matched against the operation's anchor id — the slugified
+ * `operationId` from the spec) or an exact `method` + `path` pair.
+ *
+ * Shared by the public `<OpenApi.Operation />` component so the matching logic
+ * stays free of the `virtual:vocs/openapi` module and is unit-testable.
+ */
+export function findOperation(ir: Ir, target: findOperation.Target): IrOperation | undefined {
+  const operations = ir.groups.flatMap((group) => group.operations)
+
+  if (target.operationId) {
+    const id = slug(target.operationId)
+    return operations.find(
+      (operation) => operation.id === target.operationId || operation.id === id,
+    )
+  }
+
+  if (target.method && target.path) {
+    const method = target.method.toUpperCase()
+    return operations.find(
+      (operation) => operation.method === method && operation.path === target.path,
+    )
+  }
+
+  return undefined
+}
+
+export declare namespace findOperation {
+  type Target = {
+    operationId?: string | undefined
+    method?: string | undefined
+    path?: string | undefined
+  }
+}


### PR DESCRIPTION
## Summary

Adds two public components for embedding OpenAPI endpoints inline in authored MDX pages, plus options to control the request/response sample.

- **`<OpenApi.Operation />`** — renders the full operation block (title, parameters, responses, and the interactive sample), the same block used on generated reference pages.
- **`<OpenApi.Playground />`** — renders just the bordered request/response code sample box (Copy, "Try", and per-status tabs) with no surrounding documentation.

Previously the only public OpenAPI component was `<OpenApi.Endpoints />` (the operation list).

## Usage

```mdx
import { OpenApi } from 'vocs'

# Authentication

<!-- full operation block -->
<OpenApi.Operation operationId="getAddressBalances" />

<!-- just the sample box -->
<OpenApi.Playground operationId="getBlocks" />

<!-- by method + path -->
<OpenApi.Playground method="GET" path="/v1/blocks" />

<!-- static (no clickable cross-links) + hide query params -->
<OpenApi.Playground operationId="getBlocks" anchors={false} hideQueryParams />
```

### Props

| Prop | Description |
| --- | --- |
| `operationId` | Target by the operation's anchor id (slugified `operationId`). |
| `method` + `path` | Target by HTTP method + templated path. |
| `spec` | Mount path (e.g. `/api`) to disambiguate when multiple specs are configured. Optional with a single spec. |
| `anchors` | `false` disables the hover-highlighted clickable schema cross-links in the samples. Default `true`. |
| `hideQueryParams` | Omits query parameters from the request sample. Default `false`. |
| `headingLevel` | (`Operation` only) `2` or `3` for the operation title. Default `2`. |

## Implementation

- `src/react/internal/openapi/OperationStandalone.tsx` / `PlaygroundStandalone.tsx` — public adapters; resolve the spec from `virtual:vocs/openapi`, find the operation, and wrap the existing internal `Operation` / `CodeSample` in `PlaygroundProvider` (mirrors how `OpenApiPage`/`ReferenceGroup` already render operations).
- `src/react/internal/openapi/find-operation.ts` — extracted pure matching helper (no virtual-module / Scalar imports) so it's unit-testable.
- `codeSamples()` gained a `{ hideQueryParams }` option (clears `request.queryString` before snippet generation).
- `CodeSample` gained an `anchors` prop (drops `anchorRanges`/`lineAnchors` + click handlers; the hover CSS keys off `data-anchor`, so the affordance disappears too). Threaded through the internal `Operation` and exposed on both public components.
- Exported `Operation` and `Playground` from the `OpenApi` namespace.
- Docs recipes added to `features/openapi.mdx`; working examples added to the playground `api/auth.mdx`.

## Testing

- `pnpm check` (Biome) ✅
- `pnpm check:types` ✅
- `pnpm vitest run src/react/internal/openapi src/internal/openapi` ✅ (65 tests, incl. new `find-operation.test.ts` and a `hideQueryParams` case in `sample.test.ts`)
- `pnpm --filter playground build` ✅ — `/api/auth` renders the embedded operations and playgrounds (by `operationId` and `method`+`path`, including the static / `hideQueryParams` variants).
