### PR TITLE
fix(twoslash): preserve leading indentation in custom tags

### DIFF
--- a/.changeset/twoslash-tag-indentation.md
+++ b/.changeset/twoslash-tag-indentation.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Preserved leading indentation in custom display tags (`@log`/`@error`/`@warn`/`@annotate`), so multi-line blocks (e.g. logged objects) keep their indentation instead of being flattened to the left margin.

--- a/src/internal/shiki-transformers.test.ts
+++ b/src/internal/shiki-transformers.test.ts
@@ -382,6 +382,31 @@ describe('customTag', () => {
 
     highlighter.dispose()
   })
+
+  it('should preserve leading indentation in tag content', async () => {
+    const highlighter = await createHighlighter({
+      themes: ['github-dark'],
+      langs: ['typescript'],
+    })
+
+    const html = highlighter.codeToHtml(
+      `const value = 1
+// @log: {
+// @log:   from: '0x',
+// @log:   value: 1n,
+// @log: }`,
+      {
+        lang: 'typescript',
+        theme: 'github-dark',
+        transformers: [customTag()],
+      },
+    )
+
+    const lines = [...html.matchAll(/twoslash-tag-log-line[^>]*>([^<]*)</g)].map((m) => m[1])
+    expect(lines).toEqual(['{', "  from: '0x',", '  value: 1n,', '}'])
+
+    highlighter.dispose()
+  })
 })
 
 describe('notationBlock', () => {

--- a/src/internal/shiki-transformers.ts
+++ b/src/internal/shiki-transformers.ts
@@ -1026,7 +1026,9 @@ export function shellNotation(): ShikiTransformer {
  */
 export function customTag(): ShikiTransformer {
   const customTags = ['error', 'log', 'warn', 'annotate'] as const
-  const tagPattern = new RegExp(`@(${customTags.join('|')}):\\s*(.+)`)
+  // Consume only the single separator space/tab after the colon so any further
+  // leading whitespace (indentation in multi-line `@log` blocks) is preserved.
+  const tagPattern = new RegExp(`@(${customTags.join('|')}):[ \\t]?(.+)`)
 
   type Element = import('hast').Element
 
@@ -1066,7 +1068,7 @@ export function customTag(): ShikiTransformer {
           ...line.properties,
           class: [...existingClasses, 'twoslash-tag-line', `twoslash-tag-${tagType}-line`],
         }
-        line.children = [{ type: 'text', value: message.trim() }]
+        line.children = [{ type: 'text', value: message.trimEnd() }]
       }
     },
   }


### PR DESCRIPTION
## Summary

Custom display tags (`@log`/`@error`/`@warn`/`@annotate`) were stripping leading indentation, so multi-line blocks (e.g. logged objects) collapsed to the left margin:

```
// @log: args: {
// @log:   from: '0x…',
// @log:   value: 1n,
// @log: }
```

rendered as:

```
args: {
from: '0x…',
value: 1n,
}
```

## Cause

In `customTag()` ([src/internal/shiki-transformers.ts](https://github.com/wevm/vocs/blob/main/src/internal/shiki-transformers.ts)), the content after the tag was extracted with `@(...):\s*(.+)` (the `\s*` ate all whitespace after the colon, including indentation) and then run through `message.trim()` (which removed any remaining leading whitespace).

## Fix

- Match only the single separator space/tab after the colon: `@(...):[ \t]?(.+)`, preserving further indentation.
- Use `message.trimEnd()` instead of `message.trim()` so leading indentation survives while trailing whitespace is still removed.

Now multi-line tag blocks keep their indentation:

```
args: {
  from: '0x…',
  value: 1n,
}
```

## Tests

Added `should preserve leading indentation in tag content` to the `customTag` suite. All 42 tests in `shiki-transformers.test.ts` pass.