### PR TITLE
fix(twoslash): preserve custom tag indentation

### DIFF
--- a/.changeset/twoslash-log-indentation.md
+++ b/.changeset/twoslash-log-indentation.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Preserved visual indentation in Twoslash custom tag output.

--- a/src/styles/twoslash.css
+++ b/src/styles/twoslash.css
@@ -184,7 +184,7 @@
 }
 
 .twoslash-tag-line {
-  @apply vocs:py-0.5 vocs:my-0.5 vocs:border-solid;
+  @apply vocs:py-0.5 vocs:my-0.5 vocs:border-solid vocs:whitespace-pre;
 }
 
 .twoslash-tag-multiline-line {


### PR DESCRIPTION
Twoslash custom display tag rows now preserve whitespace, so multi-line log output keeps object indentation in rendered code blocks.

This fixes visual flattening from rendering tag output as styled rows outside normal code-line whitespace behavior.
