### PR TITLE
fix(create-vocs): detect package manager for next-steps commands

### DIFF
--- a/.changeset/mighty-cups-ring.md
+++ b/.changeset/mighty-cups-ring.md
@@ -1,0 +1,5 @@
+---
+"create-vocs": patch
+---
+
+Updated to Prompt correct package manager for next-steps commands

--- a/create-vocs/index.ts
+++ b/create-vocs/index.ts
@@ -60,10 +60,12 @@ export async function init() {
 
     spinner.stop('Project created successfully')
 
+    const pkgManager = pkgFromUserAgent(process.env['npm_config_user_agent'])?.name ?? 'npm'
+
     clack.note(
       `${pc.dim('$')} cd ${projectName}
-${pc.dim('$')} npm install
-${pc.dim('$')} npm run dev`,
+${pc.dim('$')} ${pkgManager} install
+${pc.dim('$')} ${getRunCommand(pkgManager, 'dev').join(' ')}`,
       'Next steps',
     )
 
@@ -72,6 +74,26 @@ ${pc.dim('$')} npm run dev`,
     const errorMessage = error instanceof Error ? error.message : 'Unknown error'
     clack.cancel(`Failed to create project: ${errorMessage}`)
     process.exit(1)
+  }
+}
+
+function pkgFromUserAgent(userAgent: string | undefined): { name: string } | undefined {
+  if (!userAgent) return undefined
+  const pkgSpec = userAgent.split(' ')[0] ?? ''
+  const pkgSpecArr = pkgSpec.split('/')
+  return {
+    name: pkgSpecArr[0] ?? '',
+  }
+}
+
+function getRunCommand(agent: string, script: string): string[] {
+  switch (agent) {
+    case 'yarn':
+    case 'pnpm':
+    case 'bun':
+      return [agent, script]
+    default:
+      return [agent, 'run', script]
   }
 }
 


### PR DESCRIPTION
## Description

`create-vocs` always printed `npm install` / `npm run dev` in the "Next steps" output, even when the project was scaffolded with another package manager (`pnpm create vocs`, `yarn create vocs`, etc.).

This detects the package manager from `npm_config_user_agent` and prints the matching commands.

## Output

| Invoked with | Next steps |
| --- | --- |
| `npm create vocs` | `npm install` / `npm run dev` |
| `pnpm create vocs` | `pnpm install` / `pnpm dev` |
| `yarn create vocs` | `yarn install` / `yarn dev` |
| `bun create vocs` | `bun install` / `bun dev` |
