### PR TITLE
feat(search): expose MiniSearch index options

### DIFF
--- a/.changeset/configurable-minisearch.md
+++ b/.changeset/configurable-minisearch.md
@@ -1,0 +1,5 @@
+---
+"vocs": minor
+---
+
+Exposed MiniSearch index and query configuration for docs search.

--- a/site/src/pages/reference/site-config.mdx
+++ b/site/src/pages/reference/site-config.mdx
@@ -597,60 +597,165 @@ See [Code & Syntax Highlighting](/writing/syntax-highlighting) for code group ic
 
 ### `search`
 
-- **Type:**
+- **Type:** `SearchOptions`
 
-```ts
-type Search = {
-  /**
-   * Per-field weight multipliers applied during scoring. Higher values rank
-   * matches in that field higher.
-   *
-   * Defaults to `{ title: 4, subtitle: 3, text: 2, category: 1, titles: 1 }`.
-   */
-  boost?: Record<string, number>
-  /**
-   * Per-document boost function. Return a multiplier to amplify or suppress
-   * results from specific pages (pair with the page-level `searchPriority`
-   * frontmatter field).
-   */
-  boostDocument?: (
-    id: string,
-    term: string,
-    storedFields?: Record<string, unknown>,
-  ) => number
-  /**
-   * How multi-term queries are combined. `'AND'` requires every term to
-   * match, `'OR'` matches any. Defaults to `'AND'`.
-   */
-  combineWith?: 'AND' | 'OR'
-  /**
-   * Fuzzy matching tolerance. A number between `0` and `1` is the fraction
-   * of edit distance allowed; `true` is `0.2`; `false` disables fuzziness.
-   * Defaults to `0.2`.
-   */
-  fuzzy?: number | boolean
-  /**
-   * Match queries against the start of indexed terms (so typing "comp"
-   * matches "component"). Defaults to `true`.
-   */
-  prefix?: boolean
-}
-```
+Customizes built-in documentation search. `search.index` controls MiniSearch index build/load
+behavior. `search.query` controls runtime matching and ranking in the browser search dialog.
 
-Customizes built-in documentation search.
+Custom functions must be serializable because Vocs sends search config to the browser.
 
 ```ts
 export default defineConfig({
   search: {
-    combineWith: 'OR',
-    fuzzy: 0.1,
-    boost: {
-      title: 6,
-      text: 1
+    index: {
+      fields: ['title', 'text', 'path'],
+      storeFields: ['path'],
+      extractField(document, fieldName) {
+        if (fieldName === 'path') return document.href
+        return document[fieldName as keyof typeof document]
+      }
+    },
+    query: {
+      fields: ['title', 'text'],
+      boost: { title: 6, text: 1 },
+      fuzzy: false,
+      prefix: false,
+      processTerm: (term) => term.toLowerCase()
     }
   }
 })
 ```
