### PR TITLE
fix: avoid broken `es-module-lexer@2.2.0`

### DIFF
--- a/.changeset/tidy-poems-tell.md
+++ b/.changeset/tidy-poems-tell.md
@@ -1,0 +1,5 @@
+---
+'vocs': patch
+---
+
+Added a direct `es-module-lexer@^2.3.0` dependency to prevent installs from resolving the broken `2.2.0` release ([guybedford/es-module-lexer#214](https://github.com/guybedford/es-module-lexer/issues/214)).

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "cac": "^6.7.14",
     "cva": "npm:class-variance-authority@^0.7.1",
     "debug": "^4.4.0",
+    "es-module-lexer": "^2.3.0",
     "esast-util-from-js": "^2.0.1",
     "estree-util-value-to-estree": "^3.5.0",
     "estree-util-visit": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,7 @@ catalogs:
       version: 0.0.25
 
 overrides:
+  es-module-lexer: ^2.3.0
   '@vocs/twoslash-rust': workspace:*
   create-vocs: workspace:*
   yaml: 2.9.0
@@ -154,6 +155,9 @@ importers:
       debug:
         specifier: ^4.4.0
         version: 4.4.3
+      es-module-lexer:
+        specifier: ^2.3.0
+        version: 2.3.0
       esast-util-from-js:
         specifier: ^2.0.1
         version: 2.0.1
@@ -2796,8 +2800,8 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-module-lexer@2.1.0:
-    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -6818,7 +6822,7 @@ snapshots:
   '@vitejs/plugin-rsc@0.5.26(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.27.2)))(react@19.2.4)(vite@8.0.14(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.18
-      es-module-lexer: 2.1.0
+      es-module-lexer: 2.3.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
       react: 19.2.4
@@ -7587,7 +7591,7 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-module-lexer@2.1.0: {}
+  es-module-lexer@2.3.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -10029,7 +10033,7 @@ snapshots:
       '@vitest/snapshot': 4.1.7
       '@vitest/spy': 4.1.7
       '@vitest/utils': 4.1.7
-      es-module-lexer: 2.1.0
+      es-module-lexer: 2.3.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
@@ -10148,7 +10152,7 @@ snapshots:
       browserslist: 4.28.1
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.22.0
-      es-module-lexer: 2.1.0
+      es-module-lexer: 2.3.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,10 @@ catalog:
 overrides:
   '@vocs/twoslash-rust': workspace:*
   create-vocs: workspace:*
+  # es-module-lexer@2.2.0 cannot parse sources over ~4MB ("WebAssembly.Memory.grow():
+  # Maximum memory size exceeded"), crashing plugin-rsc's scan build on large modules
+  # (e.g. iconify JSON). https://github.com/guybedford/es-module-lexer/issues/214
+  es-module-lexer: ^2.3.0
   # Pin a single `yaml` version. `yaml` is an optional peer dep of vite, so
   # multiple versions fork vite/waku/plugin-rsc into separate peer-resolved
   # instances, which breaks `instanceof RunnableDevEnvironment` checks


### PR DESCRIPTION
Closes https://github.com/wevm/vocs/issues/541

`es-module-lexer@2.2.0` cannot grow wasm memory for sources over ~4MB (https://github.com/guybedford/es-module-lexer/issues/214). `@vitejs/plugin-rsc` lexes every module during its RSC scan build, so vocs apps crash on large modules such as `@iconify-json/simple-icons` with `RangeError: WebAssembly.Memory.grow(): Maximum memory size exceeded`. Fixed upstream in `2.3.0`.

`vocs` now declares `es-module-lexer@^2.3.0` directly, so a working version is hoisted and deduped for npm, yarn, and bun installs, and pnpm resolves `2.3.0` as the highest `^2.1.0` match. User projects need no overrides. A workspace override keeps this repo on a known-good version.

Apps whose lockfile already pinned `2.2.0` (created June 29 to July 2) should refresh it, e.g. `pnpm up es-module-lexer`.
