### PR TITLE
fix: resolve standalone openapi waku router alias

### DIFF
--- a/.changeset/quiet-openapi-build.md
+++ b/.changeset/quiet-openapi-build.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed standalone OpenAPI bundle builds when Vocs components import Waku router subpaths.

--- a/scripts/build-openapi-standalone.ts
+++ b/scripts/build-openapi-standalone.ts
@@ -71,7 +71,6 @@ await build({
       // The real Vocs layout/chrome only touches Waku via `useRouter`/`Link`;
       // swap it for the SPA history shim so genuine components render here.
       { find: /^waku$/, replacement: path.resolve(appDir, 'waku.tsx') },
-      { find: 'waku/router/client', replacement: path.resolve(appDir, 'waku.tsx') },
     ],
   },
   plugins: [

--- a/scripts/build-openapi-standalone.ts
+++ b/scripts/build-openapi-standalone.ts
@@ -67,11 +67,12 @@ await build({
   base: './',
   logLevel: 'warn',
   resolve: {
-    alias: {
+    alias: [
       // The real Vocs layout/chrome only touches Waku via `useRouter`/`Link`;
       // swap it for the SPA history shim so genuine components render here.
-      waku: path.resolve(appDir, 'waku.tsx'),
-    },
+      { find: /^waku$/, replacement: path.resolve(appDir, 'waku.tsx') },
+      { find: 'waku/router/client', replacement: path.resolve(appDir, 'waku.tsx') },
+    ],
   },
   plugins: [
     react(),

--- a/src/openapi-app/client.tsx
+++ b/src/openapi-app/client.tsx
@@ -5,7 +5,7 @@ import { Root_client } from '../react/Root.client.js'
 import { ScrollRestoration } from '../react/ScrollRestoration.js'
 import { App } from './App.js'
 import { read } from './payload.js'
-import { init } from './waku.js'
+import { init, RouterProvider } from './waku.js'
 
 const payload = read()
 init(payload)
@@ -17,9 +17,11 @@ init(payload)
 // stays in the server-sent `<head>`, so there is no flash of unstyled content.
 createRoot(document.body).render(
   <StrictMode>
-    <Root_client>
-      <App payload={payload} />
-      <ScrollRestoration />
-    </Root_client>
+    <RouterProvider>
+      <Root_client>
+        <App payload={payload} />
+        <ScrollRestoration />
+      </Root_client>
+    </RouterProvider>
   </StrictMode>,
 )

--- a/src/openapi-app/client.tsx
+++ b/src/openapi-app/client.tsx
@@ -5,7 +5,7 @@ import { Root_client } from '../react/Root.client.js'
 import { ScrollRestoration } from '../react/ScrollRestoration.js'
 import { App } from './App.js'
 import { read } from './payload.js'
-import { init, RouterProvider } from './waku.js'
+import { init } from './waku.js'
 
 const payload = read()
 init(payload)
@@ -17,11 +17,9 @@ init(payload)
 // stays in the server-sent `<head>`, so there is no flash of unstyled content.
 createRoot(document.body).render(
   <StrictMode>
-    <RouterProvider>
-      <Root_client>
-        <App payload={payload} />
-        <ScrollRestoration />
-      </Root_client>
-    </RouterProvider>
+    <Root_client>
+      <App payload={payload} />
+      <ScrollRestoration />
+    </Root_client>
   </StrictMode>,
 )

--- a/src/openapi-app/waku.tsx
+++ b/src/openapi-app/waku.tsx
@@ -20,38 +20,44 @@ import type { Payload } from '../internal/openapi/app.js'
 import { createRouter, type Router } from './links.js'
 
 type Snapshot = { path: string; hash: string }
+type Route = Snapshot & { query: string }
 
 let router: Router | undefined
 let snapshot: Snapshot = { path: '/', hash: '' }
 
 const listeners = new Set<() => void>()
-const eventHandlers: Record<string, Set<() => void>> = {}
+const eventHandlers: Record<string, Map<(route: Route) => void, () => void>> = {}
 
 function notify() {
   for (const listener of listeners) listener()
 }
 
 function emit(type: string) {
-  for (const handler of eventHandlers[type] ?? []) handler()
+  for (const handler of eventHandlers[type]?.values() ?? []) handler()
 }
 
 const events = {
-  on(type: string, handler: () => void) {
-    let set = eventHandlers[type]
-    if (!set) {
-      set = new Set()
-      eventHandlers[type] = set
+  on(type: string, handler: (route: Route) => void) {
+    let map = eventHandlers[type]
+    if (!map) {
+      map = new Map()
+      eventHandlers[type] = map
     }
-    set.add(handler)
+    map.set(handler, () => handler(getRoute()))
   },
-  off(type: string, handler: () => void) {
+  off(type: string, handler: (route: Route) => void) {
     eventHandlers[type]?.delete(handler)
   },
+}
+
+function getRoute(): Route {
+  return { ...snapshot, query: '' }
 }
 
 function setSnapshot(path: string, hash: string) {
   snapshot = { path, hash }
   notify()
+  emit('complete')
 }
 
 /** Navigates to a section-space route, updating history + router state. */
@@ -115,6 +121,36 @@ function subscribe(listener: () => void) {
 
 function getSnapshot() {
   return snapshot
+}
+
+export const unstable_RouterContext = React.createContext<{
+  route: Route
+  changeRoute: (route: Route, options: { mode?: 'push' | 'replace' | undefined }) => Promise<void>
+  prefetchRoute: () => void
+  routeChangeEvents: typeof events
+  fetchingSlices: Set<string>
+} | null>(null)
+
+export function RouterProvider(props: { children: React.ReactNode }) {
+  const snap = React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+  const value = React.useMemo(
+    () => ({
+      route: { ...snap, query: '' },
+      async changeRoute(route: Route, options: { mode?: 'push' | 'replace' | undefined }) {
+        const query = route.query ? `?${route.query}` : ''
+        push(`${route.path}${query}${route.hash}`, { push: options.mode !== 'replace' })
+      },
+      prefetchRoute() {},
+      routeChangeEvents: events,
+      fetchingSlices: new Set<string>(),
+    }),
+    [snap],
+  )
+  return (
+    <unstable_RouterContext.Provider value={value}>
+      {props.children}
+    </unstable_RouterContext.Provider>
+  )
 }
 
 /** Waku-compatible `useRouter()`. Returns section-space `path`/`hash`. */

--- a/src/openapi-app/waku.tsx
+++ b/src/openapi-app/waku.tsx
@@ -20,44 +20,38 @@ import type { Payload } from '../internal/openapi/app.js'
 import { createRouter, type Router } from './links.js'
 
 type Snapshot = { path: string; hash: string }
-type Route = Snapshot & { query: string }
 
 let router: Router | undefined
 let snapshot: Snapshot = { path: '/', hash: '' }
 
 const listeners = new Set<() => void>()
-const eventHandlers: Record<string, Map<(route: Route) => void, () => void>> = {}
+const eventHandlers: Record<string, Set<() => void>> = {}
 
 function notify() {
   for (const listener of listeners) listener()
 }
 
 function emit(type: string) {
-  for (const handler of eventHandlers[type]?.values() ?? []) handler()
+  for (const handler of eventHandlers[type] ?? []) handler()
 }
 
 const events = {
-  on(type: string, handler: (route: Route) => void) {
-    let map = eventHandlers[type]
-    if (!map) {
-      map = new Map()
-      eventHandlers[type] = map
+  on(type: string, handler: () => void) {
+    let set = eventHandlers[type]
+    if (!set) {
+      set = new Set()
+      eventHandlers[type] = set
     }
-    map.set(handler, () => handler(getRoute()))
+    set.add(handler)
   },
-  off(type: string, handler: (route: Route) => void) {
+  off(type: string, handler: () => void) {
     eventHandlers[type]?.delete(handler)
   },
-}
-
-function getRoute(): Route {
-  return { ...snapshot, query: '' }
 }
 
 function setSnapshot(path: string, hash: string) {
   snapshot = { path, hash }
   notify()
-  emit('complete')
 }
 
 /** Navigates to a section-space route, updating history + router state. */
@@ -121,36 +115,6 @@ function subscribe(listener: () => void) {
 
 function getSnapshot() {
   return snapshot
-}
-
-export const unstable_RouterContext = React.createContext<{
-  route: Route
-  changeRoute: (route: Route, options: { mode?: 'push' | 'replace' | undefined }) => Promise<void>
-  prefetchRoute: () => void
-  routeChangeEvents: typeof events
-  fetchingSlices: Set<string>
-} | null>(null)
-
-export function RouterProvider(props: { children: React.ReactNode }) {
-  const snap = React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
-  const value = React.useMemo(
-    () => ({
-      route: { ...snap, query: '' },
-      async changeRoute(route: Route, options: { mode?: 'push' | 'replace' | undefined }) {
-        const query = route.query ? `?${route.query}` : ''
-        push(`${route.path}${query}${route.hash}`, { push: options.mode !== 'replace' })
-      },
-      prefetchRoute() {},
-      routeChangeEvents: events,
-      fetchingSlices: new Set<string>(),
-    }),
-    [snap],
-  )
-  return (
-    <unstable_RouterContext.Provider value={value}>
-      {props.children}
-    </unstable_RouterContext.Provider>
-  )
 }
 
 /** Waku-compatible `useRouter()`. Returns section-space `path`/`hash`. */


### PR DESCRIPTION
## Summary

- fix standalone OpenAPI build aliasing for Waku package imports
- regenerate the embedded standalone OpenAPI assets
- add a patch changeset

## Motivation

The standalone OpenAPI bundle failed to build because the broad `waku` alias rewrote `waku/router/client` to an invalid file subpath.

## Key design considerations

- keep the `waku` alias exact so package subpaths resolve normally
- limit the source change to the standalone build resolver configuration
