### PR TITLE
fix(search): bake ai search index into the server bundle

### DIFF
--- a/site/src/pages/features/search.mdx
+++ b/site/src/pages/features/search.mdx
@@ -185,10 +185,9 @@ The manifest is written to `.vocs`'s cache. `vocs dev` loads that prebuilt index
 
 #### Deploy
 
-The server endpoint (`/api/search` by default) embeds each query and searches the packed vector store. Two things must be available to the server at runtime:
+The server endpoint (`/api/search` by default) embeds each query and searches the packed vector store. `vocs build` bakes the prebuilt index into the server bundle, so serverless deploys work out of the box.
 
-- The embedding provider's credentials (here `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN`), since each query is embedded on the fly.
-- The `.vocs` cache directory, which holds the prebuilt index from `vocs build` / `vocs embeddings generate`. Without it, the first request per server instance rebuilds the index in-process (refetching external sources and re-embedding uncached chunks) while the dialog falls back to keyword results.
+Make the embedding provider's credentials (here `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN`) available to the server at runtime, since each query is embedded on the fly. Keeping the `.vocs` cache between builds avoids re-embedding unchanged chunks.
 
 :::warning
 `/api/search` is public, and each request spends an embedding (plus optional rerank) call on your provider account. If abuse is a concern, rate limit the endpoint at your edge or CDN.

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -32,6 +32,10 @@ declare module 'virtual:vocs/ai-search-index' {
   export function getAiSearchIndex(): Promise<string>
 }
 
