### PR TITLE
fix(twoslash): give hover popup a z-index so it isn't covered

### DIFF
--- a/.changeset/twoslash-popup-zindex.md
+++ b/.changeset/twoslash-popup-zindex.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed the Twoslash hover popup being covered by page content on `minimal` and `blank` layouts by giving its portaled positioner a z-index.

--- a/src/react/internal/TwoslashHover.client.tsx
+++ b/src/react/internal/TwoslashHover.client.tsx
@@ -69,6 +69,9 @@ export function TwoslashHover(props: TwoslashHover.Props) {
           side="bottom"
           sideOffset={4}
           collisionAvoidance={{ side: 'none' }}
+          // Portaled to `body`; needs z-index or `minimal`/`blank` `[data-v-main]`
+          // (z-index: 10) covers it. The popup class `z-50` is inert here.
+          style={{ zIndex: 50 }}
         >
           <Popover.Popup className={className} initialFocus={false}>
             <Popover.Arrow className="vocs:data-[side=bottom]:top-[-8px] vocs:data-[side=left]:right-[-13px] vocs:data-[side=left]:rotate-90 vocs:data-[side=right]:left-[-13px] vocs:data-[side=right]:-rotate-90 vocs:data-[side=top]:bottom-[-8px] vocs:data-[side=top]:rotate-180">


### PR DESCRIPTION
resolves #539

## Problem

The hover popup is portaled to `document.body` but its positioner had no z-index:

- On `minimal`/`blank` layouts, `[data-v-main]` gets `z-index: 10` and covers it
- The `z-50` on the popup class is inert — it lands on the non-positioned popup, not the fixed positioner

## Fix

- Set `zIndex: 50` on the positioner, matching the Outline popover
