### PR TITLE
fix: use static markdown assets in `AskAi`

### DIFF
--- a/.changeset/ask-ai-static-markdown.md
+++ b/.changeset/ask-ai-static-markdown.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed Ask AI markdown actions to use generated markdown assets in static builds.

--- a/src/react/internal/AskAi.tsx
+++ b/src/react/internal/AskAi.tsx
@@ -10,6 +10,7 @@ import SimpleIconsClaude from '~icons/simple-icons/claude'
 import SimpleIconsModelcontextprotocol from '~icons/simple-icons/modelcontextprotocol'
 import SimpleIconsOpenai from '~icons/simple-icons/openai'
 import { useConfig } from '../useConfig.js'
+import { getMarkdownAssetPath } from './markdown-url.js'
 
 export function AskAi(props: AskAi.Props) {
   const { className } = props
@@ -77,14 +78,13 @@ export function AskAi(props: AskAi.Props) {
   )
 
   const markdownUrl = React.useMemo(() => {
-    if (path === '/') return `${pageUrl}index.md`
-    const url = pageUrl.endsWith('/') ? pageUrl.slice(0, -1) : pageUrl
-    return `${url}.md`
-  }, [pageUrl, path])
+    return getMarkdownAssetPath(path)
+  }, [path])
 
   const copyPageForAi = React.useCallback(async () => {
     try {
       const response = await fetch(markdownUrl)
+      if (!response.ok) throw new Error('Failed to fetch markdown')
       const text = await response.text()
       await navigator.clipboard.writeText(text)
       setCopied(true)

--- a/src/react/internal/CopyForAi.client.tsx
+++ b/src/react/internal/CopyForAi.client.tsx
@@ -5,6 +5,7 @@ import * as React from 'react'
 import { useRouter } from 'waku'
 import LucideCheck from '~icons/lucide/check'
 import LucideClipboard from '~icons/lucide/clipboard'
+import { getMarkdownAssetPath } from './markdown-url.js'
 
 type CopyState = 'idle' | 'copying' | 'copied' | 'error'
 
@@ -19,11 +20,7 @@ export function CopyForAi(props: CopyForAi.Props) {
 
     setState('copying')
     try {
-      let pagePath = router.path
-      if (pagePath === '/') pagePath = '/index'
-      else pagePath = pagePath.replace(/\/$/, '')
-
-      const response = await fetch(`/assets/md${pagePath}.md`)
+      const response = await fetch(getMarkdownAssetPath(router.path))
       if (!response.ok) throw new Error('Failed to fetch markdown')
 
       const markdown = await response.text()

--- a/src/react/internal/markdown-url.test.ts
+++ b/src/react/internal/markdown-url.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'vitest'
+import { getMarkdownAssetPath } from './markdown-url.js'
+
+describe('getMarkdownAssetPath', () => {
+  test('returns the generated markdown asset path for the root page', () => {
+    expect(getMarkdownAssetPath('/')).toBe('/assets/md/index.md')
+  })
+
+  test('returns the generated markdown asset path for a nested page', () => {
+    expect(getMarkdownAssetPath('/docs/getting-started')).toBe('/assets/md/docs/getting-started.md')
+  })
+
+  test('removes trailing slashes from page paths', () => {
+    expect(getMarkdownAssetPath('/docs/')).toBe('/assets/md/docs.md')
+  })
+})

--- a/src/react/internal/markdown-url.ts
+++ b/src/react/internal/markdown-url.ts
@@ -1,0 +1,4 @@
+export function getMarkdownAssetPath(path: string) {
+  const pagePath = path === '/' ? '/index' : path.replace(/\/$/, '')
+  return `/assets/md${pagePath}.md`
+}


### PR DESCRIPTION
Fixes https://github.com/wevm/vocs/issues/522.

Ask AI now resolves page markdown through the generated `/assets/md/...` files that full-static builds already emit. Both the menu action and sidebar copy action share the same path helper, keeping root, nested, and trailing-slash pages aligned with the build output.

The menu copy action also treats non-OK markdown responses as failures before reading the body. That prevents a static-host 404 page from being copied as page markdown.