+declare module 'virtual:vocs/ai-search-manifest' {
+  export function getAiSearchManifest(): Promise<string | undefined>
+}
+
 declare module 'virtual:vocs/group-icons.css' {}
 
 declare module 'virtual:vocs/group-icons.css?inline' {

--- a/src/internal/embedding-cache.test.ts
+++ b/src/internal/embedding-cache.test.ts
@@ -51,6 +51,14 @@ describe('load', () => {
     expect(fs.readdirSync(dir)).toEqual([])
   })
 
+  it('skips persisting on unwritable filesystems instead of throwing', () => {
+    const filePath = path.join(dir, 'not-a-dir')
+    fs.writeFileSync(filePath, 'x')
+    const cache = EmbeddingCache.load({ dir: path.join(filePath, 'nested') })
+    cache.set('a', [1])
+    expect(() => cache.save()).not.toThrow()
+  })
+
   it('recovers from a corrupt cache file', () => {
     const cache = EmbeddingCache.load({ dir })
     cache.set('a', [1])

--- a/src/internal/embedding-cache.ts
+++ b/src/internal/embedding-cache.ts
@@ -63,15 +63,19 @@ export function load(options: load.Options): Cache {
     },
     save() {
       if (ignore) return
-      fs.mkdirSync(dir, { recursive: true })
-      const entries: Record<string, number[]> = {}
-      for (const key of touched) {
-        const vector = store.get(key)
-        if (vector) entries[key] = vector
+      try {
+        fs.mkdirSync(dir, { recursive: true })
+        const entries: Record<string, number[]> = {}
+        for (const key of touched) {
+          const vector = store.get(key)
+          if (vector) entries[key] = vector
+        }
+        const tmp = `${file}.${process.pid}.tmp`
+        fs.writeFileSync(tmp, JSON.stringify({ version, entries }), 'utf-8')
+        fs.renameSync(tmp, file)
+      } catch {
+        // Read-only filesystem (e.g. serverless) — skip persisting.
       }
-      const tmp = `${file}.${process.pid}.tmp`
-      fs.writeFileSync(tmp, JSON.stringify({ version, entries }), 'utf-8')
-      fs.renameSync(tmp, file)
     },
   }
 }

--- a/src/internal/retriever.test.ts
+++ b/src/internal/retriever.test.ts
@@ -683,6 +683,70 @@ describe('end-to-end (mock embedder)', () => {
     expect(purposes).toEqual(['query'])
   })
 
+  it('serves the bundled manifest (loadManifest) without rebuilding', async () => {
+    const purposes: string[] = []
+    const inner = Embedding.mock({ dimensions: 64 })
+    const embedding = Embedding.from({
+      type: 'mock',
+      model: 'mock',
+      dimensions: 64,
+      async embed(input, context) {
+        purposes.push(context.purpose)
+        return inner.embed(input, context)
+      },
+    })
+    const config = Config.define({
+      rootDir: dir,
+      ai: { retriever: Retriever.local({ embedding, cache: false }) },
+    })
+    const manifest = await Retriever.buildIndex(config)
+    Retriever._resetServerIndexCache()
+    purposes.length = 0
+
+    const makeRequest = () =>
+      new Request('http://localhost/api/search', {
+        method: 'POST',
+        body: JSON.stringify({ query: 'embeddings cache build time' }),
+      })
+    const options = { loadManifest: async () => manifest }
+
+    const first = await Retriever.handleSearchRequest(makeRequest(), config, options)
+    expect(first.status).toBe(202)
+    await Retriever.getServerIndex(config)
+
+    const second = await Retriever.handleSearchRequest(makeRequest(), config, options)
+    expect(second.status).toBe(200)
+    const json = (await second.json()) as { results: Retriever.Result[] }
+    expect(json.results.length).toBeGreaterThan(0)
+    // Only the query was embedded — the index came from the bundled manifest.
+    expect(purposes).toEqual(['query'])
+  })
+
+  it('ignores a stale bundled manifest and rebuilds', async () => {
+    const purposes: string[] = []
+    const inner = Embedding.mock({ dimensions: 64 })
+    const embedding = Embedding.from({
+      type: 'mock',
+      model: 'mock',
+      dimensions: 64,
+      async embed(input, context) {
+        purposes.push(context.purpose)
+        return inner.embed(input, context)
+      },
+    })
+    const config = Config.define({
+      rootDir: dir,
+      ai: { retriever: Retriever.local({ embedding, cache: false }) },
+    })
+    const manifest = await Retriever.buildIndex(config)
+    const stale = { ...manifest, embedding: { ...manifest.embedding, model: 'other' } }
+    Retriever._resetServerIndexCache()
+    purposes.length = 0
+
+    await Retriever.getServerIndex(config, { loadManifest: async () => stale })
+    expect(purposes).toContain('document')
+  })
+
   it('answers 503 (not 202) after a failed index build, without instant rebuilds', async () => {
     let attempts = 0
     const embedding = Embedding.from({

--- a/src/internal/retriever.ts
+++ b/src/internal/retriever.ts
@@ -440,6 +440,14 @@ export function fromConfig(config: Config.Config): PublicConfig | undefined {
 }
 
 /**
+ * Loads a prebuilt {@link IndexManifest} from outside the module — e.g. the
+ * manifest baked into the server bundle at build time (see the
+ * `virtual:vocs/ai-search-manifest` module). Returning `undefined` falls back
+ * to the on-disk manifest, then to an in-process build.
+ */
+export type ManifestLoader = () => Promise<IndexManifest | undefined>
+
+/**
  * Handles `POST /api/search`. Framework-agnostic (Web Request/Response).
  *
  * Dispatches to whichever provider is configured — the self-owned local vector
@@ -449,10 +457,18 @@ export function fromConfig(config: Config.Config): PublicConfig | undefined {
 export async function handleSearchRequest(
   request: Request,
   config: Config.Config,
+  options: handleSearchRequest.Options = {},
 ): Promise<Response> {
-  if (config._localRetriever) return handleLocalSearchRequest(request, config)
+  if (config._localRetriever) return handleLocalSearchRequest(request, config, options)
   if (config._retriever) return handleManagedSearchRequest(request, config)
   return json({ error: 'AI search not enabled' }, 404)
+}
+
+export declare namespace handleSearchRequest {
+  type Options = {
+    /** Source of the prebuilt manifest (e.g. baked into the server bundle). */
+    loadManifest?: ManifestLoader | undefined
+  }
 }
 
 //
@@ -1091,6 +1107,16 @@ export async function loadIndex(config: Config.Config): Promise<IndexManifest | 
   }
 }
 
+/** Whether a manifest no longer matches the configured embedding. */
+function isStale(manifest: IndexManifest, priv: LocalPrivateConfig): boolean {
+  return (
+    manifest.embedding.type !== priv.embedding.type ||
+    manifest.embedding.model !== priv.embedding.model ||
+    (priv.embedding.dimensions !== undefined &&
+      manifest.embedding.dimensions !== priv.embedding.dimensions)
+  )
+}
+
 /**
  * Loads the prebuilt manifest and validates it against the current embedding
  * config. Returns the manifest, or the reason it can't be used.
@@ -1101,12 +1127,7 @@ async function loadPrebuiltIndex(
 ): Promise<IndexManifest | 'missing' | 'stale'> {
   const manifest = await loadIndex(config)
   if (!manifest) return 'missing'
-  const stale =
-    manifest.embedding.type !== priv.embedding.type ||
-    manifest.embedding.model !== priv.embedding.model ||
-    (priv.embedding.dimensions !== undefined &&
-      manifest.embedding.dimensions !== priv.embedding.dimensions)
-  if (stale) return 'stale'
+  if (isStale(manifest, priv)) return 'stale'
   return manifest
 }
 
@@ -1205,7 +1226,10 @@ function indexCacheKey(config: Config.Config, priv: LocalPrivateConfig): string 
  * A failed build is kept (as `'error'`) for {@link failedBuildRetryMs} before
  * it may be retried, so client polling can't trigger a rebuild per request.
  */
-export function ensureServerIndex(config: Config.Config): ServerIndexEntry {
+export function ensureServerIndex(
+  config: Config.Config,
+  options: ensureServerIndex.Options = {},
+): ServerIndexEntry {
   const priv = requireLocal(config)
   const cacheKey = indexCacheKey(config, priv)
   let entry = serverIndexCache.get(cacheKey)
@@ -1215,7 +1239,7 @@ export function ensureServerIndex(config: Config.Config): ServerIndexEntry {
   }
   if (!entry) {
     const created: ServerIndexEntry = { status: 'pending', promise: undefined as never }
-    created.promise = resolveServerIndex(config, priv)
+    created.promise = resolveServerIndex(config, priv, options.loadManifest)
       .then((index) => {
         created.status = 'ready'
         return index
@@ -1223,12 +1247,20 @@ export function ensureServerIndex(config: Config.Config): ServerIndexEntry {
       .catch((error) => {
         created.status = 'error'
         created.failedAt = Date.now()
+        console.error('[vocs] AI search index build failed:', error)
         throw error
       })
     entry = created
     serverIndexCache.set(cacheKey, entry)
   }
   return entry
+}
+
+export declare namespace ensureServerIndex {
+  type Options = {
+    /** Source of the prebuilt manifest (e.g. baked into the server bundle). */
+    loadManifest?: ManifestLoader | undefined
+  }
 }
 
 /**
@@ -1248,7 +1280,21 @@ export function ensureServerIndex(config: Config.Config): ServerIndexEntry {
 async function resolveServerIndex(
   config: Config.Config,
   priv: LocalPrivateConfig,
+  loadManifest?: ManifestLoader | undefined,
 ): Promise<ServerIndex> {
+  // Baked-in manifest first (emitted into the server bundle at build time) —
+  // serverless filesystems don't carry the cache directory or source pages, so
+  // this is the only source that works everywhere.
+  if (loadManifest) {
+    try {
+      const manifest = await loadManifest()
+      if (manifest && !isStale(manifest, priv))
+        return { store: VectorStore.load(manifest.vectors), chunks: manifest.chunks }
+    } catch (error) {
+      console.warn('[vocs] failed to load bundled AI search manifest:', error)
+    }
+  }
+
   const prebuilt = await loadPrebuiltIndex(config, priv)
   if (typeof prebuilt !== 'string')
     return { store: VectorStore.load(prebuilt.vectors), chunks: prebuilt.chunks }
@@ -1268,8 +1314,11 @@ async function resolveServerIndex(
 }
 
 /** Lazily builds and memoizes the in-process server index (awaits the build). */
-export async function getServerIndex(config: Config.Config): Promise<ServerIndex> {
-  return ensureServerIndex(config).promise
+export async function getServerIndex(
+  config: Config.Config,
+  options: ensureServerIndex.Options = {},
+): Promise<ServerIndex> {
+  return ensureServerIndex(config, options).promise
 }
 
 /**
@@ -1424,6 +1473,7 @@ type RequestBody = {
 async function handleLocalSearchRequest(
   request: Request,
   config: Config.Config,
+  options: handleSearchRequest.Options = {},
 ): Promise<Response> {
   const publicConfig = fromConfig(config)
   if (!publicConfig || !config._localRetriever) return json({ error: 'AI search not enabled' }, 404)
@@ -1448,7 +1498,7 @@ async function handleLocalSearchRequest(
   // keep showing keyword results (and retry shortly). A failed build answers
   // 503 (instead of 202) so the client stops polling; the entry is retried
   // after a backoff.
-  const index = ensureServerIndex(config)
+  const index = ensureServerIndex(config, options)
   index.promise.catch(() => {}) // avoid unhandled rejection on the background build
   if (index.status === 'error') return json({ error: 'Search failed' }, 503)
   if (index.status === 'pending')

--- a/src/internal/vite-plugins.ts
+++ b/src/internal/vite-plugins.ts
@@ -771,13 +771,19 @@ export function search(config: Config.Config): PluginOption {
  */
 export function aiSearch(config: Config.Config): PluginOption {
   const ai = Retriever.fromConfig(config)
-  if (!ai) return []
 
   const virtualModuleId = 'virtual:vocs/ai-search-index'
   const resolvedVirtualModuleId = `\0${virtualModuleId}`
+  // Server-side manifest, baked into the server bundle at build time so
+  // serverless deploys (no cache dir, no source pages) can serve AI search.
+  const serverManifestId = 'virtual:vocs/ai-search-manifest'
+  const resolvedServerManifestId = `\0${serverManifestId}`
+  const emptyManifestModule = 'export const getAiSearchManifest = async () => undefined'
+
   const { rootDir, basePath } = config
+  const localEnabled = Boolean(config._localRetriever)
   const exposePublic =
-    ai.runtime === 'client' || config._localRetriever?.vectorStore.expose === true
+    ai?.runtime === 'client' || config._localRetriever?.vectorStore.expose === true
 
   let mode: 'development' | 'production' = 'development'
   let manifestPromise: Promise<Retriever.IndexManifest> | undefined
@@ -847,6 +853,7 @@ export function aiSearch(config: Config.Config): PluginOption {
       // loads the prebuilt manifest written by `vocs embeddings generate` /
       // `vocs build` (falling back to keyword search if absent), and
       // client-runtime search builds it lazily when the virtual module loads.
+      if (!localEnabled) return
       if (mode !== 'production') return
       if (skipSeeding()) {
         logger.info('Skipping AI search index build (VOCS_SKIP_EMBEDDINGS).', { timestamp: true })
@@ -856,9 +863,18 @@ export function aiSearch(config: Config.Config): PluginOption {
     },
     resolveId(id) {
       if (id === virtualModuleId) return resolvedVirtualModuleId
+      if (id === serverManifestId) return resolvedServerManifestId
       return
     },
     async load(id) {
+      if (id === resolvedServerManifestId) {
+        // Dev never builds; the server loads the manifest written by
+        // `vocs embeddings generate` from disk instead.
+        if (!localEnabled || mode === 'development' || skipSeeding()) return emptyManifestModule
+        const manifest = await buildManifest()
+        return `export const getAiSearchManifest = async () => ${JSON.stringify(JSON.stringify(manifest))}`
+      }
+
       if (id !== resolvedVirtualModuleId) return
       if (!exposePublic)
         return `export const getAiSearchIndex = async () => { throw new Error('[vocs] AI search client index is not exposed (server runtime).') }`

--- a/src/waku/internal/routes/_api/api/search.tsx
+++ b/src/waku/internal/routes/_api/api/search.tsx
@@ -11,5 +11,13 @@ import * as Retriever from '../../../../../internal/retriever.js'
  */
 export async function POST(request: Request) {
   const config = await Config.resolve({ server: true })
-  return Retriever.handleSearchRequest(request, config)
+  return Retriever.handleSearchRequest(request, config, {
+    // Prebuilt manifest baked into the server bundle at build time. Falls back
+    // to the on-disk manifest (dev), then to an in-process build.
+    async loadManifest() {
+      const { getAiSearchManifest } = await import('virtual:vocs/ai-search-manifest')
+      const json = await getAiSearchManifest()
+      return json ? (JSON.parse(json) as Retriever.IndexManifest) : undefined
+    },
+  })
 }


### PR DESCRIPTION
Serverless deploys of AI search answered 503: the function bundle carries neither the `.vocs` prebuilt index nor the source pages, so the request-time rebuild could never succeed, background work after the `202` was suspended by the platform, and the failure was swallowed before the endpoint reported it.

`vocs build` now bakes the index manifest into the server bundle as a lazy `virtual:vocs/ai-search-manifest` chunk, and `/api/search` loads it first. The on-disk manifest (dev) and in-process rebuild remain as fallbacks. Index build failures are now logged, and the embedding cache skips persisting on read-only filesystems instead of throwing.

Verified against a production build served with `.vocs` and `site/src` removed, which previously reproduced the 503 and now returns results.

Follow-up to https://github.com/wevm/vocs/pull/538.
