### PR TITLE
fix: preserve public `robots.txt` and `sitemap.xml`

### DIFF
--- a/.changeset/public-robots-sitemap.md
+++ b/.changeset/public-robots-sitemap.md
@@ -1,0 +1,5 @@
+---
+'vocs': patch
+---
+
+Fixed sitemap generation overwriting user-provided `public/robots.txt` and `public/sitemap.xml` files.

--- a/src/internal/vite-plugins.test.ts
+++ b/src/internal/vite-plugins.test.ts
@@ -1,0 +1,98 @@
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import type { ResolvedConfig } from 'vite'
+import { afterEach, describe, expect, test } from 'vitest'
+import type * as Config from './config.js'
+import { sitemap } from './vite-plugins.js'
+
+const tempDirs = new Set<string>()
+
+afterEach(async () => {
+  await Promise.all([...tempDirs].map((dir) => fs.rm(dir, { force: true, recursive: true })))
+  tempDirs.clear()
+})
+
+describe('sitemap', () => {
+  test('generates robots.txt and sitemap.xml when public files do not exist', async () => {
+    const fixture = await createFixture()
+    const plugin = createSitemapPlugin(fixture.rootDir, fixture.publicDir)
+
+    await plugin.writeBundle({ dir: fixture.outDir })
+
+    await expect(fs.readFile(path.join(fixture.outDir, 'robots.txt'), 'utf-8')).resolves.toContain(
+      'Sitemap: https://example.com/sitemap.xml',
+    )
+    await expect(fs.readFile(path.join(fixture.outDir, 'sitemap.xml'), 'utf-8')).resolves.toContain(
+      '<loc>https://example.com/</loc>',
+    )
+  })
+
+  test('preserves public robots.txt', async () => {
+    const fixture = await createFixture()
+    const plugin = createSitemapPlugin(fixture.rootDir, fixture.publicDir)
+    const robots = 'User-agent: *\nContent-Signal: ai-train=yes, search=yes, ai-input=yes\n'
+
+    await fs.writeFile(path.join(fixture.publicDir, 'robots.txt'), robots)
+    await fs.writeFile(path.join(fixture.outDir, 'robots.txt'), robots)
+    await plugin.writeBundle({ dir: fixture.outDir })
+
+    await expect(fs.readFile(path.join(fixture.outDir, 'robots.txt'), 'utf-8')).resolves.toBe(
+      robots,
+    )
+    await expect(fs.readFile(path.join(fixture.outDir, 'sitemap.xml'), 'utf-8')).resolves.toContain(
+      '<loc>https://example.com/</loc>',
+    )
+  })
+
+  test('preserves public sitemap.xml', async () => {
+    const fixture = await createFixture()
+    const plugin = createSitemapPlugin(fixture.rootDir, fixture.publicDir)
+    const sitemapXml = '<urlset><url><loc>https://custom.example/</loc></url></urlset>\n'
+
+    await fs.writeFile(path.join(fixture.publicDir, 'sitemap.xml'), sitemapXml)
+    await fs.writeFile(path.join(fixture.outDir, 'sitemap.xml'), sitemapXml)
+    await plugin.writeBundle({ dir: fixture.outDir })
+
+    await expect(fs.readFile(path.join(fixture.outDir, 'sitemap.xml'), 'utf-8')).resolves.toBe(
+      sitemapXml,
+    )
+    await expect(fs.readFile(path.join(fixture.outDir, 'robots.txt'), 'utf-8')).resolves.toContain(
+      'Sitemap: https://example.com/sitemap.xml',
+    )
+  })
+})
+
+async function createFixture() {
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vocs-sitemap-'))
+  tempDirs.add(rootDir)
+
+  const pagesDir = path.join(rootDir, 'src/pages')
+  const publicDir = path.join(rootDir, 'public')
+  const outDir = path.join(rootDir, 'dist/public')
+  await fs.mkdir(pagesDir, { recursive: true })
+  await fs.mkdir(publicDir, { recursive: true })
+  await fs.mkdir(outDir, { recursive: true })
+  await fs.writeFile(path.join(pagesDir, 'index.mdx'), '# Hello\n')
+
+  return { outDir, publicDir, rootDir }
+}
+
+function createSitemapPlugin(rootDir: string, publicDir: string) {
+  const plugin = sitemap({
+    baseUrl: 'https://example.com',
+    pagesDir: 'pages',
+    srcDir: 'src',
+  } as Config.Config) as unknown as {
+    configResolved(config: ResolvedConfig): void
+    writeBundle(options: { dir: string }): Promise<void>
+  }
+
+  plugin.configResolved({
+    command: 'build',
+    publicDir,
+    root: rootDir,
+  } as ResolvedConfig)
+
+  return plugin
+}

--- a/src/internal/vite-plugins.ts
+++ b/src/internal/vite-plugins.ts
@@ -371,6 +371,16 @@ export function sitemap(config: Config.Config): PluginOption {
     ].join('\n')
   }
 
+  async function hasPublicFile(fileName: string): Promise<boolean> {
+    if (!viteConfig.publicDir) return false
+    try {
+      await fs.access(path.join(viteConfig.publicDir, fileName))
+      return true
+    } catch {
+      return false
+    }
+  }
+
   async function buildSitemapContent(): Promise<string | null> {
     const siteUrl = getSiteUrl()
     if (!siteUrl) {
@@ -482,12 +492,20 @@ export function sitemap(config: Config.Config): PluginOption {
       const sitemapContent = await buildSitemapContent()
       if (!sitemapContent || !siteUrl) return
 
-      await Promise.all([
-        fs.writeFile(path.join(options.dir, 'sitemap.xml'), sitemapContent, { encoding: 'utf-8' }),
-        fs.writeFile(path.join(options.dir, 'robots.txt'), buildRobotsTxt(siteUrl), {
-          encoding: 'utf-8',
-        }),
-      ])
+      const writes: Promise<void>[] = []
+      if (!(await hasPublicFile('sitemap.xml')))
+        writes.push(
+          fs.writeFile(path.join(options.dir, 'sitemap.xml'), sitemapContent, {
+            encoding: 'utf-8',
+          }),
+        )
+      if (!(await hasPublicFile('robots.txt')))
+        writes.push(
+          fs.writeFile(path.join(options.dir, 'robots.txt'), buildRobotsTxt(siteUrl), {
+            encoding: 'utf-8',
+          }),
+        )
+      await Promise.all(writes)
     },
   }
 }


### PR DESCRIPTION
The sitemap plugin now respects files that users place in Vite's public directory before writing generated `robots.txt` or `sitemap.xml` assets.

This restores the expected public-file precedence for custom crawler directives such as `Content-Signal`, while preserving generated files for projects without overrides.

Fixes https://github.com/wevm/vocs/issues/518
