### PR TITLE
feat(mcp): use ai search in `search_docs`

### DIFF
--- a/src/internal/mcp.test.ts
+++ b/src/internal/mcp.test.ts
@@ -1,0 +1,92 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import * as Config from './config.js'
+import * as Embedding from './embedding.js'
+import * as Mcp from './mcp.js'
+import * as Retriever from './retriever.js'
+
+let dir: string
+
+beforeEach(() => {
+  Retriever._resetServerIndexCache()
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-mcp-'))
+  const pages = path.join(dir, 'src', 'pages')
+  fs.mkdirSync(pages, { recursive: true })
+  fs.writeFileSync(
+    path.join(pages, 'index.mdx'),
+    '# Getting Started\n\nVocs is a documentation framework powered by Vite.\n',
+  )
+  fs.writeFileSync(
+    path.join(pages, 'deploy.mdx'),
+    '# Deployment\n\nPublish your documentation site to production hosting.\n',
+  )
+})
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+async function connect(server: ReturnType<typeof Mcp.createServer>) {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  const client = new Client({ name: 'test', version: '1.0.0' })
+  await server.connect(serverTransport)
+  await client.connect(clientTransport)
+  return client
+}
+
+function resultText(result: Awaited<ReturnType<Client['callTool']>>): string {
+  const content = result.content as { type: string; text?: string }[]
+  return content[0]?.text ?? ''
+}
+
+describe('search_docs', () => {
+  it('uses the AI retriever when configured', async () => {
+    const config = Config.define({
+      rootDir: dir,
+      ai: {
+        retriever: Retriever.local({
+          embedding: Embedding.mock({ dimensions: 64 }),
+          cache: false,
+        }),
+      },
+    })
+    const manifest = await Retriever.buildIndex(config)
+    Retriever._resetServerIndexCache()
+
+    const server = Mcp.createServer(config, { loadManifest: async () => manifest })
+    const client = await connect(server)
+    const result = await client.callTool({
+      name: 'search_docs',
+      arguments: { query: 'publish documentation production' },
+    })
+
+    const results = JSON.parse(resultText(result)) as {
+      path: string
+      title: string
+      score: number
+    }[]
+    expect(results.length).toBeGreaterThan(0)
+    expect(results[0]).toHaveProperty('title')
+    expect(results[0]).toHaveProperty('score')
+    expect(results.some((r) => r.path.includes('/deploy'))).toBe(true)
+  })
+
+  it('falls back to a substring scan without a retriever', async () => {
+    const config = Config.define({ rootDir: dir })
+
+    const server = Mcp.createServer(config)
+    const client = await connect(server)
+    const result = await client.callTool({
+      name: 'search_docs',
+      arguments: { query: 'production hosting' },
+    })
+
+    const results = JSON.parse(resultText(result)) as { path: string; snippet: string }[]
+    expect(results).toHaveLength(1)
+    expect(results[0]?.path).toBe('/deploy')
+    expect(results[0]?.snippet).toContain('production hosting')
+  })
+})

--- a/src/internal/mcp.ts
+++ b/src/internal/mcp.ts
@@ -4,6 +4,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import type { Config } from './config.js'
 import type * as McpSource from './mcp-source.js'
+import * as Retriever from './retriever.js'
 
 /**
  * MCP (Model Context Protocol) server configuration and tools.
@@ -41,7 +42,7 @@ export type McpConfig = {
 /**
  * Create an MCP server instance with all documentation tools registered.
  */
