### PR TITLE
fix(outline): exclude changelog release headings from outline

### DIFF
--- a/.changeset/changelog-outline-leak.md
+++ b/.changeset/changelog-outline-leak.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Excluded changelog release-body headings from the page outline and sidebar active-section tracking, fixing the overlapping/duplicated "On this page" entries on changelog pages and the stale entries that leaked onto subsequent pages.

--- a/src/react/internal/Outline.tsx
+++ b/src/react/internal/Outline.tsx
@@ -26,7 +26,10 @@ function useOutlineItems(options: { minLevel: number; maxLevel: number }) {
     const scanHeadings = () => {
       const headingElements = Array.from(
         document.querySelectorAll('article[data-v-content] :is(h2, h3, h4, h5, h6)[id]'),
-      )
+        // Changelog release bodies render as nested `[data-v-content]` inside the
+        // main article; their headings have their own `Versions` outline, so keep
+        // them out of the page outline (otherwise they flood/leak into it).
+      ).filter((element) => !element.closest('[data-v-changelog]'))
       const newItems = headingElements
         .map((element) => {
           const level = Number.parseInt(element.tagName[1] ?? '0', 10)

--- a/src/react/internal/Sidebar.tsx
+++ b/src/react/internal/Sidebar.tsx
@@ -86,7 +86,12 @@ function useActiveAnchor(enabled: boolean, path: string): string | null {
 
     const observeAll = () => {
       observer.disconnect()
-      for (const element of document.querySelectorAll(selector)) observer.observe(element)
+      for (const element of document.querySelectorAll(selector)) {
+        // Skip changelog release-body headings — they have no sidebar entry and
+        // would hijack the active section as you scroll through the changelog.
+        if (element.closest('[data-v-changelog]')) continue
+        observer.observe(element)
+      }
     }
     observeAll()
 


### PR DESCRIPTION
resolves #536 

## Problem

The outline scanners matched `<h2>/<h3>` headings nested inside changelog release bodies (`[data-v-content]` within the main article). On the Changelog page this:

- Flooded "On this page" with release headings, overlapping the "Versions" panel
- Leaked those entries onto the next page after navigating away

## Fix

- Skip headings inside `[data-v-changelog]` in both the outline (`Outline.tsx`) and sidebar (`Sidebar.tsx`) scanners