+
+#### `search.index.fields`
+
+- **Type:** `string[]`
+- **Default:** `['category', 'subtitle', 'text', 'title', 'titles']`
+
+MiniSearch document fields to index. Replaces the Vocs default indexed fields.
+
+#### `search.index.storeFields`
+
+- **Type:** `string[]`
+- **Default:** required Vocs result fields
+
+MiniSearch document fields to include on results. Extends Vocs required fields:
+`category`, `href`, `searchPriority`, `subtitle`, `text`, `title`, `titles`, and `type`.
+
+#### `search.index.idField`
+
+- **Type:** `string`
+- **Default:** `'id'`
+
+MiniSearch document id field. Advanced; Vocs expects stable result ids for search UI and HMR.
+
+#### `search.index.extractField`
+
+- **Type:** `(document, fieldName) => unknown`
+
+Reads field values during index build/load. Use this for virtual fields.
+
+#### `search.index.stringifyField`
+
+- **Type:** `(fieldValue, fieldName) => string`
+
+Converts extracted field values to strings before indexing.
+
+#### `search.index.tokenize`
+
+- **Type:** `(text, fieldName?) => string[]`
+- **Default:** Vocs tokenizer
+
+Splits indexed field values into terms. Replaces the default camelCase/path-aware tokenizer.
+
+#### `search.index.processTerm`
+
+- **Type:** `(term, fieldName?) => string | string[] | null | undefined | false`
+
+Normalizes or expands terms during indexing.
+
+#### `search.index.autoVacuum`
+
+- **Type:** `boolean | AutoVacuumOptions`
+
+Controls MiniSearch automatic vacuuming after documents are discarded.
+
+#### `search.index.searchOptions`
+
+- **Type:** `SearchOptions`
+
+MiniSearch default search options stored on the index. Prefer `search.query` for the built-in
+search dialog.
+
+#### `search.index.autoSuggestOptions`
+
+- **Type:** `SearchOptions`
+
+MiniSearch default auto-suggest options. Vocs does not currently call MiniSearch auto-suggest in
+the built-in search UI.
+
+#### `search.query.fields`
+
+- **Type:** `string[]`
+
+Restricts which indexed fields are searched at runtime.
+
+#### `search.query.filter`
+
+- **Type:** `(result) => boolean`
+
+Filters scored results in the browser before display.
+
+#### `search.query.boost`
+
+- **Type:** `Record<string, number>`
+- **Default:** `{ title: 4, subtitle: 3, text: 2, category: 1, titles: 1 }`
+
+Per-field runtime score boosts. Merges with Vocs defaults.
+
+#### `search.query.boostDocument`
+
+- **Type:** `(id, term, storedFields?) => number`
+
+Per-document runtime score boost. Defaults to Vocs search priority and path-depth boosting.
+
+#### `search.query.combineWith`
+
+- **Type:** `'AND' | 'OR' | 'AND_NOT'`
+- **Default:** `'AND'`
+
+Controls how query terms are combined.
+
+#### `search.query.fuzzy`
+
+- **Type:** `boolean | number | ((term, index, terms) => boolean | number)`
+- **Default:** `0.2`
+
+Controls fuzzy matching.
+
+#### `search.query.prefix`
+
+- **Type:** `boolean | ((term, index, terms) => boolean)`
+- **Default:** `true`
+
+Controls prefix matching.
+
+#### `search.query.weights`
+
+- **Type:** `{ fuzzy: number; prefix: number }`
+
+Relative score weights for fuzzy and prefix matches.
+
+#### `search.query.tokenize`
+
+- **Type:** `(text) => string[]`
+
+Splits search queries into terms at runtime.
+
+#### `search.query.processTerm`
+
+- **Type:** `(term) => string | string[] | null | undefined | false`
+
+Normalizes or expands search query terms at runtime.
 
 :::tip
 See [Search](/features/search) for recipes covering fuzzy matching, prefix matching, and field weighting.

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -1,6 +1,10 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import type * as MdxRollup from '@mdx-js/rollup'
+import type {
+  Options as MiniSearchOptions,
+  SearchOptions as MiniSearchSearchOptions,
+} from 'minisearch'
 import type * as Changelog from './changelog.js'
 import type * as Feedback from './feedback.js'
 import * as Langs from './langs.js'
@@ -12,6 +16,218 @@ import type * as TopNav from './topNav.js'
 import type { MaybePartial, UnionOmit } from './types.js'
 
 export type ThemeValue<value> = { light: value; dark: value }
