### PR TITLE
feat: add /.well-known/agent.json discovery manifest

### DIFF
--- a/.changeset/agent-manifest.md
+++ b/.changeset/agent-manifest.md
@@ -1,0 +1,5 @@
+---
+"vocs": minor
+---
+
+Added a `/.well-known/agent.json` discovery manifest for AI agents. The manifest is generated at build time (and served in dev) when `baseUrl` is configured, and ties together the machine-readable surfaces Vocs already emits — `llms.txt`, `llms-full.txt`, and `sitemap.xml` — behind a single predictable well-known path, so agents can discover the docs corpus without guessing at conventional URLs.

--- a/src/internal/agent.test.ts
+++ b/src/internal/agent.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'vitest'
+import { buildAgentManifest } from './agent.js'
+
+describe('buildAgentManifest', () => {
+  test('title only', () => {
+    const manifest = buildAgentManifest({
+      title: 'My Docs',
+      siteUrl: 'https://example.com',
+    })
+
+    expect(manifest).toMatchInlineSnapshot(`
+      {
+        "name": "My Docs",
+        "resources": {
+          "llms": "https://example.com/llms.txt",
+          "llmsFull": "https://example.com/llms-full.txt",
+          "sitemap": "https://example.com/sitemap.xml",
+        },
+        "url": "https://example.com",
+      }
+    `)
+  })
+
+  test('with description', () => {
+    const manifest = buildAgentManifest({
+      title: 'My Docs',
+      description: 'Docs for Agents & Humans',
+      siteUrl: 'https://example.com',
+    })
+
+    expect(manifest.description).toBe('Docs for Agents & Humans')
+  })
+
+  test('omits description when absent', () => {
+    const manifest = buildAgentManifest({
+      title: 'My Docs',
+      siteUrl: 'https://example.com',
+    })
+
+    expect('description' in manifest).toBe(false)
+  })
+
+  test('strips trailing slash from siteUrl', () => {
+    const manifest = buildAgentManifest({
+      title: 'My Docs',
+      siteUrl: 'https://example.com/',
+    })
+
+    expect(manifest.url).toBe('https://example.com')
+    expect(manifest.resources.llms).toBe('https://example.com/llms.txt')
+  })
+
+  test('builds absolute resource URLs under a base path', () => {
+    const manifest = buildAgentManifest({
+      title: 'My Docs',
+      siteUrl: 'https://example.com/docs',
+    })
+
+    expect(manifest.resources).toEqual({
+      llms: 'https://example.com/docs/llms.txt',
+      llmsFull: 'https://example.com/docs/llms-full.txt',
+      sitemap: 'https://example.com/docs/sitemap.xml',
+    })
+  })
+})

--- a/src/internal/agent.ts
+++ b/src/internal/agent.ts
@@ -1,0 +1,50 @@
+/**
+ * Builds the `/.well-known/agent.json` discovery manifest.
+ *
+ * The manifest gives AI agents a single, predictable entrypoint that ties
+ * together the machine-readable surfaces Vocs already emits (`llms.txt`,
+ * `llms-full.txt`, `sitemap.xml`) alongside basic site metadata. Agents can
+ * fetch one well-known file to discover where the full docs corpus lives,
+ * rather than guessing at conventional paths.
+ */
+export function buildAgentManifest(
+  options: buildAgentManifest.Options,
+): buildAgentManifest.Manifest {
+  const { description, siteUrl, title } = options
+  const base = siteUrl.replace(/\/$/, '')
+  return {
+    name: title,
+    ...(description ? { description } : {}),
+    url: base,
+    resources: {
+      llms: `${base}/llms.txt`,
+      llmsFull: `${base}/llms-full.txt`,
+      sitemap: `${base}/sitemap.xml`,
+    },
+  }
+}
+
+export declare namespace buildAgentManifest {
+  type Options = {
+    /** Site title, used as the manifest `name`. */
+    title: string
+    /** General site description. Omitted from the manifest when absent. */
+    description?: string | undefined
+    /** Absolute site origin used to build resource URLs (no trailing slash required). */
+    siteUrl: string
+  }
+
+  type Manifest = {
+    name: string
+    description?: string
+    url: string
+    resources: {
+      /** Concise, link-only index of every page. */
+      llms: string
+      /** Full Markdown corpus of the docs. */
+      llmsFull: string
+      /** XML sitemap with per-page last-modified dates. */
+      sitemap: string
+    }
+  }
+}

--- a/src/internal/vite-plugins.ts
+++ b/src/internal/vite-plugins.ts
@@ -5,6 +5,7 @@ import mdxPlugin from '@mdx-js/rollup'
 import tailwindcss, { type PluginOptions as TailwindOptions } from '@tailwindcss/vite'
 import type { PluginOption, ResolvedConfig, Rolldown, ViteDevServer } from 'vite'
 import { createLogger } from 'vite'
+import * as Agent from './agent.js'
 import * as Config from './config.js'
 import * as ConfigSerializer from './config-serializer.js'
 import * as Git from './git.js'
@@ -488,6 +489,78 @@ export function sitemap(config: Config.Config): PluginOption {
           encoding: 'utf-8',
         }),
       ])