-export function createServer(config: Config): McpServer {
+export function createServer(config: Config, options: createServer.Options = {}): McpServer {
   const server = new McpServer(
     {
       name: 'vocs',
@@ -109,12 +110,34 @@ export function createServer(config: Config): McpServer {
   server.registerTool(
     'search_docs',
     {
-      description: 'Search documentation for a query string.',
+      description:
+        'Search documentation for a query string. Uses AI (semantic) search when configured, with keyword fallback.',
       inputSchema: {
         query: z.string().describe('The search query'),
       },
     },
     async ({ query }) => {
+      // AI (semantic) search when a retriever is configured. Falls back to the
+      // substring scan below when disabled, empty, or failing.
+      const semantic = await Retriever.retrieve(config, {
+        query,
+        loadManifest: options.loadManifest,
+      }).catch((error) => {
+        console.warn('[vocs] mcp search_docs: AI search failed, falling back:', error)
+        return [] as Retriever.Result[]
+      })
+      if (semantic.length > 0) {
+        const results = semantic.map((result) => ({
+          path: result.href,
+          title: result.title,
+          snippet: result.snippet,
+          score: result.score,
+        }))
+        return {
+          content: [{ type: 'text', text: JSON.stringify(results, null, 2) }],
+        }
+      }
+
       const lowerQuery = query.toLowerCase()
       const pages = await Array.fromAsync(fs.glob(`${pagesDir}/**/*.{md,mdx}`))
 
@@ -309,4 +332,11 @@ export function createServer(config: Config): McpServer {
   }
 
   return server
+}
+
+export declare namespace createServer {
+  type Options = {
+    /** Source of the prebuilt AI search manifest (e.g. baked into the server bundle). */
+    loadManifest?: Retriever.ManifestLoader | undefined
+  }
 }

--- a/src/internal/retriever.test.ts
+++ b/src/internal/retriever.test.ts
@@ -160,6 +160,34 @@ describe('retrieveManaged', () => {
   })
 })
 
+describe('retrieve', () => {
+  it('returns [] when no retriever is configured', async () => {
+    const config = { ai: undefined } as unknown as Config.Config
+    expect(await Retriever.retrieve(config, { query: 'x' })).toEqual([])
+  })
+
+  it('dispatches to the managed adapter', async () => {
+    const managed: Retriever.Adapter = {
+      type: 'x',
+      retrieve: async () => [
+        {
+          category: '',
+          href: '/a',
+          id: '1',
+          score: 0.9,
+          snippet: 'a',
+          title: 'A',
+          titles: [],
+          type: 'page',
+        },
+      ],
+    }
+    const config = toConfig(Retriever.resolveManaged(Retriever.from(managed), ctx))
+    const results = await Retriever.retrieve(config, { query: 'anything' })
+    expect(results.map((r) => r.href)).toEqual(['/a'])
+  })
+})
+
 describe('handleSearchRequest (managed)', () => {
   it('400s on missing query, 404s when disabled', async () => {
     const config = toConfig(Retriever.resolveManaged(Retriever.from(adapter), ctx))

--- a/src/internal/retriever.ts
+++ b/src/internal/retriever.ts
@@ -471,6 +471,38 @@ export declare namespace handleSearchRequest {
   }
 }
 
+/**
+ * Retrieves AI search results for a query with whichever provider is
+ * configured, awaiting the index when needed (unlike the `/api/search`
+ * endpoint, which answers `202` while it loads). Returns `[]` when AI search
+ * is not enabled or the index is empty.
+ */
+export async function retrieve(
+  config: Config.Config,
+  options: retrieve.Options,
+): Promise<Result[]> {
+  const { limit, loadManifest, query, signal } = options
+  if (config._localRetriever) {
+    await getServerIndex(config, { loadManifest })
+    return retrieveLocal(config, { limit, query })
+  }
+  if (config._retriever) return retrieveManaged(config, { limit, query, signal })
+  return []
+}
+
+export declare namespace retrieve {
+  type Options = {
+    /** Max results to return. @default topK */
+    limit?: number | undefined
+    /** Source of the prebuilt manifest (e.g. baked into the server bundle). */
+    loadManifest?: ManifestLoader | undefined
+    /** Search query. */
+    query: string
+    /** Optional abort signal (managed retrievers only). */
+    signal?: AbortSignal | undefined
+  }
+}
+
 //
 // Managed retriever (delegated to a backend adapter)
 //

--- a/src/waku/internal/ai-search.ts
+++ b/src/waku/internal/ai-search.ts
@@ -1,0 +1,12 @@
+import type * as Retriever from '../../internal/retriever.js'
+
+/**
+ * Loads the AI search manifest baked into the server bundle at build time (see
+ * the `vocs:ai-search` Vite plugin). Resolves to `undefined` in dev or when AI
+ * search is disabled, so callers fall back to the on-disk manifest.
+ */
+export async function loadAiSearchManifest(): Promise<Retriever.IndexManifest | undefined> {
+  const { getAiSearchManifest } = await import('virtual:vocs/ai-search-manifest')
+  const json = await getAiSearchManifest()
+  return json ? (JSON.parse(json) as Retriever.IndexManifest) : undefined
+}

--- a/src/waku/internal/routes/_api/api/mcp.tsx
+++ b/src/waku/internal/routes/_api/api/mcp.tsx
@@ -5,6 +5,7 @@ import {
   WebSSEServerTransport,
   WebStreamableHTTPServerTransport,
 } from '../../../../../internal/mcp-transport.js'
+import { loadAiSearchManifest } from '../../../ai-search.js'
 
 /**
  * GET /api/mcp - Establish SSE stream (deprecated HTTP+SSE transport)
@@ -20,7 +21,7 @@ export async function GET() {
   }
 
   const transport = new WebSSEServerTransport('/api/mcp/messages')
-  const server = Mcp.createServer(config)
+  const server = Mcp.createServer(config, { loadManifest: loadAiSearchManifest })
 
   McpSessions.setSession(transport.sessionId, { transport, server })
 
@@ -88,7 +89,7 @@ export async function POST(request: Request) {
     },
   })
 
-  const server = Mcp.createServer(config)
+  const server = Mcp.createServer(config, { loadManifest: loadAiSearchManifest })
   await server.connect(transport as never)
 
   return transport.handleRequest(body, useSSE)

--- a/src/waku/internal/routes/_api/api/search.tsx
+++ b/src/waku/internal/routes/_api/api/search.tsx
@@ -1,5 +1,6 @@
 import * as Config from '../../../../../internal/config.js'
 import * as Retriever from '../../../../../internal/retriever.js'
+import { loadAiSearchManifest } from '../../../ai-search.js'
 
 /**
  * POST /api/search - AI search.
@@ -11,13 +12,5 @@ import * as Retriever from '../../../../../internal/retriever.js'
  */
 export async function POST(request: Request) {
   const config = await Config.resolve({ server: true })
-  return Retriever.handleSearchRequest(request, config, {
-    // Prebuilt manifest baked into the server bundle at build time. Falls back
-    // to the on-disk manifest (dev), then to an in-process build.
-    async loadManifest() {
-      const { getAiSearchManifest } = await import('virtual:vocs/ai-search-manifest')
-      const json = await getAiSearchManifest()
-      return json ? (JSON.parse(json) as Retriever.IndexManifest) : undefined
-    },
-  })
+  return Retriever.handleSearchRequest(request, config, { loadManifest: loadAiSearchManifest })
 }


### PR DESCRIPTION
The MCP server's `search_docs` tool scanned page sources for an exact substring, independent of both keyword and AI search. It now retrieves through the configured `ai.retriever` first, returning ranked semantic results with titles and scores, and keeps the substring scan as the fallback when AI search is disabled, the index is empty, or retrieval fails.

Adds `Retriever.retrieve`, a programmatic dispatcher that awaits the index and routes to the configured provider. Both MCP transports and the `/api/search` route share a `loadAiSearchManifest` helper for the manifest baked into the server bundle, so MCP search also works on serverless deploys.

Follow-up to https://github.com/wevm/vocs/pull/553.
