### PR TITLE
fix(openapi): forward sidebar.intro, add sidebar.backLink option, fix _layout routing

### DIFF
--- a/.changeset/openapi-sidebar-intro-backlink-layout.md
+++ b/.changeset/openapi-sidebar-intro-backlink-layout.md
@@ -2,8 +2,4 @@
 "vocs": patch
 ---
 
-Fixed OpenAPI section sidebar and routing:
-
-- `sidebar.intro` items are now forwarded into the generated section sidebar from the Vite/site integration (previously only the standalone handler applied them).
-- Added a `sidebar.backLink` option (default `true`) to omit the back link at the top of a generated OpenAPI section sidebar.
-- `_layout` files mounted under an OpenAPI section are no longer registered as standalone page routes or skipped during mounting, so section layouts apply correctly.
+Fixed OpenAPI section sidebar/routing: forward `sidebar.intro` in the Vite integration, add a `sidebar.backLink` option (default `true`), and mount `_layout` files under OpenAPI sections correctly.

--- a/.changeset/openapi-sidebar-intro-backlink-layout.md
+++ b/.changeset/openapi-sidebar-intro-backlink-layout.md
@@ -1,0 +1,9 @@
+---
+"vocs": patch
+---
+
+Fixed OpenAPI section sidebar and routing:
+
+- `sidebar.intro` items are now forwarded into the generated section sidebar from the Vite/site integration (previously only the standalone handler applied them).
+- Added a `sidebar.backLink` option (default `true`) to omit the back link at the top of a generated OpenAPI section sidebar.
+- `_layout` files mounted under an OpenAPI section are no longer registered as standalone page routes or skipped during mounting, so section layouts apply correctly.

--- a/src/internal/openapi/openapi.ts
+++ b/src/internal/openapi/openapi.ts
@@ -62,6 +62,13 @@ export type SidebarExtras = {
    * @default false
    */
   collapsed?: boolean | undefined
+  /**
+   * Render a "back" link at the top of the generated section sidebar. Set to
+   * `false` to omit it (e.g. when the section is the site's primary navigation).
+   *
+   * @default true
+   */
+  backLink?: boolean | undefined
 }
 
 /**

--- a/src/internal/openapi/registry.test.ts
+++ b/src/internal/openapi/registry.test.ts
@@ -79,6 +79,28 @@ describe('mergeSidebar', () => {
     expect(items.at(-1)).toEqual({ text: 'Errors', link: '/api/errors' })
   })
 
+  test('omits the back link when `sidebar.backLink` is false', async () => {
+    const cfg = config(undefined, { backLink: false })
+    await Registry.build(cfg)
+
+    const sidebar = Registry.mergeSidebar(cfg).sidebar as Record<string, { backLink: boolean }>
+    expect(sidebar['/api']?.backLink).toBe(false)
+  })
+
+  test('forwards `sidebar.intro` items into the generated Introduction group', async () => {
+    const cfg = config(undefined, {
+      intro: [{ text: 'Authentication', link: '/api/auth' }],
+    })
+    await Registry.build(cfg)
+
+    const sidebar = Registry.mergeSidebar(cfg).sidebar as Record<string, { items: SidebarItem[] }>
+    const introduction = sidebar['/api']?.items[0]
+    expect(introduction?.items).toEqual([
+      { text: 'Overview', link: '/api' },
+      { text: 'Authentication', link: '/api/auth' },
+    ])
+  })
+
   test('does not mutate the input config', async () => {
     const cfg = config([{ text: 'Home', link: '/' }])
     await Registry.build(cfg)

--- a/src/internal/openapi/registry.ts
+++ b/src/internal/openapi/registry.ts
@@ -50,8 +50,11 @@ export function sidebars(
   const result: Record<string, { backLink: boolean; items: SidebarItem<true>[] }> = {}
   if (!cache) return result
   for (const [path, ir] of Object.entries(cache)) {
-    const collapsed = config?.openapi?.find((entry) => entry.path === path)?.sidebar?.collapsed
-    result[path] = { backLink: true, items: Sidebar.toSidebar(ir, { collapsed }) }
+    const entry = config?.openapi?.find((entry) => entry.path === path)
+    const collapsed = entry?.sidebar?.collapsed
+    const intro = entry?.sidebar?.intro
+    const backLink = entry?.sidebar?.backLink ?? true
+    result[path] = { backLink, items: Sidebar.toSidebar(ir, { collapsed, intro }) }
   }
   return result
 }

--- a/src/waku/internal/patches/router.ts
+++ b/src/waku/internal/patches/router.ts
@@ -127,7 +127,9 @@ export function router(
           ? items.slice(0, -1)
           : items
         ).join('/')
-      consumerModules.set(route, importFn)
+      // `_layout` files are layouts, not pages: never register them as a
+      // consumer page route.
+      if (last !== '_layout') consumerModules.set(route, importFn)
     }
   }
 
@@ -189,12 +191,14 @@ export function router(
           // creating a standalone page here so the OpenAPI loop can mount it
           // with the generated reference body (it reads the same module as the
           // page intro).
-          if (openapiRoutePaths.has(path)) continue
+          // `_layout` files are skipped so the OpenAPI loop can mount the
+          // section layout itself, rather than being treated as an override.
+          if (openapiRoutePaths.has(path) && pathItems.at(-1) !== '_layout') continue
 
           // A consumer page mounted *under* an OpenAPI section path (e.g.
           // `/api/auth`) but not at a generated route is a "guide" page. Skip it
           // here so the OpenAPI loop can mount it with the section layout.
-          if (isOpenApiGuidePath(path)) continue
+          if (isOpenApiGuidePath(path) && pathItems.at(-1) !== '_layout') continue
 
           const sourceFile = isBuiltIn ? undefined : srcPath
           const sourceFileProperty = sourceFile ? { unstable_sourceFile: sourceFile } : {}


### PR DESCRIPTION
## Summary

Three independent fixes to the OpenAPI section sidebar and routing, surfaced while building a docs site that uses an OpenAPI mount as primary navigation.

### 1. Forward `sidebar.intro` in the Vite/site integration (bug fix)
`sidebar.intro` is a documented `SidebarExtras` option, but `registry.sidebars()` never forwarded it to `toSidebar` — so intro items only appeared via the standalone server handler (`server/openapi/state.ts`), not in the Vite/site build. This wires it through so both code paths behave the same.

### 2. Add `sidebar.backLink` option (default `true`)
The generated section sidebar always rendered a back link. Added an opt-out `sidebar.backLink?: boolean` (default `true`, fully backward compatible) for sites where an OpenAPI section *is* the primary navigation.

### 3. Fix `_layout` handling under OpenAPI sections (bug fix)
`_layout` files mounted under an OpenAPI section were registered as standalone consumer page routes and skipped during the OpenAPI mount loop, so a section `_layout` never applied. Now `_layout` files are excluded from consumer page registration and not treated as overrides/guides, letting the section layout mount correctly.

## Tests
- Added 2 tests in `registry.test.ts` covering `backLink: false` and `intro` forwarding.
- `tsc -b` clean; all 54 `src/internal/openapi` tests pass; biome clean.

## Changeset
Included (`patch`).