### PR TITLE
fix: index imported markdown pages

### DIFF
--- a/src/internal/llms.test.ts
+++ b/src/internal/llms.test.ts
@@ -1,3 +1,6 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
 import { describe, expect, test } from 'vitest'
 import { buildLlmsContent } from './llms.js'
 import {
@@ -431,5 +434,37 @@ const a = 1
       \`\`\`
       "
     `)
+  })
+
+  test('includes imported markdown content for file-backed pages', async () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-llms-'))
+    const pagesDir = path.join(rootDir, 'src/pages')
+    fs.mkdirSync(pagesDir, { recursive: true })
+
+    const externalPath = path.join(rootDir, 'notes.md')
+    const pagePath = path.join(pagesDir, 'notes.mdx')
+    fs.writeFileSync(
+      externalPath,
+      '# Notes\n\nSome indexable prose about widgets. See [the docs](https://example.com).',
+    )
+    fs.writeFileSync(
+      pagePath,
+      `---
+title: Notes
+---
+
+import Notes from '../../notes.md'
+
+<Notes />`,
+    )
+
+    const result = await buildLlmsContent({
+      pages: [{ path: '/notes', content: { path: pagePath } }],
+      title: 'My Docs',
+      ...plugins,
+    })
+
+    expect(result.results[0]?.content).toContain('Some indexable prose about widgets.')
+    expect(result.full).toContain('Some indexable prose about widgets.')
   })
 })

--- a/src/internal/llms.ts
+++ b/src/internal/llms.ts
@@ -5,6 +5,7 @@ import remarkStringify from 'remark-stringify'
 import type { PluggableList } from 'unified'
 import { unified } from 'unified'
 import type * as Config from './config.js'
+import * as MarkdownImports from './markdown-imports.js'
 import * as OpenApiMarkdown from './openapi/markdown.js'
 import type * as Sidebar from './sidebar.js'
 
@@ -40,10 +41,14 @@ export async function buildLlmsContent(options: buildLlmsContent.Options) {
         }
       }
 
-      const content =
+      const rawContent =
         typeof page.content === 'string'
           ? page.content
           : await fs.readFile(page.content.path, 'utf-8')
+      const content =
+        typeof page.content === 'string'
+          ? rawContent
+          : MarkdownImports.inlineMarkdownImports(rawContent, page.content.path)
       const file = await unified()
         .use(remarkParse)
         .use(remarkMdx)