+
+type SearchDocument = {
+  category: string
+  href: string
+  id: string
+  searchPriority: number | undefined
+  subtitle: string
+  text: string
+  title: string
+  titles: string[]
+  type: 'page' | 'section' | 'nav'
+}
+
+export type SearchIndexOptions = Omit<MiniSearchOptions<SearchDocument>, 'fields'> & {
+  /**
+   * Document fields to index during MiniSearch build and load.
+   *
+   * Replaces the Vocs default indexed fields: `category`, `subtitle`, `text`, `title`, and
+   * `titles`. Runs on the server when Vocs builds the index, and is reused in the browser when
+   * loading the serialized index.
+   */
+  fields?: string[]
+  /**
+   * Document fields to store on search results during MiniSearch build and load.
+   *
+   * Extends the required Vocs UI fields. Required fields are always stored even when omitted:
+   * `category`, `href`, `searchPriority`, `subtitle`, `text`, `title`, `titles`, and `type`.
+   * Runs on the server when Vocs builds the index, and is reused in the browser when loading the
+   * serialized index.
+   */
+  storeFields?: string[]
+  /**
+   * Document field used as the unique MiniSearch id.
+   *
+   * Defaults to `id`. Replaces the MiniSearch id field during server index build and browser index
+   * load. Changing this is advanced because Vocs HMR and UI behavior expect stable document ids.
+   */
+  idField?: string
+  /**
+   * Reads a field value from a Vocs search document during MiniSearch indexing and storage.
+   *
+   * Defaults to MiniSearch object property access. Replaces that behavior on the server during
+   * index build, and in the browser when loading the index. Use this to provide virtual fields.
+   * The function must be serializable because Vocs sends search config to the browser.
+   */
+  extractField?: (document: SearchDocument, fieldName: string) => unknown
+  /**
+   * Converts extracted field values to strings during MiniSearch indexing.
+   *
+   * Defaults to MiniSearch stringification. Replaces that behavior on the server during index
+   * build, and in the browser when loading the index. The function must be serializable because
+   * Vocs sends search config to the browser.
+   */
+  stringifyField?: (fieldValue: unknown, fieldName: string) => string
+  /**
+   * Splits indexed document field values into terms.
+   *
+   * Defaults to the Vocs tokenizer, which handles whitespace, punctuation, paths, and camelCase.
+   * Replaces the index tokenizer on the server during build and in the browser when loading the
+   * serialized index. The function must be serializable because Vocs sends search config to the
+   * browser.
+   */
+  tokenize?: (text: string, fieldName?: string) => string[]
+  /**
+   * Normalizes or expands terms while MiniSearch indexes document fields.
+   *
+   * Defaults to MiniSearch lowercase processing. Replaces index-time term processing on the server
+   * and in the browser when loading the serialized index. The function must be serializable because
+   * Vocs sends search config to the browser.
+   */
+  processTerm?:
+    | ((term: string, fieldName?: string) => string | string[] | null | undefined | false)
+    | undefined
+  /**
+   * Controls MiniSearch automatic vacuuming after discarded documents.
+   *
+   * Passed through to MiniSearch during server index build and browser index load. Defaults to
+   * MiniSearch behavior.
+   */
+  autoVacuum?: MiniSearchOptions<SearchDocument>['autoVacuum']
+  /**
+   * Default MiniSearch query options stored on the index.
+   *
+   * Merges with MiniSearch defaults during index build/load. Vocs still applies `search.query`
+   * at runtime, so prefer `search.query` for docs search dialog behavior.
+   */
+  searchOptions?: MiniSearchSearchOptions
+  /**
+   * Default MiniSearch auto-suggest options stored on the index.
+   *
+   * Merges with MiniSearch defaults during index build/load. Vocs does not currently call
+   * MiniSearch auto-suggest in its built-in search UI.
+   */
+  autoSuggestOptions?: MiniSearchSearchOptions
+}
+
+export type SearchQueryOptions = MiniSearchSearchOptions & {
+  /**
+   * Restricts which indexed fields are searched at query runtime.
+   *
+   * Defaults to every indexed field. Replaces the runtime field set in the browser search dialog.
+   */
+  fields?: string[]
+  /**
+   * Filters MiniSearch results at query runtime.
+   *
+   * Runs in the browser after scoring and before results are shown. The function must be
+   * serializable because Vocs sends search config to the browser.
+   */
+  filter?: MiniSearchSearchOptions['filter']
+  /**
+   * Per-field score boosts used at query runtime.
+   *
+   * Merges with the Vocs defaults: `title: 4`, `subtitle: 3`, `text: 2`, `category: 1`,
+   * `titles: 1`.
+   */
+  boost?: MiniSearchSearchOptions['boost']
+  /**
+   * Per-document score boost used at query runtime.
+   *
+   * Defaults to Vocs search priority and path-depth boosting. Runs in the browser search dialog.
+   * The function must be serializable because Vocs sends search config to the browser.
+   */
+  boostDocument?: MiniSearchSearchOptions['boostDocument']
+  /**
+   * Controls whether query terms are combined with `AND` or `OR` at runtime.
+   *
+   * Defaults to `AND`. Replaces the Vocs default in the browser search dialog.
+   */
+  combineWith?: MiniSearchSearchOptions['combineWith']
+  /**
+   * Controls fuzzy matching at query runtime.
+   *
+   * Defaults to `0.2`. Replaces the Vocs default in the browser search dialog.
+   */
+  fuzzy?: MiniSearchSearchOptions['fuzzy']
+  /**
+   * Controls prefix matching at query runtime.
+   *
+   * Defaults to `true`. Replaces the Vocs default in the browser search dialog.
+   */
+  prefix?: MiniSearchSearchOptions['prefix']
+  /**
+   * Relative score weights for fuzzy and prefix matches at query runtime.
+   *
+   * Uses MiniSearch defaults unless provided. Replaces MiniSearch runtime weights in the browser
+   * search dialog.
+   */
+  weights?: MiniSearchSearchOptions['weights']
+  /**
+   * Splits search queries into terms at runtime.
+   *
+   * Defaults to the index tokenizer, which is the Vocs tokenizer unless `search.index.tokenize`
+   * overrides it. Runs in the browser search dialog. The function must be serializable because
+   * Vocs sends search config to the browser.
+   */
+  tokenize?: MiniSearchSearchOptions['tokenize']
+  /**
+   * Normalizes or expands query terms at runtime.
+   *
+   * Defaults to the index term processor. Runs in the browser search dialog. The function must be
+   * serializable because Vocs sends search config to the browser.
+   */
+  processTerm?: MiniSearchSearchOptions['processTerm']
+}
+
+export type SearchOptions = {
+  /**
+   * MiniSearch constructor/load options for index build and index load.
+   *
+   * Use this for changing what gets indexed or stored. Function options run during server index
+   * build and browser index load, so they must be serializable.
+   */
+  index?: SearchIndexOptions
+  /**
+   * MiniSearch search options for runtime queries.
+   *
+   * Use this for changing how the built-in search dialog matches, ranks, and filters results.
+   * Function options run in the browser and must be serializable.
+   */
+  query?: SearchQueryOptions
+  /**
+   * Legacy alias for `search.query.boost`.
+   *
+   * Merges with Vocs default query boosts.
+   */
+  boost: NonNullable<MiniSearchSearchOptions['boost']>
+  /**
+   * Legacy alias for `search.query.boostDocument`.
+   *
+   * Defaults to Vocs search priority and path-depth boosting.
+   */
+  boostDocument: NonNullable<MiniSearchSearchOptions['boostDocument']>
+  /**
+   * Legacy alias for `search.query.combineWith`.
+   *
+   * Defaults to `AND`.
+   */
+  combineWith: NonNullable<MiniSearchSearchOptions['combineWith']>
+  /**
+   * Legacy alias for `search.query.fuzzy`.
+   *
+   * Defaults to `0.2`.
+   */
+  fuzzy: NonNullable<MiniSearchSearchOptions['fuzzy']>
+  /**
+   * Legacy alias for `search.query.prefix`.
+   *
+   * Defaults to `true`.
+   */
+  prefix: NonNullable<MiniSearchSearchOptions['prefix']>
+}
 
 export type Config<partial extends boolean = false> = MaybePartial<
   partial,