+    },
+  }
+}
+
+/**
+ * Generates `/.well-known/agent.json`, a discovery manifest for AI agents.
+ *
+ * Ties together the machine-readable surfaces Vocs already emits (`llms.txt`,
+ * `llms-full.txt`, `sitemap.xml`) behind a single predictable well-known path,
+ * so agents can discover the docs corpus without guessing at conventional URLs.
+ * Requires `baseUrl` to be configured for absolute resource URLs in production.
+ *
+ * @param config - Vocs configuration.
+ * @returns Plugin.
+ */
+export function agentManifest(config: Config.Config): PluginOption {
+  const { baseUrl, description, title } = config
+  const manifestPath = '.well-known/agent.json'
+
+  let built = false
+  let viteConfig: ResolvedConfig
+
+  function getSiteUrl(): string | null {
+    return baseUrl ?? (viteConfig.command === 'serve' ? 'http://localhost:5173' : null)
+  }
+
+  function buildManifestContent(): string | null {
+    const siteUrl = getSiteUrl()
+    if (!siteUrl) {
+      logger.warn('Agent manifest generation skipped: baseUrl is not configured', {
+        timestamp: true,
+      })
+      return null
+    }
+    const manifest = Agent.buildAgentManifest({ title, description, siteUrl })
+    return `${JSON.stringify(manifest, null, 2)}\n`
+  }
+
+  return {
+    name: 'vocs:agent-manifest',
+    enforce: 'post',
+    configResolved(resolvedConfig) {
+      viteConfig = resolvedConfig
+    },
+    configureServer(server) {
+      server.middlewares.use(async (req, res, next) => {
+        if (req.url === `/${manifestPath}`) {
+          const content = buildManifestContent()
+          if (!content) {
+            res.statusCode = 404
+            res.end('agent.json not available: baseUrl is not configured')
+            return
+          }
+          res.setHeader('Content-Type', 'application/json')
+          res.end(content)
+          return
+        }
+
+        next()
+      })
+    },
+    async writeBundle(options) {
+      if (!options.dir?.endsWith('/public')) return
+      if (built) return
+      built = true
+
+      const content = buildManifestContent()
+      if (!content) return
+
+      const outPath = path.join(options.dir, manifestPath)
+      await fs.mkdir(path.dirname(outPath), { recursive: true })
+      await fs.writeFile(outPath, content, { encoding: 'utf-8' })
     },
   }
 }

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -16,6 +16,7 @@ export async function vocs(): Promise<PluginOption[]> {
   const config = await Config.resolve()
 
   return [
+    Plugins.agentManifest(config),
     Plugins.arraybuffer(),
     Plugins.deps(),
     Plugins.groupIcons(config),


### PR DESCRIPTION
## Overview

Adds a `/.well-known/agent.json` discovery manifest for AI agents. It ties together the machine-readable surfaces Vocs already emits — `llms.txt`, `llms-full.txt`, and `sitemap.xml` — behind a single predictable well-known path, so an agent can fetch one file to discover where the docs corpus lives instead of guessing at conventional URLs.

Example output (from the playground with `baseUrl` set):

```json
{
  "name": "Vocs",
  "description": "Vocs is a library for creating documentation websites.",
  "url": "https://example.com",
  "resources": {
    "llms": "https://example.com/llms.txt",
    "llmsFull": "https://example.com/llms-full.txt",
    "sitemap": "https://example.com/sitemap.xml"
  }
}
```

## How it works

A new `agentManifest` Vite plugin, modeled directly on the existing `sitemap` plugin:

- **Dev:** `configureServer` middleware serves `/.well-known/agent.json` on the fly.
- **Build:** `writeBundle` writes `dist/public/.well-known/agent.json`.
- **Gating:** uses the same `baseUrl` resolution as `sitemap` (absolute URLs in prod, `localhost:5173` in dev). When `baseUrl` is unset it warns and skips — identical behavior to the sitemap/robots plugins, so no surprises and no broken relative links.

The manifest body is built by a small pure function (`src/internal/agent.ts`, mirroring `llms.ts`) so it's trivially unit-testable.

## Verification

- ✅ `pnpm exec tsc -b` — clean
- ✅ `biome check` — clean
- ✅ Full suite: **429 passed, 3 skipped** (incl. 5 new tests in `agent.test.ts`)
- ✅ **Dev:** ran the playground with `BASE_URL` set → `GET /.well-known/agent.json` returns `200 application/json` with correct content, alongside the real `/llms.txt` and `/sitemap.xml` it links.
- ✅ **Build:** production build of the playground emits `dist/public/.well-known/agent.json` next to `llms.txt` and `sitemap.xml`.

## Notes / open questions for maintainers

1. **Path choice.** `/.well-known/agent.json` overlaps with Google's A2A "Agent Card" convention. If you'd prefer to avoid that collision (e.g. `/.well-known/docs.json` or similar), the path is a single constant in the plugin — easy to change. Happy to adjust to whatever you prefer.
2. **Always-on vs opt-in.** I followed the `llms`/`sitemap` precedent (always generated, gated on `baseUrl`). If you'd rather gate it behind a config flag, easy to add.
3. **Resource set.** Kept it to surfaces Vocs emits universally. If you'd like to make the resource list extensible via config, that's a natural follow-up.
4. **Docs.** Left undocumented to match `llms.txt`/`sitemap.xml` (also undocumented today). Glad to add a page if you'd like.

Context: came out of a docs AI-readiness effort — happy to iterate on any of the above.
