### PR TITLE
feat: add trailingSlashRedirect config option

### DIFF
--- a/.changeset/trailing-slash-redirect.md
+++ b/.changeset/trailing-slash-redirect.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Add `trailingSlashRedirect` config option (default `true`). Set to `false` when an upstream host (reverse proxy / CDN) owns trailing-slash canonicalization — Vocs then normalizes `/foo/` to `/foo` internally for routing instead of emitting a 308 redirect, which avoids redirect loops when the upstream adds trailing slashes.

--- a/.changeset/trailing-slash-redirect.md
+++ b/.changeset/trailing-slash-redirect.md
@@ -2,4 +2,4 @@
 "vocs": patch
 ---
 
-Add `trailingSlashRedirect` config option (default `true`). Set to `false` when an upstream host (reverse proxy / CDN) owns trailing-slash canonicalization — Vocs then normalizes `/foo/` to `/foo` internally for routing instead of emitting a 308 redirect, which avoids redirect loops when the upstream adds trailing slashes.
+Added `trailingSlashRedirect` config option (default `true`). 

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -587,6 +587,18 @@ export type Config<partial extends boolean = false> = MaybePartial<
      */
     topNav?: readonly TopNav.Item[] | undefined
     /**
+     * Whether Vocs redirects trailing-slash page URLs to their no-slash form
+     * (e.g. `/about/` → `/about` via a 308).
+     *
+     * Disable this when an upstream host (e.g. a reverse proxy or CDN) owns
+     * trailing-slash canonicalization. When disabled, Vocs internally
+     * normalizes `/foo/` to `/foo` for routing instead of emitting a redirect,
+     * which avoids redirect loops when the upstream adds trailing slashes.
+     *
+     * @default true
+     */
+    trailingSlashRedirect: boolean
+    /**
      * TwoSlash configuration. Set to `false` to disable.
      */
     twoslash?: Mdx.rehypeShiki.Options['twoslash'] | undefined
@@ -713,6 +725,7 @@ export function define(config: define.Options = {}): Config {
     title = 'Docs',
     titleTemplate = `%s – ${title}`,
     topNav,
+    trailingSlashRedirect = true,
     twoslash,
   } = config
 
@@ -829,6 +842,7 @@ export function define(config: define.Options = {}): Config {
     title,
     titleTemplate,
     topNav,
+    trailingSlashRedirect,
     twoslash,
   }
 }

--- a/src/waku/internal/middleware/trailing-slash.test.ts
+++ b/src/waku/internal/middleware/trailing-slash.test.ts
@@ -9,7 +9,11 @@ import { trailingSlash } from './trailing-slash.js'
 function request(path: string, options?: trailingSlash.Options) {
   const app = new Hono()
   app.use('*', trailingSlash(options))
-  app.get('*', (c) => c.text('ok'))
+  // Echo the downstream pathname + search so tests can assert internal rewrites.
+  app.get('*', (c) => {
+    const url = new URL(c.req.url)
+    return c.text(url.pathname + url.search)
+  })
   return app.request(path)
 }
 
@@ -63,5 +67,34 @@ describe('trailingSlash', () => {
     const res = await request('http://localhost/sdk/typescript/core/')
     expect(res.status).toBe(308)
     expect(res.headers.get('location')).toBe('/sdk/typescript/core')
+  })
+
+  describe('redirect: false (internal rewrite)', () => {
+    it('normalizes trailing slash internally without a redirect', async () => {
+      const res = await request('http://localhost/about/', { redirect: false })
+      expect(res.status).toBe(200)
+      expect(res.headers.get('location')).toBeNull()
+      expect(await res.text()).toBe('/about')
+    })
+
+    it('preserves query string when rewriting internally', async () => {
+      const res = await request('http://localhost/docs/?ref=nav', { redirect: false })
+      expect(res.status).toBe(200)
+      expect(res.headers.get('location')).toBeNull()
+      expect(await res.text()).toBe('/docs?ref=nav')
+    })
+
+    it('still skips root, base path root, and file-extension paths', async () => {
+      expect((await request('http://localhost/', { redirect: false })).status).toBe(200)
+      expect(
+        (
+          await request('http://localhost/open-source/', {
+            redirect: false,
+            basePath: '/open-source',
+          })
+        ).status,
+      ).toBe(200)
+      expect((await request('http://localhost/styles.css', { redirect: false })).status).toBe(200)
+    })
   })
 })