@@ -275,18 +491,45 @@ export type Config<partial extends boolean = false> = MaybePartial<
     rootDir: string
     /**
      * Configuration for docs search.
-     * Accepts MiniSearch options for customizing search behavior.
+     *
+     * `search.index` customizes MiniSearch index construction/loading. `search.query`
+     * customizes runtime searches in the browser. Legacy top-level query options such as
+     * `boost`, `fuzzy`, `prefix`, `combineWith`, and `boostDocument` remain supported.
+     *
+     * Custom functions must be serializable because Vocs sends search config to the client.
+     *
+     * @example
+     * ```ts
+     * export default defineConfig({
+     *   search: {
+     *     index: {
+     *       fields: ['title', 'text', 'path'],
+     *       extractField(document, fieldName) {
+     *         if (fieldName === 'path') return document.href
+     *         return document[fieldName as keyof typeof document]
+     *       },
+     *     },
+     *   },
+     * })
+     * ```
+     *
+     * @example
+     * ```ts
+     * export default defineConfig({
+     *   search: {
+     *     index: { storeFields: ['href'] },
+     *     query: {
+     *       fields: ['title', 'text'],
+     *       boost: { title: 6, text: 1 },
+     *       fuzzy: false,
+     *       prefix: false,
+     *       processTerm: (term) => term.toLowerCase(),
+     *     },
+     *   },
+     * })
+     * ```
      */
-    search: MaybePartial<
-      partial,
-      {
-        boost: Record<string, number>
-        boostDocument: (id: string, term: string, storedFields?: Record<string, unknown>) => number
-        combineWith: 'AND' | 'OR'
-        fuzzy: number | boolean
-        prefix: boolean
-      }
-    >
+    search: MaybePartial<partial, SearchOptions>
     /**
      * Navigation displayed on the sidebar.
      */
