### PR TITLE
feat(search): enable hybrid fusion by default

### DIFF
--- a/.changeset/hybrid-default.md
+++ b/.changeset/hybrid-default.md
@@ -1,0 +1,5 @@
+---
+"vocs": minor
+---
+
+Defaulted AI search `hybrid` fusion on; pass `hybrid: false` to append semantic results below keyword results instead.

--- a/.changeset/hybrid-default.md
+++ b/.changeset/hybrid-default.md
@@ -1,5 +1,5 @@
 ---
-"vocs": minor
+"vocs": patch
 ---
 
 Defaulted AI search `hybrid` fusion on; pass `hybrid: false` to append semantic results below keyword results instead.

--- a/site/src/pages/features/search.mdx
+++ b/site/src/pages/features/search.mdx
@@ -344,7 +344,7 @@ A common setup is to build embeddings on a schedule (cron/CI) and skip them on r
 
 ### Blend keyword and AI results
 
-By default the dialog shows keyword results and appends AI results. Turn on `hybrid` (a shared option on every retriever constructor) to instead **fuse** both lists into a single ranking, weighting each contribution:
+The dialog **fuses** keyword and AI results into a single ranking by default, weighting each contribution. Tune the weights with `hybrid` (a shared option on every retriever constructor):
 
 ```ts twoslash
 import { defineConfig, Embedding, Retriever } from 'vocs/config'
@@ -362,7 +362,7 @@ export default defineConfig({
 })
 ```
 
-Pass `hybrid: true` for defaults, or an object to tune the weights.
+Pass `hybrid: false` to keep the keyword ordering untouched and append AI results below it instead.
 
 ## See More
 

--- a/src/internal/retriever.test.ts
+++ b/src/internal/retriever.test.ts
@@ -84,11 +84,11 @@ describe('resolveManaged', () => {
     expect(resolved?.public.endpoint).toBe('/api/search')
   })
 
-  it('derives endpoint from basePath and defaults hybrid off', () => {
+  it('derives endpoint from basePath and defaults hybrid on', () => {
     const resolved = Retriever.resolveManaged(Retriever.from(adapter), { basePath: '/docs/' })
     expect(resolved?.public.endpoint).toBe('/docs/api/search')
     expect(resolved?.public.hybrid).toEqual({
-      enabled: false,
+      enabled: true,
       keywordWeight: 0.3,
       semanticWeight: 0.7,
     })
@@ -356,6 +356,14 @@ describe('resolveLocal (config split)', () => {
     expect(resolved?.public.enabled).toBe(true)
     expect(resolved?.public.runtime).toBe('server')
     expect(resolved?.public.endpoint).toBe('/api/search')
+    // Hybrid fusion is on by default; `hybrid: false` opts into append mode.
+    expect(resolved?.public.hybrid.enabled).toBe(true)
+    expect(
+      Retriever.resolveLocal(
+        { embedding: Embedding.mock(), retrieval: { hybrid: false } },
+        { basePath: '/' },
+      )?.public.hybrid.enabled,
+    ).toBe(false)
     // adapters live only in the private half
     expect(resolved?.private.embedding.type).toBe('mock')
     expect(resolved?.public).not.toHaveProperty('embedding')

--- a/src/internal/retriever.ts
+++ b/src/internal/retriever.ts
@@ -78,7 +78,8 @@ export type BaseRetriever = {
   endpoint?: string | undefined
   /**
    * Fuse semantic results with keyword (MiniSearch) results into a single
-   * ranking. Pass an object to tune each contribution. @default false
+   * ranking. Pass an object to tune each contribution, or `false` to append
+   * semantic results below the keyword list instead. @default true
    */
   hybrid?:
     | boolean
@@ -543,7 +544,7 @@ export function resolveManaged(
     enabled: true,
     endpoint,
     hybrid: {
-      enabled: Boolean(hybrid),
+      enabled: hybrid !== false,
       keywordWeight: hybridObj.keywordWeight ?? 0.3,
       semanticWeight: hybridObj.semanticWeight ?? 0.7,
     },
@@ -653,7 +654,7 @@ export type ChunkingOptions = {
 export type RetrievalOptions = {
   /** Candidates scored before dedupe/rerank. @default 40 */
   candidateK?: number | undefined
-  /** Fuse with keyword search. @default false */
+  /** Fuse with keyword search. @default true */
   hybrid?: boolean | undefined
   /** Keyword weight for hybrid fusion. @default 0.3 */
   keywordWeight?: number | undefined
@@ -794,7 +795,7 @@ export function resolveLocal(
     runtime,
     endpoint,
     hybrid: {
-      enabled: options.retrieval?.hybrid ?? false,
+      enabled: options.retrieval?.hybrid ?? true,
       semanticWeight: options.retrieval?.semanticWeight ?? 0.7,
       keywordWeight: options.retrieval?.keywordWeight ?? 0.3,
     },
@@ -826,7 +827,7 @@ export function resolveLocal(
     retrieval: {
       topK: options.retrieval?.topK ?? 8,
       candidateK: options.retrieval?.candidateK ?? 40,
-      hybrid: options.retrieval?.hybrid ?? false,
+      hybrid: options.retrieval?.hybrid ?? true,
       semanticWeight: options.retrieval?.semanticWeight ?? 0.7,
       keywordWeight: options.retrieval?.keywordWeight ?? 0.3,
     },

--- a/src/react/internal/Search.tsx
+++ b/src/react/internal/Search.tsx
@@ -116,9 +116,9 @@ export function Search(props: Search.Props) {
   // store or a managed retriever — and both serialize to the same public shape
   // and request/response contract, so the dialog treats them uniformly. We fetch
   // semantic results in the background and blend them with the instant MiniSearch
-  // keyword results (appended below by default, fused into one ranking with
-  // `hybrid`). Keyword results render immediately; the list updates once
-  // semantic results return, so the UI never blocks on the network.
+  // keyword results (fused into one ranking by default; `hybrid: false` appends
+  // them below instead). Keyword results render immediately; the list updates
+  // once semantic results return, so the UI never blocks on the network.
   const aiConfig = (config as { ai?: { retriever?: SemanticConfig } }).ai?.retriever
   const semanticConfig = React.useMemo<SemanticConfig | undefined>(() => {
     // The self-owned provider only queries the server endpoint in server runtime.
@@ -190,8 +190,8 @@ export function Search(props: Search.Props) {
     // in flight, show fresh keyword results rather than stale AI ones.
     const semanticFresh = semanticEnabled && semanticResultsQuery === query ? semanticResults : []
     if (semanticFresh.length === 0) return search.results
-    // Default: keyword ordering stays put, AI results are appended below.
-    // `hybrid` opts into fusing both lists into a single ranking.
+    // `hybrid: false` opts into append mode: keyword ordering stays put and AI
+    // results follow below. Fusion is the default.
     if (!semanticConfig?.hybrid?.enabled) return append(search.results, semanticFresh, 20)
     return fuse({
       keyword: search.results,


### PR DESCRIPTION
The dialog's default blend appended AI results below the keyword list, capped at 20 total. Keyword configs with `combineWith: 'OR'` or fuzzy matching fill every slot on natural-language queries, so the appended semantic results were sliced off entirely: fetched and paid for, never shown.

Hybrid RRF fusion is now the default, interleaving both lists by rank so high-scoring semantic hits surface. `hybrid: false` opts back into append mode.
