### PR TITLE
fix: keep react-server-dom-webpack out of standalone OpenAPI bundle

### DIFF
--- a/.changeset/fix-openapi-standalone-webpack.md
+++ b/.changeset/fix-openapi-standalone-webpack.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed the standalone OpenAPI reference rendering blank (`__webpack_require__ is not defined`). The genuine `react/Link` imports `unstable_RouterContext` from `waku/router/client`, which dragged `react-server-dom-webpack` into the prebuilt browser bundle. The standalone build now aliases `waku/router/client` to its Waku shim (which provides the router context), keeping the RSC client out of the bundle.

--- a/scripts/build-openapi-standalone.ts
+++ b/scripts/build-openapi-standalone.ts
@@ -71,6 +71,11 @@ await build({
       // The real Vocs layout/chrome only touches Waku via `useRouter`/`Link`;
       // swap it for the SPA history shim so genuine components render here.
       { find: /^waku$/, replacement: path.resolve(appDir, 'waku.tsx') },
+      // `react/Link` imports `unstable_RouterContext` from `waku/router/client`;
+      // alias it to the same shim so the real Waku client (which pulls in
+      // `react-server-dom-webpack` and leaks `__webpack_require__` into the
+      // browser bundle) stays out of the standalone build.
+      { find: /^waku\/router\/client$/, replacement: path.resolve(appDir, 'waku.tsx') },
     ],
   },
   plugins: [

--- a/src/openapi-app/App.tsx
+++ b/src/openapi-app/App.tsx
@@ -4,7 +4,7 @@ import type { Payload } from '../internal/openapi/app.js'
 import { OpenApiGuide, OpenApiPage } from '../react/internal/openapi/OpenApiPage.js'
 import { Blocks } from './blocks.js'
 import { join } from './links.js'
-import { useRouter } from './waku.js'
+import { RouterProvider, useRouter } from './waku.js'
 
 /**
  * Resolves the active section route to real Vocs page content:
@@ -19,6 +19,16 @@ import { useRouter } from './waku.js'
  * still renders below.
  */
 export function App(props: App.Props) {
+  // The genuine `react/Link` reads the active route from `unstable_RouterContext`
+  // (shimmed in `waku.tsx`); provide it so links resolve relative `#hash`s.
+  return (
+    <RouterProvider>
+      <Content {...props} />
+    </RouterProvider>
+  )
+}
+
+function Content(props: App.Props) {
   const { payload } = props
   const { ir, pages } = payload
   const base = ir.path || '/'

--- a/src/openapi-app/waku.tsx
+++ b/src/openapi-app/waku.tsx
@@ -129,6 +129,27 @@ export function useRouter() {
   }
 }
 
+/**
+ * Shim for `waku/router/client`'s `unstable_RouterContext`. The genuine Vocs
+ * `react/Link` reads `router?.route.path` from this context to resolve bare
+ * `#hash` links against the current page. Aliasing `waku/router/client` to this
+ * module keeps the real `react-server-dom-webpack`-backed Waku client out of the
+ * standalone browser bundle (importing it leaks `__webpack_require__`).
+ */
+export const unstable_RouterContext = React.createContext<{
+  route: { path: string }
+} | null>(null)
+
+/** Feeds {@link unstable_RouterContext} the live section route for `react/Link`. */
+export function RouterProvider(props: { children: React.ReactNode }) {
+  const { path } = useRouter()
+  return (
+    <unstable_RouterContext.Provider value={{ route: { path } }}>
+      {props.children}
+    </unstable_RouterContext.Provider>
+  )
+}
+
 /** Waku-compatible `Link`. Renders a real, mount-prefixed `<a>`. */
 export function Link(props: Link.Props) {
   const {


### PR DESCRIPTION
## Problem

The standalone OpenAPI reference (`Handler.openApi`) renders a **blank page** at runtime:

```
Uncaught ReferenceError: __webpack_require__ is not defined
  at /_vocs/openapi/client.js
```

## Root cause

The genuine `react/Link` (`src/react/Link.tsx`) — used by `Layout`, `Sidebar`, `TopNav`, etc., all rendered by the standalone bundle — imports `unstable_RouterContext` from `waku/router/client`:

```ts
import { unstable_RouterContext as WakuRouterContext } from 'waku/router/client'
```

The standalone build (`scripts/build-openapi-standalone.ts`) only aliased the **bare** `waku` specifier (`/^waku$/`), so `waku/router/client` slipped through and pulled the real `react-server-dom-webpack`-backed Waku client into the browser bundle, leaking `__webpack_require__`. (#532 converted the alias to array form but didn't add this subpath.)

## Fix

- Export an `unstable_RouterContext` shim + a `RouterProvider` (wired to the SPA section route) from `src/openapi-app/waku.tsx`.
- Alias `waku/router/client` → that shim in the standalone build.
- Wrap the standalone `App` in `RouterProvider` so `react/Link` still resolves relative `#hash` links.

No `react-server-dom-webpack` / `__webpack_require__` in the rebuilt bundle.

> Note: the committed `src/server/openapi/assets.generated.ts` is left untouched — it's a generated artifact regenerated by `pnpm build` (which the publish flow runs), and it has already drifted from source independently of this change. This PR keeps the diff to the source fix.

## Verification

Built the standalone bundle and served it (`http.createServer(Handler.openApi({ spec }).listener)`) against a real OpenAPI spec, loaded in Chrome:

- Full reference renders (sidebar + endpoints), **no console errors**; rebuilt `client.js` has **0** `__webpack_require__` refs (was 4).
- Client-side link navigation works through the shimmed router (clicking a section updates URL + title + content without a full reload).
