### PR TITLE
fix(twoslash): render custom tags in checkOnly mode and preserve order

### DIFF
--- a/.changeset/twoslash-custom-tags-checkonly.md
+++ b/.changeset/twoslash-custom-tags-checkonly.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed custom display tags (`@log`/`@error`/`@warn`/`@annotate`) being stripped instead of rendered in Twoslash `checkOnly` mode, and fixed runs of consecutive tags rendering in reverse order.

--- a/src/internal/shiki-transformers.test.ts
+++ b/src/internal/shiki-transformers.test.ts
@@ -2,6 +2,7 @@ import { type BundledLanguage, createHighlighter } from 'shiki'
 import { describe, expect, it } from 'vitest'
 import {
   checkTwoslashSnippets,
+  customTag,
   inlineLanguage,
   notationBlock,
   notationInclude,
@@ -291,6 +292,93 @@ appSettings.version`,
     expect(twoslashErrors).toHaveLength(0)
 
     resetTwoslashSnippets()
+
+    highlighter.dispose()
+  })
+
+  it('should render custom tag comments in check-only mode', async () => {
+    const highlighter = await createHighlighter({
+      themes: ['github-dark'],
+      langs: ['typescript'],
+    })
+
+    const html = highlighter.codeToHtml(
+      `const value = 1
+// @log: value: 10500000n
+// @log: formatted: '10.5'`,
+      {
+        lang: 'typescript',
+        theme: 'github-dark',
+        transformers: [
+          twoslash({ checkOnly: true, explicitTrigger: false, throws: false }),
+          customTag(),
+        ],
+      },
+    )
+
+    // Check-only mode emits no twoslash tag nodes, so the downstream
+    // `customTag()` transformer must render the `@log` lines instead of them
+    // being stripped entirely.
+    expect(html).toContain('twoslash-tag-log-line')
+    expect(html).toContain('value: 10500000n')
+    expect(html).toContain("formatted: '10.5'")
+    expect(html).not.toContain('@log')
+
+    // Adjacent tags must keep their source order.
+    expect(html.indexOf('value: 10500000n')).toBeLessThan(html.indexOf("formatted: '10.5'"))
+
+    highlighter.dispose()
+  })
+})
+
+describe('customTag', () => {
+  it('should render custom tags as styled tag lines', async () => {
+    const highlighter = await createHighlighter({
+      themes: ['github-dark'],
+      langs: ['typescript'],
+    })
+
+    const html = highlighter.codeToHtml(
+      `const value = 1
+// @log: hello
+// @error: boom`,
+      {
+        lang: 'typescript',
+        theme: 'github-dark',
+        transformers: [customTag()],
+      },
+    )
+
+    expect(html).toContain('twoslash-tag-log-line')
+    expect(html).toContain('twoslash-tag-error-line')
+    expect(html).toContain('hello')
+    expect(html).toContain('boom')
+    expect(html).not.toContain('@log')
+    expect(html).not.toContain('@error')
+
+    highlighter.dispose()
+  })
+
+  it('should preserve source order for consecutive tags', async () => {
+    const highlighter = await createHighlighter({
+      themes: ['github-dark'],
+      langs: ['typescript'],
+    })
+
+    const html = highlighter.codeToHtml(
+      `const value = 1
+// @log: one
+// @log: two
+// @log: three`,
+      {
+        lang: 'typescript',
+        theme: 'github-dark',
+        transformers: [customTag()],
+      },
+    )
+
+    const order = [...html.matchAll(/twoslash-tag-log-line[^>]*>([^<]*)</g)].map((m) => m[1])
+    expect(order).toEqual(['one', 'two', 'three'])
 
     highlighter.dispose()
   })

--- a/src/internal/shiki-transformers.ts
+++ b/src/internal/shiki-transformers.ts
@@ -423,7 +423,13 @@ function checkOnlyTwoslasher(options: {
     })
 
     return {
-      code: removeTwoslashNotations(code, twoslashOptions.customTags),
+      // Keep custom display tags (`@log`/`@error`/`@warn`/`@annotate`) in the
+      // emitted code so the downstream `customTag()` transformer can render
+      // them. In check-only mode we don't emit twoslash tag nodes (so the
+      // renderer's `lineCustomTag` never runs); passing `customTags` here would
+      // strip those lines entirely and they'd never be displayed. Other
+      // twoslash notations (compiler flags, `^?` markers) are still removed.
+      code: removeTwoslashNotations(code),
       nodes: [],
     }
   }
@@ -1023,7 +1029,6 @@ export function customTag(): ShikiTransformer {
   const tagPattern = new RegExp(`@(${customTags.join('|')}):\\s*(.+)`)
 
   type Element = import('hast').Element
-  type Text = import('hast').Text
 
   function getTextContent(element: Element): string {
     let text = ''
@@ -1036,88 +1041,32 @@ export function customTag(): ShikiTransformer {
 
   return {
     name: 'vocs:custom-tag',
-    preprocess(code, options) {
-      const meta = options.meta?.__raw || ''
-      if (meta.includes('twoslash')) return code
-      return code
-    },
     code(code) {
       const lines = code.children.filter((x) => x.type === 'element') as Element[]
-      const tagsToInsert: Array<{ afterIndex: number; type: string; message: string }> = []
-      const linesToRemove: Element[] = []
 
-      lines.forEach((line, index) => {
+      for (const line of lines) {
         const lineText = getTextContent(line)
         const match = lineText.match(tagPattern)
-        if (!match) return
+        if (!match) continue
 
         const [, tagType, message] = match as [string, string, string]
-        tagsToInsert.push({
-          afterIndex: index,
-          type: tagType,
-          message: message.trim(),
-        })
-        linesToRemove.push(line)
-      })
 
-      // remove lines with tags
-      for (const line of linesToRemove) {
-        const index = code.children.indexOf(line)
-        if (index === -1) continue
-        const nextLine = code.children[index + 1]
-        let removeLength = 1
-        // also remove the newline after the line
-        if (nextLine?.type === 'text' && nextLine.value === '\n') removeLength = 2
-        code.children.splice(index, removeLength)
-      }
-
-      // adjust indices for removed lines
-      const adjustedTags = tagsToInsert.map((tag) => {
-        let adjustedIndex = tag.afterIndex
-        for (const removedLine of linesToRemove) {
-          const removedIndex = lines.indexOf(removedLine)
-          if (removedIndex !== -1 && removedIndex <= tag.afterIndex) adjustedIndex--
-        }
-        return { ...tag, afterIndex: adjustedIndex }
-      })
-
-      // insert tag divs (in reverse order to maintain indices)
-      const sortedTags = adjustedTags.sort((a, b) => b.afterIndex - a.afterIndex)
-
-      for (const tag of sortedTags) {
-        const currentLines = code.children.filter((x) => x.type === 'element') as Element[]
-        const targetLine = currentLines[tag.afterIndex]
-        if (!targetLine) continue
-
-        const targetIndex = code.children.indexOf(targetLine)
-        if (targetIndex === -1) continue
-
-        const targetClasses = targetLine.properties?.['class']
-        const existingClasses = Array.isArray(targetClasses)
-          ? targetClasses.filter((x) => typeof x === 'string' && x && !x.startsWith('tag-'))
-          : typeof targetClasses === 'string'
-            ? targetClasses.split(' ').filter((x) => x && !x.startsWith('tag-'))
+        // Rewrite the comment line in place. Removing the line and reinserting
+        // a new node would reverse runs of adjacent tags (e.g. consecutive
+        // `// @log:` lines), so we keep the existing line element and swap its
+        // class + content instead — preserving source order and position.
+        const classes = line.properties?.['class']
+        const existingClasses = Array.isArray(classes)
+          ? classes.filter((x) => typeof x === 'string' && x && !x.startsWith('tag-'))
+          : typeof classes === 'string'
+            ? classes.split(' ').filter((x) => x && !x.startsWith('tag-'))
             : []
 
-        const tagLine: Element = {
-          type: 'element',
-          tagName: 'span',
-          properties: {
-            class: [
-              ...existingClasses,
-              'line',
-              'twoslash-tag-line',
-              `twoslash-tag-${tag.type}-line`,
-            ],
-          },
-          children: [{ type: 'text', value: tag.message }],
+        line.properties = {
+          ...line.properties,
+          class: [...existingClasses, 'twoslash-tag-line', `twoslash-tag-${tagType}-line`],
         }
-
-        // insert after the target line + its newline
-        const nextIndex = targetIndex + 1
-        if (code.children[nextIndex]?.type === 'text' && code.children[nextIndex]?.value === '\n')
-          code.children.splice(nextIndex + 1, 0, tagLine, { type: 'text', value: '\n' } as Text)
-        else code.children.splice(nextIndex, 0, tagLine, { type: 'text', value: '\n' } as Text)
+        line.children = [{ type: 'text', value: message.trim() }]
       }
     },
   }


### PR DESCRIPTION
## Problem

In Twoslash `checkOnly` mode, custom display tags (`// @log:`, `// @error:`, `// @warn:`, `// @annotate:`) are silently stripped from code blocks and never rendered.

`checkOnlyTwoslasher` calls `removeTwoslashNotations(code, twoslashOptions.customTags)`. Because `@shikijs/twoslash` defaults `customTags` to `['annotate','log','warn','error']`, those lines get removed; and since `checkOnly` returns `nodes: []`, the renderer's `lineCustomTag` never runs. The downstream `customTag()` transformer then finds nothing to render, so the lines vanish entirely.

This affects any site using `twoslash: { checkOnly: true }` (e.g. [viem](https://viem.sh)'s docs).

## Fix

1. **`checkOnlyTwoslasher`**: call `removeTwoslashNotations(code)` without `customTags`, so the custom display tags survive for the downstream `customTag()` transformer to render. Compiler flags and `^?` markers are still stripped.
2. **`customTag()`**: rewrite tag comment lines **in place** instead of remove-then-reinsert. The old logic collapsed adjacent tags to the same index and reinserted in reverse, so runs of consecutive tags (e.g. multiple `// @log:` lines) rendered **backwards**. This was a latent bug now exposed since `checkOnly` routes through this path.

## Tests

Added 3 regression tests in `shiki-transformers.test.ts`:
- `checkOnly` mode renders `@log` tags (and not the raw `@log` text)
- custom tags render as styled tag lines
- consecutive tags preserve source order

Verified with `pnpm check:types` and the full `shiki-transformers` suite (41 passing). Also verified end-to-end against viem's docs build: all `@log` output lines now render in correct order.