@@ -497,9 +740,10 @@ export function define(config: define.Options = {}): Config {
     redirects,
     renderStrategy,
     rootDir,
-    search: {
-      ...search,
-      boostDocument:
+    search: (() => {
+      const query = search?.query ?? {}
+      const boostDocument =
+        query.boostDocument ??
         search?.boostDocument ??
         ((_id, _term, storedFields) => {
           const priority = (storedFields?.['searchPriority'] as number | undefined) ?? 1
@@ -511,12 +755,41 @@ export function define(config: define.Options = {}): Config {
           const depthBoost = 1 / Math.max(depth, 1)
           const docsBoost = isDocsPath ? 1.5 : 1
           return priority * depthBoost * docsBoost
-        }),
-      combineWith: search?.combineWith ?? 'AND',
-      fuzzy: search?.fuzzy ?? 0.2,
-      prefix: search?.prefix ?? true,
-      boost: { title: 4, subtitle: 3, text: 2, category: 1, titles: 1, ...search?.boost },
-    },
+        })
+
+      return {
+        ...search,
+        query: {
+          ...query,
+          boostDocument,
+          combineWith: query.combineWith ?? search?.combineWith ?? 'AND',
+          fuzzy: query.fuzzy ?? search?.fuzzy ?? 0.2,
+          prefix: query.prefix ?? search?.prefix ?? true,
+          boost: {
+            title: 4,
+            subtitle: 3,
+            text: 2,
+            category: 1,
+            titles: 1,
+            ...search?.boost,
+            ...query.boost,
+          },
+        },
+        boostDocument,
+        combineWith: query.combineWith ?? search?.combineWith ?? 'AND',
+        fuzzy: query.fuzzy ?? search?.fuzzy ?? 0.2,
+        prefix: query.prefix ?? search?.prefix ?? true,
+        boost: {
+          title: 4,
+          subtitle: 3,
+          text: 2,
+          category: 1,
+          titles: 1,
+          ...search?.boost,
+          ...query.boost,
+        },
+      }
+    })(),
     sidebar,
     socials,
     srcDir,

--- a/src/internal/search.client.ts
+++ b/src/internal/search.client.ts
@@ -1,3 +1,9 @@
+import type {
+  Options as MiniSearchOptions,
+  SearchOptions as MiniSearchSearchOptions,
+} from 'minisearch'
+import type * as Config from './config.js'
+
 export const searchFields = ['category', 'subtitle', 'text', 'title', 'titles'] as const
 export const storeFields = [
   'category',
@@ -39,4 +45,27 @@ export function tokenize(text: string): string[] {
   }
 
   return tokens.filter((w) => w.length > 0)
+}
+
+export namespace SearchConfig {
+  export function getIndexOptions(config?: Config.Config): MiniSearchOptions {
+    const index = config?.search.index ?? {}
+    return {
+      ...index,
+      fields: index.fields ? [...index.fields] : [...searchFields],
+      storeFields: mergeStoreFields(index.storeFields),
+      tokenize: index.tokenize ?? tokenize,
+    }
+  }
+
+  export function getQueryOptions(config: Config.Config): MiniSearchSearchOptions {
+    return {
+      ...config.search.query,
+      tokenize: config.search.query?.tokenize ?? config.search.index?.tokenize ?? tokenize,
+    }
+  }
+
+  function mergeStoreFields(fields: readonly string[] | undefined): string[] {
+    return [...new Set([...storeFields, ...(fields ?? [])])]
+  }
 }

--- a/src/internal/search.test.ts
+++ b/src/internal/search.test.ts
@@ -882,6 +882,65 @@ describe('Config.search defaults', () => {
     expect(config.search.fuzzy).toBe(0.2)
     expect(config.search.prefix).toBe(true)
     expect(typeof config.search.boostDocument).toBe('function')
+    expect(config.search.query?.boost).toEqual(config.search.boost)
+    expect(config.search.query?.fuzzy).toBe(0.2)
+    expect(config.search.query?.prefix).toBe(true)
+  })
+
+  it('normalizes legacy search options into query options', () => {
+    const config = Config.define({
+      search: {
+        boost: { text: 10 },
+        combineWith: 'OR',
+        fuzzy: false,
+        prefix: false,
+      },
+    })
+
+    expect(config.search.query?.boost).toMatchObject({ title: 4, text: 10 })
+    expect(config.search.query?.combineWith).toBe('OR')
+    expect(config.search.query?.fuzzy).toBe(false)
+    expect(config.search.query?.prefix).toBe(false)
+  })
+})
+
+describe('SearchConfig', () => {
+  it('returns default index options', () => {
+    expect(Search.SearchConfig.getIndexOptions(config)).toMatchObject({
+      fields: ['category', 'subtitle', 'text', 'title', 'titles'],
+      storeFields: [
+        'category',
+        'href',
+        'searchPriority',
+        'subtitle',
+        'text',
+        'title',
+        'titles',
+        'type',
+      ],
+    })
+  })
+
+  it('keeps required store fields when custom store fields are configured', () => {
+    const config = Config.define({
+      search: {
+        index: {
+          storeFields: ['href', 'custom'],
+        },
+      },
+    })
+
+    expect(Search.SearchConfig.getIndexOptions(config).storeFields).toEqual([
+      'category',
+      'href',
+      'searchPriority',
+      'subtitle',
+      'text',
+      'title',
+      'titles',
+      'type',
+      'custom',
+    ])
   })
 })
 
