### PR TITLE
fix: serve `public/*.md` files as-is

### DIFF
--- a/.changeset/public-md-files.md
+++ b/.changeset/public-md-files.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed static `.md` files in `public/` being shadowed by markdown-twin routing.

--- a/playground/public/SKILL.md
+++ b/playground/public/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: test-skill
+description: A test skill manifest
+---
+
+# SKILL
+
+This is a static public markdown file.

--- a/src/waku/internal/middleware/md-router.test.ts
+++ b/src/waku/internal/middleware/md-router.test.ts
@@ -3,6 +3,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('node:fs/promises', () => ({
   readFile: vi.fn(),
+  stat: vi.fn(),
+}))
+
+vi.mock('../../../internal/config.js', () => ({
+  resolve: vi.fn(),
 }))
 
 vi.mock('node:path', async () => {
@@ -205,6 +210,59 @@ describe('middleware', () => {
     expect(await response.text()).toBe('<p>ok</p>')
     expect(readFile).not.toHaveBeenCalled()
     expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('serves public `.md` files as-is instead of resolving a twin', async () => {
+    process.env['NODE_ENV'] = 'production'
+
+    const { readFile, stat } = await import('node:fs/promises')
+    vi.mocked(stat).mockResolvedValue({ isFile: () => true } as never)
+
+    const fetchSpy = vi.fn()
+    globalThis.fetch = fetchSpy
+
+    const response = await request('http://localhost/SKILL.md')
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('text/html')
+    expect(await response.text()).toBe('<p>ok</p>')
+    expect(vi.mocked(stat).mock.calls[0]?.[0]).toMatch(/\/public\/SKILL\.md$/)
+    expect(readFile).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('serves public `.md` files as-is in dev', async () => {
+    const Config = await import('../../../internal/config.js')
+    vi.mocked(Config.resolve).mockResolvedValue({ rootDir: '/site' } as never)
+
+    const { readFile, stat } = await import('node:fs/promises')
+    vi.mocked(stat).mockResolvedValue({ isFile: () => true } as never)
+
+    const fetchSpy = vi.fn()
+    globalThis.fetch = fetchSpy
+
+    const response = await request('http://localhost/SKILL.md')
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('<p>ok</p>')
+    expect(vi.mocked(stat).mock.calls[0]?.[0]).toBe('/site/public/SKILL.md')
+    expect(readFile).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('resolves the markdown twin for `.md` requests without a matching public file', async () => {
+    process.env['NODE_ENV'] = 'production'
+
+    const { readFile, stat } = await import('node:fs/promises')
+    vi.mocked(stat).mockRejectedValue(new Error('ENOENT'))
+    vi.mocked(readFile).mockResolvedValue('# Hello from disk')
+
+    const response = await request('http://localhost/docs.md')
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('text/markdown; charset=utf-8')
+    expect(await response.text()).toBe('# Hello from disk')
+    expect(vi.mocked(readFile).mock.calls[0]?.[0]).toMatch(/\/public\/assets\/md\/docs\.md$/)
   })
 
   it('serves markdown for clean routes whose parent segments contain dots', async () => {

--- a/src/waku/internal/middleware/md-router.ts
+++ b/src/waku/internal/middleware/md-router.ts
@@ -49,6 +49,32 @@ export async function fetchMarkdown(url: URL, assetPath: string, cookie?: string
   return response.text()
 }
 
+/** Whether an exact file for `pathname` exists in the `public/` (dev) or static output (build) directory. */
+async function hasPublicFile(pathname: string) {
+  const relativePath = pathname.replace(/^\//, '')
+  if (!relativePath) return false
+  try {
+    const fs = await import('node:fs/promises')
+    const path = await import('node:path')
+
+    let publicDir: string
+    if (isDev) {
+      const Config = await import('../../../internal/config.js')
+      const config = await Config.resolve({ server: true })
+      publicDir = path.resolve(config.rootDir, 'public')
+    } else {
+      const { fileURLToPath } = await import('node:url')
+      const distDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+      publicDir = path.join(distDir, 'public')
+    }
+
+    const stats = await fs.stat(path.join(publicDir, relativePath))
+    return stats.isFile()
+  } catch {
+    return false
+  }
+}
+
 export function middleware(): MiddlewareHandler {
   return async (context, next) => {
     const url = new URL(context.req.url)
@@ -86,6 +112,10 @@ export function middleware(): MiddlewareHandler {
     }
 
     const isMarkdownRequest = url.pathname.endsWith('.md')
+
+    // A file physically present in `public/` wins over markdown-twin resolution,
+    // so static `.md` files (skill manifests, plain markdown) are served as-is.
+    if (isMarkdownRequest && (await hasPublicFile(url.pathname))) return next()
 
     // Static assets (`.json`, `.svg`, `.png`, ...) have no markdown twin. Skip
     // twin resolution so a disk miss never falls back to a slow self-fetch.

--- a/src/waku/internal/patches/adapters/vercel-build-enhancer.test.ts
+++ b/src/waku/internal/patches/adapters/vercel-build-enhancer.test.ts
@@ -45,13 +45,14 @@ describe('vercel build enhancer', () => {
     expect(fs.existsSync('.vercel/output/functions/RSC.func/dist/public')).toBe(false)
   })
 
-  it('routes markdown requests to the serverless function before static files', async () => {
+  it('routes clean-URL negotiation before static files and `.md` requests after', async () => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-vercel-'))
     process.chdir(tempDir)
 
     fs.mkdirSync('dist/public/assets', { recursive: true })
     fs.mkdirSync('dist/server', { recursive: true })
     fs.writeFileSync('dist/public/assets/index.js', 'public asset')
+    fs.writeFileSync('dist/public/SKILL.md', 'static markdown')
     fs.writeFileSync('dist/server/index.js', 'server entry')
 
     const build = await buildEnhancer(async () => {})
@@ -69,39 +70,70 @@ describe('vercel build enhancer', () => {
       },
     )
 
+    // `public/*.md` files land in the static output served by the filesystem handler.
+    expect(fs.readFileSync('.vercel/output/static/SKILL.md', 'utf-8')).toBe('static markdown')
+
     const config = JSON.parse(fs.readFileSync('.vercel/output/config.json', 'utf-8'))
 
-    expect(config.routes).toMatchObject([
-      {
-        src: '^/assets/(.*)$',
-      },
-      {
-        src: '^/(?!assets/)(.*\\.md)$',
-        dest: '/RSC/',
-      },
-      {
-        src: '^/(?!assets/)(?!.*\\.[^/]+$)(.*)$',
-        has: [{ type: 'header', key: 'accept', value: '.*text/markdown.*' }],
-        dest: '/RSC/',
-      },
-      {
-        src: '^/(?!assets/)(?!.*\\.[^/]+$)(.*)$',
-        has: [
-          {
-            type: 'header',
-            key: 'user-agent',
-            value: expect.stringContaining('GPTBot'),
+    const userAgentPattern = config.routes
+      .flatMap((route: { has?: { key: string; value: string }[] }) => route.has ?? [])
+      .find((condition: { key: string }) => condition.key === 'user-agent')?.value
+    expect(userAgentPattern).toContain('GPTBot')
+    expect(userAgentPattern).toContain('curl/')
+
+    // Redact the user-agent pattern; the list is asserted above.
+    const routes = config.routes.map((route: { has?: { key: string; value: string }[] }) => {
+      if (!route.has?.some((condition) => condition.key === 'user-agent')) return route
+      return {
+        ...route,
+        has: route.has.map((condition) =>
+          condition.key === 'user-agent' ? { ...condition, value: '<user-agents>' } : condition,
+        ),
+      }
+    })
+
+    expect(routes).toMatchInlineSnapshot(`
+      [
+        {
+          "headers": {
+            "cache-control": "public, immutable, max-age=31536000",
           },
-        ],
-        dest: '/RSC/',
-      },
-      {
-        handle: 'filesystem',
-      },
-      {
-        src: '/(.*)',
-        dest: '/RSC/',
-      },
-    ])
+          "src": "^/assets/(.*)$",
+        },
+        {
+          "dest": "/RSC/",
+          "has": [
+            {
+              "key": "accept",
+              "type": "header",
+              "value": ".*text/markdown.*",
+            },
+          ],
+          "src": "^/(?!assets/)(?!.*\\.[^/]+$)(.*)$",
+        },
+        {
+          "dest": "/RSC/",
+          "has": [
+            {
+              "key": "user-agent",
+              "type": "header",
+              "value": "<user-agents>",
+            },
+          ],
+          "src": "^/(?!assets/)(?!.*\\.[^/]+$)(.*)$",
+        },
+        {
+          "handle": "filesystem",
+        },
+        {
+          "dest": "/RSC/",
+          "src": "^/(?!assets/)(.*\\.md)$",
+        },
+        {
+          "dest": "/RSC/",
+          "src": "/(.*)",
+        },
+      ]
+    `)
   })
 })

--- a/src/waku/internal/patches/adapters/vercel-build-enhancer.ts
+++ b/src/waku/internal/patches/adapters/vercel-build-enhancer.ts
@@ -28,25 +28,32 @@ function markdownRoutes({
     .map(escapeRegExp)
     .join('|')}).*`
 
-  // Vercel's filesystem handler would serve prerendered HTML before mdRouter sees
-  // the request. Route markdown-eligible clean URLs to RSC first so mdRouter can
-  // choose markdown or HTML.
-  return [
-    {
-      src: markdownSource,
-      dest: destination,
-    },
-    {
-      src: cleanPageSource,
-      has: [{ type: 'header', key: 'accept', value: '.*text/markdown.*' }],
-      dest: destination,
-    },
-    {
-      src: cleanPageSource,
-      has: [{ type: 'header', key: 'user-agent', value: markdownUserAgentPattern }],
-      dest: destination,
-    },
-  ]
+  return {
+    // Vercel's filesystem handler would serve prerendered HTML before mdRouter sees
+    // the request. Route markdown-eligible clean URLs to RSC first so mdRouter can
+    // choose markdown or HTML.
+    beforeFilesystem: [
+      {
+        src: cleanPageSource,
+        has: [{ type: 'header', key: 'accept', value: '.*text/markdown.*' }],
+        dest: destination,
+      },
+      {
+        src: cleanPageSource,
+        has: [{ type: 'header', key: 'user-agent', value: markdownUserAgentPattern }],
+        dest: destination,
+      },
+    ],
+    // `.md` URLs reach RSC only after the filesystem handler misses, so `public/*.md`
+    // files are served as-is. Markdown twins live at `/assets/md/`, never in the
+    // static output root, so they still fall through to twin resolution.
+    afterFilesystem: [
+      {
+        src: markdownSource,
+        dest: destination,
+      },
+    ],
+  }
 }
 
 async function postBuild({
@@ -110,6 +117,7 @@ export default getRequestListener(
     )
   }
 
+  const markdown = markdownRoutes({ assetsDir, basePath, rscBase })
   const routes = [
     {
       src: `^${basePath}${assetsDir}/(.*)$`,
@@ -119,8 +127,9 @@ export default getRequestListener(
     },
     ...(serverless
       ? [
-          ...markdownRoutes({ assetsDir, basePath, rscBase }),
+          ...markdown.beforeFilesystem,
           { handle: 'filesystem' },
+          ...markdown.afterFilesystem,
           {
             src: basePath + '(.*)',
             dest: basePath + rscBase + '/',


### PR DESCRIPTION
Fixes https://github.com/wevm/vocs/issues/549. Static `.md` files dropped in `public/` (e.g. `SKILL.md`) were shadowed by markdown-twin routing: a hard 404 on Vercel, and a slow twin-resolution self-fetch on the node server.

On Vercel, the explicit `.md`-suffix route now runs after `{ handle: 'filesystem' }`. Files present in the static output are served as-is, while page twins (stored at `/assets/md/<path>.md`) are absent from it and still fall through to twin resolution.

The extensionless clean-URL negotiation routes stay before `filesystem`; prerendered HTML would otherwise win over `Accept`/`User-Agent` markdown negotiation.

The `md-router` middleware now checks for an exact `public/` file match before twin resolution, extending the `hasPublicFile()` approach from https://github.com/wevm/vocs/issues/518 to `.md` requests. This keeps dev and the node server consistent with Vercel routing.