--- a/src/waku/internal/middleware/trailing-slash.ts
+++ b/src/waku/internal/middleware/trailing-slash.ts
@@ -5,35 +5,59 @@ import { appendSearch } from '../../../internal/redirects.js'
 const normalizeBasePath = (basePath: string) => (basePath.endsWith('/') ? basePath : `${basePath}/`)
 
 /**
- * Removes trailing slashes from URLs.
+ * Normalizes trailing slashes on page URLs (e.g. `/about/` → `/about`).
  *
- * Redirects `/about/` → `/about` with a 308 Permanent Redirect.
- * Skips the root path (`/`), configured base path root, and paths with file
- * extensions.
+ * By default, redirects `/about/` → `/about` with a 308 Permanent Redirect.
+ *
+ * When `redirect` is `false`, the trailing slash is stripped internally for
+ * downstream routing instead of emitting a redirect. This avoids redirect
+ * loops when an upstream host (reverse proxy / CDN) owns trailing-slash
+ * canonicalization and adds the trailing slash that Vocs would otherwise
+ * strip — particularly when the upstream rewrites the path so the redirect
+ * `Location` would lose its public prefix.
+ *
+ * Skips the root path (`/`), the configured base path root, and paths with
+ * file extensions.
  *
  * Uses relative Location values so redirects work correctly behind
  * TLS-terminating reverse proxies, where the internal request URL
  * may use `http://`.
  */
 export const trailingSlash = (options: trailingSlash.Options = {}): MiddlewareHandler => {
-  const basePathPromise =
-    options.basePath !== undefined
-      ? Promise.resolve(normalizeBasePath(options.basePath))
-      : Config.resolve({ server: true }).then((config) => normalizeBasePath(config.basePath))
+  const optionsPromise =
+    options.basePath !== undefined || options.redirect !== undefined
+      ? Promise.resolve({
+          basePath: normalizeBasePath(options.basePath ?? '/'),
+          redirect: options.redirect ?? true,
+        })
+      : Config.resolve({ server: true }).then((config) => ({
+          basePath: normalizeBasePath(config.basePath),
+          redirect: config.trailingSlashRedirect,
+        }))
 
   return async (context, next) => {
     const url = new URL(context.req.url)
-    const basePath = await basePathPromise
+    const { basePath, redirect } = await optionsPromise
 
     // Skip root path, base path root, and paths with file extensions
     if (url.pathname === '/' || url.pathname === basePath || /\.\w+$/.test(url.pathname))
       return next()
 
-    // Redirect trailing slash to non-trailing slash
     if (url.pathname.endsWith('/')) {
-      const destination = appendSearch(url.pathname.slice(0, -1), url.search)
-      context.res = context.redirect(destination, 308)
-      return
+      const pathname = url.pathname.slice(0, -1)
+
+      // Emit a redirect to the no-slash form (default).
+      if (redirect) {
+        const destination = appendSearch(pathname, url.search)
+        context.res = context.redirect(destination, 308)
+        return
+      }
+
+      // Otherwise, normalize the path internally (no redirect) so downstream
+      // routing matches the no-slash route. Preserves the query string.
+      url.pathname = pathname
+      context.req.raw = new Request(url, context.req.raw)
+      return next()
     }
 
     return next()
@@ -45,5 +69,12 @@ export default trailingSlash
 export declare namespace trailingSlash {
   type Options = {
     basePath?: string | undefined
+    /**
+     * Whether to emit a 308 redirect to the no-slash form. When `false`, the
+     * trailing slash is stripped internally for routing without a redirect.
+     *
+     * @default true
+     */
+    redirect?: boolean | undefined
   }
 }


### PR DESCRIPTION
## Problem

When Vocs is deployed behind an upstream host (reverse proxy / CDN) that **adds** trailing slashes and **rewrites the path** before requests reach Vocs, the built-in trailing-slash middleware can cause an **infinite redirect loop**.

Concrete case (docs served under a `/developers/*` prefix on a Vercel deployment that has `trailingSlash: true`):

```
/developers/docs   ──Vercel 308──▶  /developers/docs/      (upstream adds slash)
/developers/docs/  ──Vercel maps──▶  Waku /docs/           (upstream strips prefix)
        Waku /docs/  ──Vocs 308──▶   /docs                 (Vocs strips slash, loses /developers)
/docs              ──Vercel 308──▶  /developers/docs        (upstream re-adds prefix)  ⟲ loop
```

Vocs's middleware strips the trailing slash and emits `Location: /docs` — which has lost the public `/developers` prefix because Vocs (correctly) only sees the rewritten, unprefixed path. The upstream then re-prefixes it, and the cycle repeats forever.

## Fix

Add a `trailingSlashRedirect` config option (default `true`, preserving current behavior):

- `true` (default): redirect `/foo/` → `/foo` with a 308 (unchanged).
- `false`: normalize `/foo/` → `/foo` **internally** for routing (`context.req.raw` rewrite + `next()`) — no redirect, no `Location`, so nothing escapes to be re-prefixed.

This lets the upstream host own trailing-slash canonicalization while Vocs still routes the slashed URL to the correct page.

```ts
// vocs.config.ts
export default defineConfig({
  trailingSlashRedirect: false,
})
```

## Notes

- Root path, configured `basePath` root, and file-extension paths are still skipped in both modes.
- Query strings are preserved in the internal-rewrite path.

## Tests

Added coverage for the internal-rewrite mode (no redirect, status 200, downstream sees the normalized path, query string preserved, skips still apply). Existing redirect-mode tests unchanged. Full middleware suite green.