@@ -984,6 +1043,105 @@ describe('SearchIndex.fromSearchDocuments', () => {
     expect(results[1]?.id).toBe('/docs/config.mdx#configuration')
     // Score should be 10x higher for the high priority doc
     expect(results[0]?.score).toBeGreaterThan(results[1]?.score ?? 0)
+  })
+
+  it('indexes custom virtual fields', () => {
+    const docs: SearchDocuments.Document[] = [
+      {
+        category: '',
+        href: '/docs/runtime-api',
+        id: '/docs/runtime-api.mdx#runtime-api',
+        searchPriority: undefined,
+        subtitle: '',
+        text: 'Reference content.',
+        title: 'Runtime API',
+        titles: [],
+        type: 'page',
+      },
+    ]
+    const config = Config.define({
+      search: {
+        index: {
+          fields: ['path'],
+          extractField(document, fieldName) {
+            if (fieldName === 'path') return document.href
+            return document[fieldName as keyof typeof document]
+          },
+        },
+      },
+    })
+
+    const index = SearchIndex.fromSearchDocuments(docs, config)
+
+    expect(index.search('runtime', Search.SearchConfig.getQueryOptions(config))[0]?.id).toBe(
+      '/docs/runtime-api.mdx#runtime-api',
+    )
+  })
+
+  it('stores custom fields', () => {
+    const docs: SearchDocuments.Document[] = [
+      {
+        category: 'Docs',
+        href: '/guide',
+        id: '/docs/guide.mdx#guide',
+        searchPriority: undefined,
+        subtitle: '',
+        text: 'Install instructions.',
+        title: 'Guide',
+        titles: [],
+        type: 'page',
+      },
+    ]
+    const config = Config.define({
+      search: {
+        index: {
+          storeFields: ['path'],
+          extractField(document, fieldName) {
+            if (fieldName === 'path') return document.href
+            return document[fieldName as keyof typeof document]
+          },
+        },
+      },
+    })
+
+    const index = SearchIndex.fromSearchDocuments(docs, config)
+    const result = index.search('guide', Search.SearchConfig.getQueryOptions(config))[0]
+
+    expect(result).toMatchObject({ href: '/guide', path: '/guide', title: 'Guide' })
+  })
+
+  it('applies query fields, weights, and filter at runtime', () => {
+    const docs = [
+      ...buildDoc(
+        '/docs/title.mdx',
+        '/title',
+        `# Alpha
+
+No keyword.
+`,
+      ),
+      ...buildDoc(
+        '/docs/text.mdx',
+        '/text',
+        `# Other
+
+Alpha keyword.
+`,
+      ),
+    ]
+    const config = Config.define({
+      search: {
+        query: {
+          fields: ['text'],
+          filter: (result) => result.id !== '/docs/text.mdx#other',
+          weights: { fuzzy: 0.5, prefix: 0.5 },
+        },
+      },
+    })
+
+    const index = SearchIndex.fromSearchDocuments(docs, config)
+
+    expect(index.search('alpha', Search.SearchConfig.getQueryOptions(config))).toEqual([])
   })
 
   it('boosts shallow paths over deep paths', () => {

--- a/src/internal/search.ts
+++ b/src/internal/search.ts
@@ -16,7 +16,7 @@ import * as yaml from 'yaml'
 import type * as Config from './config.js'
 import { extractSubheading, getPhrasingContentText } from './mdx.js'
 import * as Path from './path.js'
-import { searchFields, storeFields, tokenize } from './search.client.js'
+import { SearchConfig } from './search.client.js'
 import * as Sidebar from './sidebar.js'
 import * as TaskRunner from './task-runner.js'
 import * as TopNav from './topNav.js'
@@ -186,12 +186,11 @@ export namespace SearchIndex {
   /**
    * Create a search index from documents.
    */
-  export function fromSearchDocuments(documents: SearchDocuments.Document[]): SearchIndex {
-    const index = new MiniSearch<SearchDocuments.Document>({
-      fields: [...searchFields],
-      storeFields: [...storeFields],
-      tokenize,
-    })
+  export function fromSearchDocuments(
+    documents: SearchDocuments.Document[],
+    config?: Config.Config,
+  ): SearchIndex {
+    const index = new MiniSearch<SearchDocuments.Document>(SearchConfig.getIndexOptions(config))
     index.addAll(documents)
     return index
   }
@@ -200,17 +199,15 @@ export namespace SearchIndex {
    * Load a search index from a JSON file.
    */
   export function loadFromFile(options: loadFromFile.Options): SearchIndex {
-    const { filePath } = options
+    const { config, filePath } = options
 
     const json = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
-    return MiniSearch.loadJSON(json, {
-      fields: [...searchFields],
-      storeFields: [...storeFields],
-    })
+    return MiniSearch.loadJSON(json, SearchConfig.getIndexOptions(config))
   }
 
   export declare namespace loadFromFile {
     type Options = {
+      config?: Config.Config
       filePath: string
     }
   }

--- a/src/internal/vite-plugins.ts
+++ b/src/internal/vite-plugins.ts
@@ -612,7 +612,7 @@ export function search(config: Config.Config): PluginOption {
   async function buildIndex(): Promise<SearchIndex.SearchIndex> {
     logger.info('Building search index...', { timestamp: true })
     const docs = await SearchDocuments.fromConfig(config)
-    const index = SearchIndex.fromSearchDocuments(docs)
+    const index = SearchIndex.fromSearchDocuments(docs, config)
 
     // Populate fileIds map for HMR
     for (const doc of docs) {

--- a/src/react/internal/Search.tsx
+++ b/src/react/internal/Search.tsx
@@ -11,7 +11,7 @@ import LucideFile from '~icons/lucide/file'
 import LucideHash from '~icons/lucide/hash'
 import LucideSearch from '~icons/lucide/search'
 import * as Path from '../../internal/path.js'
-import { searchFields, storeFields, tokenize } from '../../internal/search.client.js'
+import { SearchConfig } from '../../internal/search.client.js'
 import { Link } from '../Link.js'
 import { useConfig } from '../useConfig.js'
 import { DialogTrigger } from './DialogTrigger.js'
@@ -86,14 +86,12 @@ export function Search(props: Search.Props) {
         const json = await getSearchIndex()
         setIndex(
           MiniSearch.loadJSON<SearchResult>(json, {
-            fields: [...searchFields],
-            storeFields: [...storeFields],
-            tokenize,
+            ...SearchConfig.getIndexOptions(config),
           }),
         )
       })
       .catch((error) => console.error('Failed to load search index:', error))
-  }, [open, index])
+  }, [open, index, config])
 
   React.useEffect(() => {
     try {
@@ -108,12 +106,11 @@ export function Search(props: Search.Props) {
       return
     }
 
-    const results = (index.search(query, { ...config.search, tokenize }) as SearchResult[]).slice(
-      0,
-      20,
-    )
+    const results = (
+      index.search(query, SearchConfig.getQueryOptions(config)) as SearchResult[]
+    ).slice(0, 20)
     setSearch((s) => ({ ...s, results, selectedIndex: 0 }))
-  }, [query, index, config.search])
+  }, [query, index, config])
 
   React.useEffect(() => {
     if (disableKeyboardShortcut) return


### PR DESCRIPTION
## Motivation

Vocs currently fixes indexed and stored search fields internally. This allows projects to customize MiniSearch indexing and runtime query behavior without patching Vocs internals.

## Summary

- Expose split `search.index` and `search.query` configuration for MiniSearch
- Normalize legacy top-level search options into query options
- Document all exposed index and query options in the site config reference

## Key design considerations

- Preserve existing top-level `search.boost`, `fuzzy`, `prefix`, `combineWith`, and `boostDocument` aliases
- Always keep required stored fields for the built-in search UI
- Keep index option normalization shared between server index creation and browser index loading