--- a/src/internal/markdown-imports.ts
+++ b/src/internal/markdown-imports.ts
@@ -1,0 +1,154 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import type * as Estree from 'estree'
+import type * as MdAst from 'mdast'
+import remarkMdx from 'remark-mdx'
+import remarkParse from 'remark-parse'
+import { unified } from 'unified'
+
+type MdxEsm = MdAst.RootContent & {
+  type: 'mdxjsEsm'
+  data?: {
+    estree?: Estree.Program
+  }
+}
+
+type MdxJsxElement = MdAst.RootContent & {
+  type: 'mdxJsxFlowElement' | 'mdxJsxTextElement'
+  attributes?: unknown[]
+  children?: MdAst.RootContent[]
+  name?: string | null
+}
+
+type MarkdownImport = {
+  source: string
+}
+
+type Replacement = {
+  end: number
+  start: number
+  value: string
+}
+
+export function inlineMarkdownImports(source: string, filePath: string): string {
+  return inline(source, path.resolve(filePath), new Set())
+}
+
+function inline(source: string, filePath: string, seen: Set<string>): string {
+  if (seen.has(filePath)) return ''
+  seen.add(filePath)
+
+  let tree: MdAst.Root
+  try {
+    tree = unified().use(remarkParse).use(remarkMdx).parse(source)
+  } catch {
+    return source
+  }
+
+  const imports = new Map<string, MarkdownImport>()
+  const replacements: Replacement[] = []
+
+  collectImports(tree.children, imports, replacements)
+  collectComponentReplacements(tree, imports, filePath, seen, replacements)
+
+  if (replacements.length === 0) return source
+  return applyReplacements(source, replacements)
+}
+
+function collectImports(
+  children: MdAst.RootContent[],
+  imports: Map<string, MarkdownImport>,
+  replacements: Replacement[],
+) {
+  for (const node of children) {
+    if (node.type !== 'mdxjsEsm') continue
+
+    const mdxEsm = node as MdxEsm
+    const declarations = mdxEsm.data?.estree?.body.filter(
+      (statement): statement is Estree.ImportDeclaration => statement.type === 'ImportDeclaration',
+    )
+    if (!declarations || declarations.length === 0) continue
+
+    let markdownDeclarations = 0
+    for (const declaration of declarations) {
+      const source = declaration.source.value
+      if (typeof source !== 'string' || !isMarkdownImport(source)) continue
+      markdownDeclarations++
+
+      const specifier = declaration.specifiers.find(
+        (specifier): specifier is Estree.ImportDefaultSpecifier =>
+          specifier.type === 'ImportDefaultSpecifier',
+      )
+      if (!specifier) continue
+      imports.set(specifier.local.name, { source })
+    }
+
+    if (markdownDeclarations === declarations.length) {
+      const replacement = toReplacement(node, '')
+      if (replacement) replacements.push(replacement)
+    }
+  }
+}
+
+function collectComponentReplacements(
+  node: MdAst.Root | MdAst.RootContent,
+  imports: Map<string, MarkdownImport>,
+  filePath: string,
+  seen: Set<string>,
+  replacements: Replacement[],
+) {
+  if (isMdxJsxElement(node)) {
+    const name = node.name ?? undefined
+    const markdownImport = name ? imports.get(name) : undefined
+    if (markdownImport && isStaticMdxComponent(node)) {
+      const importedPath = resolveMarkdownImport(markdownImport.source, filePath)
+      if (importedPath) {
+        const importedSource = fs.readFileSync(importedPath, 'utf-8')
+        const value = inline(importedSource, importedPath, new Set(seen))
+        const replacement = toReplacement(node, value)
+        if (replacement) replacements.push(replacement)
+      }
+    }
+  }
+
+  if ('children' in node && Array.isArray(node.children))
+    for (const child of node.children)
+      collectComponentReplacements(child, imports, filePath, seen, replacements)
+}
+
+function isMdxJsxElement(node: MdAst.Root | MdAst.RootContent): node is MdxJsxElement {
+  return node.type === 'mdxJsxFlowElement' || node.type === 'mdxJsxTextElement'
+}
+
+function isStaticMdxComponent(node: MdxJsxElement): boolean {
+  return (node.attributes?.length ?? 0) === 0 && (node.children?.length ?? 0) === 0
+}
+
+function resolveMarkdownImport(source: string, filePath: string): string | undefined {
+  if (!source.startsWith('.') && !path.isAbsolute(source)) return undefined
+
+  const resolved = path.isAbsolute(source) ? source : path.resolve(path.dirname(filePath), source)
+  if (fs.existsSync(resolved) && fs.statSync(resolved).isFile()) return resolved
+  return undefined
+}
+
+function isMarkdownImport(source: string): boolean {
+  return /\.(md|mdx)$/.test(source)
+}
+
+function toReplacement(
+  node: MdAst.Root | MdAst.RootContent,
+  value: string,
+): Replacement | undefined {
+  const start = node.position?.start.offset
+  const end = node.position?.end.offset
+  if (start === undefined || end === undefined) return undefined
+  return { end, start, value }
+}
+
+function applyReplacements(source: string, replacements: Replacement[]): string {
+  let result = source
+  for (const replacement of replacements.sort((a, b) => b.start - a.start))
+    result = result.slice(0, replacement.start) + replacement.value + result.slice(replacement.end)
+  return result
+}

--- a/src/internal/search.test.ts
+++ b/src/internal/search.test.ts
@@ -1,3 +1,6 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
 import type * as MdAst from 'mdast'
 import { describe, expect, it } from 'vitest'
 import * as Config from './config.js'
@@ -856,6 +859,40 @@ Some content here.
 
     const { sections } = Search.extract('# hello world\n\nSome text.', customConfig)
     expect(sections[0]?.title).toBe('HELLO WORLD')
+  })
+})
+
+describe('SearchDocuments.fromConfig', () => {
+  it('indexes imported markdown content from file-backed pages', async () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-search-'))
+    const pagesDir = path.join(rootDir, 'src/pages')
+    fs.mkdirSync(pagesDir, { recursive: true })
+
+    fs.writeFileSync(
+      path.join(rootDir, 'notes.md'),
+      '# Notes\n\nSome indexable prose about widgets and links.',
+    )
+    fs.writeFileSync(
+      path.join(pagesDir, 'notes.mdx'),
+      `---
+title: Notes
+---
+
+import Notes from '../../notes.md'
+
+<Notes />`,
+    )
+
+    const documents = await Search.SearchDocuments.fromConfig(Config.define({ rootDir }))
+
+    expect(documents).toContainEqual(
+      expect.objectContaining({
+        href: '/notes#notes',
+        text: ' Some indexable prose about widgets and links.',
+        title: 'Notes',
+        type: 'page',
+      }),
+    )
   })
 })
 

