### PR TITLE
fix(openapi): don't flag OpenAPI-generated routes as dead links

### DIFF
--- a/.changeset/openapi-deadlink-routes.md
+++ b/.changeset/openapi-deadlink-routes.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Stopped flagging OpenAPI-generated routes (the mount overview and per-category pages) as dead links.

--- a/src/internal/mdx.test.ts
+++ b/src/internal/mdx.test.ts
@@ -8,8 +8,10 @@ import { unified } from 'unified'
 import { describe, expect, it } from 'vitest'
 import * as Config from './config.js'
 import {
+  deadLinks,
   getCompileOptions,
   recmaMdxLayout,
+  rehypeLinks,
   remarkCodeTitle,
   remarkDefaultFrontmatter,
   remarkFilename,
@@ -18,6 +20,7 @@ import {
   remarkRestoreUnknownTextDirectives,
   remarkSubheading,
 } from './mdx.js'
+import * as OpenApiRegistry from './openapi/registry.js'
 
 type CodeNode = {
   type: 'code'
@@ -553,5 +556,64 @@ describe('remarkFileTree', () => {
       comment: 'A page at /guide/getting-started.',
       highlighted: true,
     })
+  })
+})
+
+describe('rehypeLinks', () => {
+  function anchor(href: string) {
+    return {
+      type: 'element' as const,
+      tagName: 'a',
+      properties: { href } as Record<string, unknown>,
+      children: [],
+    }
+  }
+
+  it('allows OpenAPI-generated routes and flags genuinely dead links', async () => {
+    OpenApiRegistry.invalidate()
+    const config = Config.define({
+      rootDir: process.cwd(),
+      openapi: [
+        {
+          path: '/api',
+          spec: {
+            openapi: '3.1.0',
+            info: { title: 'Test', version: '1.0.0' },
+            tags: [{ name: 'Indexer' }],
+            paths: {
+              '/v1/indexer/query': {
+                get: {
+                  tags: ['Indexer'],
+                  operationId: 'indexerQuery',
+                  responses: { '200': { description: 'ok' } },
+                },
+              },
+            },
+          },
+        },
+      ],
+    })
+    await OpenApiRegistry.build(config)
+
+    const overview = anchor('/api')
+    const generated = anchor('/api/indexer')
+    const trailing = anchor('/api/indexer/')
+    const dead = anchor('/api/does-not-exist')
+    const tree = {
+      type: 'root' as const,
+      children: [overview, generated, trailing, dead],
+    }
+    const vfile = { path: path.join(process.cwd(), 'src/pages/api/indexer-api.mdx') }
+
+    rehypeLinks(config)()(tree as never, vfile as never)
+
+    expect(overview.properties['data-v-dead-link']).toBeUndefined()
+    expect(generated.properties['data-v-dead-link']).toBeUndefined()
+    expect(trailing.properties['data-v-dead-link']).toBeUndefined()
+    expect(dead.properties['data-v-dead-link']).toBe('')
+    expect(deadLinks.get(vfile.path)).toEqual(['/api/does-not-exist'])
+
+    deadLinks.delete(vfile.path)
+    OpenApiRegistry.invalidate()
   })
 })

--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -36,6 +36,7 @@ import * as yaml from 'yaml'
 import type * as Config from './config.js'
 import * as Git from './git.js'
 import * as Icons from './icons.js'
+import * as OpenApiRegistry from './openapi/registry.js'
 import { rehypeImageSize } from './rehype-image-size.js'
 import { remarkVocsScope } from './remark-vocs-scope.js'
 import { remarkSandbox } from './sandbox.js'
@@ -435,6 +436,19 @@ export function rehypeLinks(config: Config.Config) {
   return () => (tree: HAst.Root, vfile: VFile) => {
     const links: string[] = []
 
+    // OpenAPI specs generate routes (the mount overview and one page per
+    // category group) that have no backing file in `pages/`, so links to them
+    // would otherwise be flagged as dead. Collect the valid routes from the
+    // parsed specs to allow them through.
+    const openapiRoutes = new Set<string>()
+    const specs = OpenApiRegistry.peek()
+    if (specs)
+      for (const [mount, ir] of Object.entries(specs)) {
+        const base = mount === '/' ? '' : mount.replace(/\/$/, '')
+        openapiRoutes.add(base || '/')
+        for (const group of ir.groups) openapiRoutes.add(`${base}/${group.id}`)
+      }
+
     UnistUtil.visit(tree, 'element', (node) => {
       const element = node as HAst.Element
       if (element.tagName !== 'a') return
@@ -469,8 +483,16 @@ export function rehypeLinks(config: Config.Config) {
         ? path.join(pagesDirPath, linkPath)
         : path.resolve(currentDir, linkPath ?? '')
 
+      // Allow OpenAPI-generated routes (no backing file) by matching the link's
+      // absolute path against the routes collected from the parsed specs.
+      const isOpenapiRoute =
+        linkPath !== undefined &&
+        linkPath.startsWith('/') &&
+        openapiRoutes.has(linkPath.replace(/\/$/, '') || '/')
+
       // Check for file existence (try with extensions if not present)
       const exists =
+        isOpenapiRoute ||
         fs.existsSync(resolvedPath) ||
         extensions.some((ext) => fs.existsSync(`${resolvedPath}${ext}`)) ||
         extensions.some((ext) => fs.existsSync(`${resolvedPath}/index${ext}`))


### PR DESCRIPTION
The dead-link checker only resolved links against the filesystem, so links to OpenAPI-generated routes (the mount overview and per-category pages, e.g. `/api/indexer`) were reported as dead even though they render fine at runtime.

`rehypeLinks` now collects the routes from the parsed specs (the mount path plus `${mount}/${group.id}` for each category) and treats matching absolute links as valid. Genuinely missing links are still flagged.

Added a unit test covering the overview route, a generated category route (with and without a trailing slash), and a genuinely dead link.