### PR TITLE
feat(openapi): support OpenAPI 3.1 webhooks

### DIFF
--- a/.changeset/openapi-webhooks.md
+++ b/.changeset/openapi-webhooks.md
@@ -1,0 +1,5 @@
+---
+"vocs": minor
+---
+
+Added support for OpenAPI 3.1 webhooks. Top-level `webhooks` are rendered as non-callable operations (no interactive client or request samples), with a "Webhook" badge in the operation header and a webhook glyph in the sidebar.

--- a/.changeset/openapi-webhooks.md
+++ b/.changeset/openapi-webhooks.md
@@ -1,5 +1,5 @@
 ---
-"vocs": minor
+"vocs": patch
 ---
 
 Added support for OpenAPI 3.1 webhooks. Top-level `webhooks` are rendered as non-callable operations (no interactive client or request samples), with a "Webhook" badge in the operation header and a webhook glyph in the sidebar.

--- a/src/internal/openapi/parser.test.ts
+++ b/src/internal/openapi/parser.test.ts
@@ -226,6 +226,45 @@ describe('parse', () => {
       globalThis.fetch = fetch_
     }
   })
+
+  test('parses OpenAPI 3.1 top-level `webhooks` as non-callable operations', async () => {
+    const webhookSpec = {
+      openapi: '3.1.0',
+      info: { title: 'Petstore', version: '1.0.0' },
+      tags: [{ name: 'Webhooks', description: 'Outbound deliveries.' }],
+      paths: {
+        '/pets': { get: { operationId: 'listPets', tags: ['pets'], responses: { '200': {} } } },
+      },
+      webhooks: {
+        event: {
+          post: {
+            summary: 'Webhook event delivery',
+            tags: ['Webhooks'],
+            parameters: [
+              { name: 'x-signature', in: 'header', required: true, schema: { type: 'string' } },
+            ],
+            requestBody: {
+              required: true,
+              content: { 'application/json': { schema: { type: 'object' } } },
+            },
+            responses: { '2xx': { description: 'Delivery acknowledged.' } },
+          },
+        },
+      },
+    }
+    const ir = await parse(OpenApi.from({ spec: webhookSpec, path: '/api' }))
+
+    const webhooks = ir.groups.find((group) => group.name === 'Webhooks')
+    expect(webhooks?.operations).toHaveLength(1)
+    const event = webhooks?.operations[0]
+    expect(event?.method).toBe('POST')
+    expect(event?.path).toBe('event')
+    expect(event?.isWebhook).toBe(true)
+    expect(event?.summary).toBe('Webhook event delivery')
+    expect(event?.requestBody?.content[0]?.schema).toEqual({ type: 'object' })
+    // Webhook ids are prefixed so they can't collide with real path operations.
+    expect(event?.id).toBe('webhook-post-event')
+  })
 })
 
 describe('from', () => {

--- a/src/internal/openapi/parser.ts
+++ b/src/internal/openapi/parser.ts
@@ -95,8 +95,14 @@ export type IrOperation = {
   id: string
   /** HTTP method (uppercased for display, e.g. `GET`). */
   method: string
-  /** Templated path (e.g. `/pets/{petId}`). */
+  /** Templated path (e.g. `/pets/{petId}`), or the event name for webhooks. */
   path: string
+  /**
+   * `true` for an OpenAPI 3.1 outbound webhook delivery (from the document's
+   * top-level `webhooks`). The renderer omits the interactive client and code
+   * samples for these, since there's no endpoint to call.
+   */
+  isWebhook?: boolean | undefined
   /**
    * Name of the host operation's request example to preselect in the
    * interactive client. Set for JSON-RPC operations expanded from an OpenRPC
@@ -192,6 +198,12 @@ type Document = {
     'x-parent'?: string
   }[]
   paths?: Record<string, PathItem>
+  /**
+   * OpenAPI 3.1 outbound webhook deliveries. Keyed by event name (an arbitrary
+   * label, not a URL); each value is a Path Item with the same operation shape
+   * as `paths`. Rendered as non-callable operations (no server endpoint).
+   */
+  webhooks?: Record<string, PathItem>
   components?: { securitySchemes?: Record<string, IrSecurityScheme> }
   security?: Record<string, string[]>[]
 }
@@ -551,6 +563,35 @@ async function buildGroups(
     }
   }
 
+  // OpenAPI 3.1 outbound webhooks: same Path Item shape as `paths`, but keyed by
+  // event name and rendered as non-callable operations.
+  for (const [name, item] of Object.entries(document.webhooks ?? {})) {
+    if (!item || typeof item !== 'object') continue
+    const pathParameters = item.parameters ?? []
+
+    for (const method of methods) {
+      const operation = item[method]
+      if (!operation) continue
+
+      const groupName = operation.tags?.[0] ?? 'Webhooks'
+      if (!byName.has(groupName)) {
+        byName.set(groupName, [])
+        order.push(groupName)
+      }
+
+      byName.get(groupName)?.push(
+        buildOperation({
+          method,
+          pathname: name,
+          operation,
+          pathParameters,
+          slugger,
+          isWebhook: true,
+        }),
+      )
+    }
+  }
+
   const groups = order
     .map((name) => ({
       id: slugger.slug(name),
@@ -569,10 +610,13 @@ function buildOperation(options: {
   operation: Operation
   pathParameters: RawParameter[]
   slugger: GithubSlugger
+  isWebhook?: boolean
 }): IrOperation {
-  const { method, pathname, operation, pathParameters, slugger } = options
+  const { method, pathname, operation, pathParameters, slugger, isWebhook = false } = options
 
-  const idSource = operation.operationId || `${method}-${pathname}`
+  // Webhook keys are arbitrary labels (not URLs) and can collide with real
+  // paths, so prefix the id source to keep anchors unique.
+  const idSource = operation.operationId || `${isWebhook ? 'webhook-' : ''}${method}-${pathname}`
 
   // Merge path-level parameters with operation-level (operation wins on conflict).
   const merged = new Map<string, RawParameter>()
@@ -585,6 +629,7 @@ function buildOperation(options: {
     id: slugger.slug(idSource),
     method: method.toUpperCase(),
     path: pathname,
+    ...(isWebhook ? { isWebhook: true } : {}),
     summary: operation.summary,
     description: operation.description,
     deprecated: operation.deprecated,

--- a/src/internal/openapi/sidebar.test.ts
+++ b/src/internal/openapi/sidebar.test.ts
@@ -119,6 +119,37 @@ describe('toSidebar', () => {
   })
 })
 
+describe('webhook badges', () => {
+  const webhookIr: Ir = {
+    ...ir,
+    groups: [
+      {
+        id: 'webhooks',
+        name: 'Webhooks',
+        operations: [
+          {
+            id: 'payment-succeeded',
+            method: 'POST',
+            path: 'payment.succeeded',
+            summary: 'Payment succeeded',
+            parameters: [],
+            responses: [],
+            isWebhook: true,
+          },
+        ],
+      },
+    ],
+  }
+
+  test('webhook operations get an icon badge instead of the POST method text', () => {
+    const sidebar = toSidebar(webhookIr)
+    const group = sidebar[1] as { items: { badge?: { icon?: string; text?: string } }[] }
+    const badge = group.items[1]?.badge
+    expect(badge?.text).toBeUndefined()
+    expect(badge?.icon).toContain('<svg')
+  })
+})
+
 describe('methodVariant', () => {
   test('maps methods to badge variants', () => {
     expect(methodVariant('GET')).toBe('info')

--- a/src/internal/openapi/sidebar.ts
+++ b/src/internal/openapi/sidebar.ts
@@ -1,5 +1,9 @@
+import { resolveIconSync } from '../icons.js'
 import type { SidebarItem } from '../sidebar.js'
 import type { Ir, IrOperation } from './parser.js'
+
+/** Inline SVG for the webhook badge, resolved once at module load (server-side). */
+const webhookIcon = resolveIconSync('lucide:webhook')
 
 export type Badge = NonNullable<SidebarItem['badge']>
 export type BadgeVariant = NonNullable<Exclude<Badge, string>['variant']>
@@ -72,7 +76,12 @@ export function toSidebar(ir: Ir, options: toSidebar.Options = {}): SidebarItem<
         ...group.operations.map((operation) => ({
           text: operation.summary || `${operation.method} ${operation.path}`,
           link: operationLink(operation, group.id),
-          badge: { text: operation.method, variant: methodVariant(operation.method) },
+          // Webhooks are inbound deliveries, not callable endpoints — show a
+          // webhook glyph instead of the HTTP method (which is always POST).
+          badge:
+            operation.isWebhook && webhookIcon
+              ? { icon: webhookIcon, variant: methodVariant(operation.method) }
+              : { text: operation.method, variant: methodVariant(operation.method) },
         })),
       ],
     })),

--- a/src/internal/sidebar.ts
+++ b/src/internal/sidebar.ts
@@ -3,8 +3,14 @@ import type { Config } from './config.js'
 export type SidebarItemBadge =
   | string
   | {
-      /** Text displayed inside the badge. */
-      text: string
+      /**
+       * Inline SVG markup rendered before the badge text. Used for icon badges
+       * (e.g. the generated OpenAPI webhook badge). Resolve an icon name to SVG
+       * server-side (via the icon helpers) before assigning.
+       */
+      icon?: string | undefined
+      /** Text displayed inside the badge. Optional when an `icon` is provided. */
+      text?: string | undefined
       /** Visual variant. Defaults to `'info'`. */
       variant?: 'note' | 'info' | 'warning' | 'danger' | 'tip' | 'success' | undefined
     }

--- a/src/react/internal/Sidebar.tsx
+++ b/src/react/internal/Sidebar.tsx
@@ -169,13 +169,23 @@ export declare namespace Sidebar {
 
 /** @internal */
 function ItemBadge(props: { badge: Sidebar_core.SidebarItemBadge }) {
-  const badge = typeof props.badge === 'string' ? { text: props.badge } : props.badge
+  const badge =
+    typeof props.badge === 'string' ? { text: props.badge, icon: undefined } : props.badge
   return (
     <Badge
       className="vocs:shrink-0 vocs:ml-2"
       data-v-sidebar-item-badge
+      data-v-icon={badge.icon ? '' : undefined}
       variant={badge.variant ?? 'info'}
     >
+      {badge.icon && (
+        <span
+          aria-hidden
+          data-v-sidebar-item-badge-icon
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: server-resolved SVG markup
+          dangerouslySetInnerHTML={{ __html: badge.icon }}
+        />
+      )}
       {badge.text}
     </Badge>
   )

--- a/src/react/internal/openapi/Operation.tsx
+++ b/src/react/internal/openapi/Operation.tsx
@@ -48,7 +48,9 @@ export function Operation(props: Operation.Props) {
   const title = operation.summary || `${operation.method} ${operation.path}`
   const Heading = `h${headingLevel}` as 'h2' | 'h3'
 
-  const samples = codeSamples(operation, server, { hideQueryParams })
+  // Webhooks are inbound deliveries to the consumer's URL, not callable
+  // endpoints — so skip the "Try" client and the request code samples.
+  const samples = operation.isWebhook ? [] : codeSamples(operation, server, { hideQueryParams })
   const responses = responseSamples(operation)
 
   return (
@@ -65,6 +67,7 @@ export function Operation(props: Operation.Props) {
           <HeadingAnchor id={operation.id} />
         </Heading>
         <div data-v-openapi-endpoint>
+          {operation.isWebhook && <Badge variant="note">Webhook</Badge>}
           <Badge variant={methodVariant(operation.method)}>{operation.method}</Badge>
           <code data-v-openapi-endpoint-path>{operation.path}</code>
         </div>

--- a/src/styles/openapi.css
+++ b/src/styles/openapi.css
@@ -15,6 +15,17 @@
   @apply vocs:text-[10px] vocs:px-1.5 vocs:py-0.5;
 }
 
+/* Icon badges (e.g. webhooks) center a glyph instead of method text. */
+[data-v-sidebar-item-badge][data-v-icon] {
+  @apply vocs:inline-flex vocs:items-center vocs:justify-center;
+}
+[data-v-sidebar-item-badge-icon] {
+  @apply vocs:inline-flex vocs:items-center vocs:justify-center;
+}
+[data-v-sidebar-item-badge-icon] svg {
+  @apply vocs:size-3;
+}
+
 /* #region Page layout */
 
 /* Both the landing and group pages use the full-bleed layout (left gutter


### PR DESCRIPTION
## Overview

Adds support for OpenAPI 3.1 **webhooks** in the generated API reference. Webhooks are inbound deliveries to the consumer's URL, not callable endpoints, so they're rendered as non-callable operations.

## What changed

- **Parser** ([parser.ts](https://github.com/wevm/vocs/blob/feat/openapi-webhooks/src/internal/openapi/parser.ts)) — parses the document's top-level `webhooks` field into operations, keyed by event name, grouped under "Webhooks" by default, flagged with `isWebhook`.
- **Operation renderer** ([Operation.tsx](https://github.com/wevm/vocs/blob/feat/openapi-webhooks/src/react/internal/openapi/Operation.tsx)) — skips the interactive "Try" client and request code samples for webhooks, and shows a `Webhook` badge in the header.
- **Sidebar** — webhook operations render a `lucide:webhook` glyph instead of the HTTP method badge (always `POST`):
  - `SidebarItemBadge` gains an optional `icon` (inline SVG; `text` is now optional).
  - The icon is resolved to SVG **server-side** at module load, so no iconify data lands in the client bundle.

```
before                          after
  payment.succeeded  [POST]       payment.succeeded  [⎔]
```

## Tests

- `pnpm vitest run src/internal/openapi` — 56/56 ✅ (added a webhook sidebar-badge test + parser webhook tests)
- `pnpm build` and `pnpm check` pass
- `pnpm check:types` clean except pre-existing `site/src/components/Landing.tsx` `~icons` errors (unrelated)