--- a/src/internal/search.ts
+++ b/src/internal/search.ts
@@ -14,6 +14,7 @@ import { unified } from 'unified'
 import * as UnistUtil from 'unist-util-visit'
 import * as yaml from 'yaml'
 import type * as Config from './config.js'
+import * as MarkdownImports from './markdown-imports.js'
 import { extractSubheading, getPhrasingContentText } from './mdx.js'
 import * as OpenApiRegistry from './openapi/registry.js'
 import * as OpenApiSearch from './openapi/search.js'
@@ -61,7 +62,8 @@ export namespace SearchDocuments {
     for (const page of mdxPages)
       taskRunner.run(async () => {
         const filePath = path.join(pagesDirPath, page)
-        const content = await fs.promises.readFile(filePath, 'utf-8')
+        const rawContent = await fs.promises.readFile(filePath, 'utf-8')
+        const content = MarkdownImports.inlineMarkdownImports(rawContent, filePath)
 
         const { searchPriority, sections } = extract(content, config)
         if (sections.length === 0) return
@@ -260,7 +262,8 @@ export namespace SearchIndex {
   ): string[] {
     const { pagesDir, previousIds = [], config } = options
 
-    const content = fs.readFileSync(filePath, 'utf-8')
+    const rawContent = fs.readFileSync(filePath, 'utf-8')
+    const content = MarkdownImports.inlineMarkdownImports(rawContent, filePath)
     const { searchPriority, sections } = extract(content, config)
 
     // Remove old entries for this file

--- a/src/react/Link.tsx
+++ b/src/react/Link.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import { useRouter, Link as WakuLink } from 'waku'
+import { useContext, useEffect, useState } from 'react'
+import { Link as WakuLink } from 'waku'
+import { unstable_RouterContext as WakuRouterContext } from 'waku/router/client'
 import * as Path from '../internal/path.js'
 
 const viewportPrefetchDelayMs = 2_000
@@ -57,14 +58,18 @@ function useViewportPrefetchReady(enabled: boolean) {
 
 export function Link(props: Link.Props) {
   const { to, unstable_prefetchOnEnter = true, unstable_prefetchOnView = true, ...rest } = props
-  const { path } = useRouter()
-  const prefetchOnView = useViewportPrefetchReady(Boolean(unstable_prefetchOnView))
+  const router = useContext(WakuRouterContext)
+  const routerPath = router?.route.path
+  const isExternal = Path.isExternal(props.to)
+  const prefetchOnView = useViewportPrefetchReady(
+    Boolean(unstable_prefetchOnView) && !isExternal && routerPath !== undefined,
+  )
 
-  if (Path.isExternal(props.to))
-    return <a {...rest} href={props.to} rel="noopener noreferrer" target="_blank" />
+  if (isExternal) return <a {...rest} href={props.to} rel="noopener noreferrer" target="_blank" />
 
   const [before, after] = (props.to || '').split('#')
-  const resolvedTo = `${before ? before : path}${after ? `#${after}` : ''}`
+  const resolvedTo = `${before ? before : (routerPath ?? '')}${after ? `#${after}` : ''}`
+  if (routerPath === undefined) return <a {...rest} href={resolvedTo || props.to} />
   return (
     <WakuLink
       {...rest}


### PR DESCRIPTION
Imported Markdown pages now feed resolved local Markdown imports into the llms and search indexing paths before the existing MDX extraction pipeline runs.

The root cause was that those indexers read page source from disk independently of the Vite module graph, so rendered Markdown imports were invisible to `llms.txt`, `llms-full.txt`, and search. The shared expansion helper keeps that behavior file-backed and local to Markdown imports.

Imported Markdown links also no longer crash dev SSR when they render outside the Waku router context. In that case, Vocs falls back to a plain anchor while preserving normal Waku link behavior inside routed pages.

Fixes https://github.com/wevm/vocs/issues/528