### PR TITLE
feat: render ::changelog in the markdown pipeline

### DIFF
--- a/.changeset/changelog-markdown-twin.md
+++ b/.changeset/changelog-markdown-twin.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Rendered `::changelog` releases in markdown output (`llms.txt`, `.md` twins) instead of a literal `::changelog` line.

--- a/src/internal/changelog.test.ts
+++ b/src/internal/changelog.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest'
+import { stripDuplicateTitle } from './changelog.js'
+
+describe('stripDuplicateTitle', () => {
+  test('strips a leading H1 that duplicates the title', () => {
+    expect(stripDuplicateTitle({ body: '# v1.0.0\n\nBody text.', title: 'v1.0.0' })).toBe(
+      'Body text.',
+    )
+  })
+
+  test('keeps a leading H1 that differs from the title', () => {
+    const body = '# Breaking Changes\n\nBody text.'
+    expect(stripDuplicateTitle({ body, title: 'v1.0.0' })).toBe(body)
+  })
+
+  test('matches loosely across case, whitespace and unicode dashes', () => {
+    expect(
+      stripDuplicateTitle({
+        body: '# Release v1.6.0 — T3  Update\n\nBody.',
+        title: 'release v1.6.0 - t3 update',
+      }),
+    ).toBe('Body.')
+  })
+
+  test('returns the body unchanged when body or title is empty', () => {
+    expect(stripDuplicateTitle({ body: '', title: 'v1.0.0' })).toBe('')
+    expect(stripDuplicateTitle({ body: '# v1.0.0\n\nBody.', title: '' })).toBe('# v1.0.0\n\nBody.')
+  })
+})

--- a/src/internal/changelog.ts
+++ b/src/internal/changelog.ts
@@ -49,6 +49,47 @@ export function from(adapter: Adapter): Adapter {
 }
 
 /**
+ * Strips a leading H1 from the release body when it duplicates the release title.
+ *
+ * GitHub renders the release name as the heading on the release page, so
+ * authors often write a body that *also* begins with `# <title>`. When such a
+ * release is shown in our changelog UI we already render the title above the
+ * body, which produces a visible duplicate (see e.g. release authors writing
+ * `# Release v1.6.0 — T3 …` while the GitHub release name is
+ * `Release v1.6.0 - T3 …`). We compare the leading H1 text against the title
+ * with loose normalization (lowercase, whitespace collapsing, all unicode
+ * dashes treated as the same character) and strip it on match.
+ */
+export function stripDuplicateTitle(
+  options: stripDuplicateTitle.Options,
+): stripDuplicateTitle.ReturnType {
+  const { body, title } = options
+  if (!body || !title) return body
+  const match = body.match(/^\s*#\s+(.+?)\s*(?:\r?\n|$)/)
+  if (!match) return body
+  if (normalizeTitle(match[1] ?? '') !== normalizeTitle(title)) return body
+  return body.slice(match[0].length).replace(/^\s+/, '')
+}
+
+export declare namespace stripDuplicateTitle {
+  type Options = {
+    /** Release notes content (Markdown). */
+    body: string
+    /** Release title/name. */
+    title: string
+  }
+  type ReturnType = string
+}
+
+function normalizeTitle(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[-\u2010-\u2015\u2212]/g, '-')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/**
  * Creates a GitHub releases changelog adapter.
  *
  * @example

--- a/src/internal/llms.test.ts
+++ b/src/internal/llms.test.ts
@@ -1,9 +1,13 @@
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
+import remarkDirective from 'remark-directive'
+import type { Pluggable } from 'unified'
 import { describe, expect, test } from 'vitest'
+import type * as Changelog from './changelog.js'
 import { buildLlmsContent } from './llms.js'
 import {
+  remarkChangelogMarkdown,
   remarkDefaultFrontmatter,
   remarkExtractFrontmatter,
   remarkFrontmatter,
@@ -434,6 +438,150 @@ const a = 1
       \`\`\`
       "
     `)
+  })
+
+  describe('::changelog directive', () => {
+    const releases: Changelog.Release[] = [
+      {
+        version: 'vocs@2.1.0',
+        title: 'vocs@2.1.0',
+        date: '2026-06-02T00:00:00.000Z',
+        body: '### Patch Changes\n\n- Fixed a thing.',
+        url: 'https://example.com/releases/2.1.0',
+      },
+      {
+        version: 'vocs@2.0.0',
+        title: 'Big Bang',
+        date: '2026-05-01T00:00:00.000Z',
+        body: '### Major Changes\n\n- Everything changed.',
+        url: 'https://example.com/releases/2.0.0',
+      },
+      {
+        version: 'vocs@1.9.0',
+        title: 'vocs@1.9.0',
+        date: '2026-04-01T00:00:00.000Z',
+        body: '- Older release.',
+        url: 'https://example.com/releases/1.9.0',
+      },
+    ]
+    const adapter: Changelog.Adapter = {
+      type: 'mock',
+      async fetch(options = {}) {
+        return releases.slice(0, options.limit ?? releases.length)
+      },
+    }
+    const page = {
+      path: '/changelog',
+      content: '---\ntitle: Changelog\n---\n\n::changelog',
+    }
+    const withChangelog = (changelog?: Changelog.Adapter) => ({
+      rehypePlugins: [],
+      remarkPlugins: [
+        ...plugins.remarkPlugins,
+        remarkDirective,
+        [remarkChangelogMarkdown, { changelog }] as Pluggable,
+      ],
+    })
+
+    test('renders releases from the adapter', async () => {
+      const result = await buildLlmsContent({
+        pages: [page],
+        title: 'My Docs',
+        ...withChangelog(adapter),
+      })
+
+      const content = result.results[0]?.content ?? ''
+      expect(content).not.toContain('::changelog')
+      expect(content).toContain('## vocs@2.1.0 (2026-06-02)')
+      expect(content).toContain('Fixed a thing.')
+      // A title differing from the version is included in the heading.
+      expect(content).toContain('## vocs@2.0.0 — Big Bang (2026-05-01)')
+      expect(content).toContain('Everything changed.')
+    })
+
+    test('respects the limit attribute', async () => {
+      const result = await buildLlmsContent({
+        pages: [{ ...page, content: '---\ntitle: Changelog\n---\n\n::changelog{limit=1}' }],
+        title: 'My Docs',
+        ...withChangelog(adapter),
+      })
+
+      const content = result.results[0]?.content ?? ''
+      expect(content).toContain('## vocs@2.1.0 (2026-06-02)')
+      expect(content).not.toContain('vocs@2.0.0')
+    })
+
+    test('replaces multiple directives on one page independently', async () => {
+      const result = await buildLlmsContent({
+        pages: [
+          {
+            path: '/changelog',
+            content:
+              '---\ntitle: Changelog\n---\n\n::changelog{limit=1}\n\nOlder releases:\n\n::changelog{limit=2}',
+          },
+        ],
+        title: 'My Docs',
+        ...withChangelog(adapter),
+      })
+
+      const content = result.results[0]?.content ?? ''
+      expect(content).not.toContain('::changelog')
+      // First directive (limit=1): only the latest release.
+      // Second directive (limit=2): latest two — so vocs@2.1.0 appears twice,
+      // vocs@2.0.0 once, and the separator paragraph sits between them.
+      expect(content.match(/## vocs@2\.1\.0/g)).toHaveLength(2)
+      expect(content.match(/## vocs@2\.0\.0/g)).toHaveLength(1)
+      const separator = content.indexOf('Older releases:')
+      expect(separator).toBeGreaterThan(-1)
+      expect(content.indexOf('## vocs@2.1.0')).toBeLessThan(separator)
+      expect(content.lastIndexOf('## vocs@2.0.0')).toBeGreaterThan(separator)
+    })
+
+    test('degrades to a comment without an adapter', async () => {
+      const result = await buildLlmsContent({
+        pages: [page],
+        title: 'My Docs',
+        ...withChangelog(undefined),
+      })
+
+      const content = result.results[0]?.content ?? ''
+      expect(content).not.toContain('::changelog')
+      expect(content).toContain('<!-- changelog unavailable -->')
+    })
+
+    test('degrades to a comment when the adapter throws', async () => {
+      const throwing: Changelog.Adapter = {
+        type: 'mock',
+        async fetch() {
+          throw new Error('rate limit exceeded')
+        },
+      }
+      const result = await buildLlmsContent({
+        pages: [page],
+        title: 'My Docs',
+        ...withChangelog(throwing),
+      })
+
+      const content = result.results[0]?.content ?? ''
+      expect(content).toContain('<!-- changelog unavailable -->')
+    })
+
+    test('unhandled directives round-trip unchanged', async () => {
+      const result = await buildLlmsContent({
+        pages: [
+          {
+            path: '/guide',
+            content: '---\ntitle: Guide\n---\n\n:::steps\n### One\n\nDo the thing.\n:::',
+          },
+        ],
+        title: 'My Docs',
+        ...withChangelog(adapter),
+      })
+
+      const content = result.results[0]?.content ?? ''
+      expect(content).toContain(':::steps')
+      expect(content).toContain('Do the thing.')
+    })
   })
 
   test('includes imported markdown content for file-backed pages', async () => {

--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -12,6 +12,7 @@ import remarkDirective from 'remark-directive'
 import remarkFrontmatter from 'remark-frontmatter'
 import remarkGfm from 'remark-gfm'
 import remarkMdxFrontmatter from 'remark-mdx-frontmatter'
+import remarkParse from 'remark-parse'
 import type {
   BuiltinTheme,
   CodeOptionsMultipleThemes,
@@ -28,11 +29,12 @@ import solidity from 'shiki/langs/solidity.mjs'
 import sql from 'shiki/langs/sql.mjs'
 import toml from 'shiki/langs/toml.mjs'
 import yamlLang from 'shiki/langs/yaml.mjs'
-import type { Pluggable, PluggableList } from 'unified'
+import { type Pluggable, type PluggableList, unified } from 'unified'
 import * as UnistUtil from 'unist-util-visit'
 import type { VFile } from 'vfile'
 import { createLogger } from 'vite'
 import * as yaml from 'yaml'
+import * as Changelog from './changelog.js'
 import type * as Config from './config.js'
 import * as Git from './git.js'
 import * as Icons from './icons.js'
@@ -214,6 +216,11 @@ export function getCompileOptions(
           remarkStripFrontmatter,
           remarkStripJs,
           remarkStripInlineCache,
+          // Parse directive syntax (`::name`/`:::name`) so data-backed
+          // directives can render real markdown below. Unhandled directives
+          // round-trip back to their source form on stringify.
+          remarkDirective,
+          [remarkChangelogMarkdown, config] as Pluggable,
           // User plugins extend the parser (e.g. `remark-math`) so syntax
           // recognized in the React build also parses for llms/search.
           ...(markdown?.remarkPlugins ?? []),
@@ -1479,4 +1486,78 @@ export function remarkChangelog(): remarkChangelog.ReturnType {
 
 export declare namespace remarkChangelog {
   type ReturnType = (tree: MdAst.Root) => void
+}
+
+/**
+ * Remark plugin (markdown/`txt` pipeline) that renders `::changelog` leaf
+ * directives as release markdown, so `llms.txt` and the per-page markdown
+ * twins carry the releases instead of a literal `::changelog` line — the
+ * content only exists behind the adapter, so without this the markdown
+ * output loses the page's entire content.
+ *
+ * Mirrors the react pipeline's `remarkChangelog` + `Changelog` component
+ * pair: same adapter, `{limit=N}` handling, and duplicate-title
+ * normalization. Failures (no adapter, offline, rate limit) degrade to an
+ * HTML comment — a missing changelog must never fail the llms/markdown build.
+ */
+export function remarkChangelogMarkdown(
+  options: remarkChangelogMarkdown.Options = {},
+): remarkChangelogMarkdown.ReturnType {
+  return async (tree: MdAst.Root) => {
+    // Collect matches first (visit is sync), then fetch and splice.
+    const found: { index: number; limit: number; parent: MdAst.Parent }[] = []
+    UnistUtil.visit(tree, 'leafDirective', (node, index, parent) => {
+      if (node.name !== 'changelog') return
+      if (index === undefined || !parent) return
+      const limit = node.attributes?.['limit'] ? Number.parseInt(node.attributes['limit'], 10) : 999
+      found.push({ index, limit, parent })
+    })
+    if (found.length === 0) return
+
+    // Splice back-to-front so earlier indices stay valid.
+    for (const { index, limit, parent } of found.reverse())
+      parent.children.splice(index, 1, ...(await render(limit)))
+
+    async function render(limit: number): Promise<MdAst.RootContent[]> {
+      const unavailable: MdAst.RootContent[] = [
+        { type: 'html', value: '<!-- changelog unavailable -->' },
+      ]
+      const adapter = options.changelog
+      if (!adapter) return unavailable
+      try {
+        const releases = await adapter.fetch({ limit, prereleases: false })
+        const markdown = releases
+          .map((release) => {
+            const date = release.date.slice(0, 10)
+            const body = Changelog.stripDuplicateTitle({
+              body: release.body,
+              title: release.title,
+            })
+            const title =
+              release.title && release.title !== release.version ? ` — ${release.title}` : ''
+            return `## ${release.version}${title} (${date})\n\n${body}`.trim()
+          })
+          .join('\n\n')
+        // Parsed without GFM on purpose: the outer txt pipeline stringifies
+        // without GFM extensions, so GFM nodes (tables, …) spliced in here
+        // would make it throw. Plain parsing keeps GFM constructs as
+        // readable literal text.
+        return unified().use(remarkParse).parse(markdown).children
+      } catch (error) {
+        logger.warn(
+          `Failed to render \`::changelog\` in markdown output: ${error instanceof Error ? error.message : String(error)}`,
+          { timestamp: true },
+        )
+        return unavailable
+      }
+    }
+  }
+}
+
+export declare namespace remarkChangelogMarkdown {
+  type Options = {
+    /** Changelog adapter to fetch releases from (`config.changelog`). */
+    changelog?: Changelog.Adapter | undefined
+  }
+  type ReturnType = (tree: MdAst.Root) => Promise<void>
 }

--- a/src/server/changelog.ts
+++ b/src/server/changelog.ts
@@ -1,4 +1,4 @@
-import type * as Changelog from '../internal/changelog.js'
+import * as Changelog from '../internal/changelog.js'
 import * as Config from '../internal/config.js'
 import * as Markdown from '../internal/markdown.js'
 
@@ -32,41 +32,13 @@ export async function fetchChangelog(
   })
 
   return releases.map((release) => {
-    const body = stripDuplicateTitle(release.body, release.title)
+    const body = Changelog.stripDuplicateTitle({ body: release.body, title: release.title })
     return {
       ...release,
       body,
       bodyHtml: Markdown.toHtml(body),
     }
   })
-}
-
-/**
- * Strips a leading H1 from the release body when it duplicates the release title.
- *
- * GitHub renders the release name as the heading on the release page, so
- * authors often write a body that *also* begins with `# <title>`. When such a
- * release is shown in our changelog UI we already render the title above the
- * body, which produces a visible duplicate (see e.g. release authors writing
- * `# Release v1.6.0 — T3 …` while the GitHub release name is
- * `Release v1.6.0 - T3 …`). We compare the leading H1 text against the title
- * with loose normalization (lowercase, whitespace collapsing, all unicode
- * dashes treated as the same character) and strip it on match.
- */
-function stripDuplicateTitle(body: string, title: string): string {
-  if (!body || !title) return body
-  const match = body.match(/^\s*#\s+(.+?)\s*(?:\r?\n|$)/)
-  if (!match) return body
-  if (normalizeTitle(match[1] ?? '') !== normalizeTitle(title)) return body
-  return body.slice(match[0].length).replace(/^\s+/, '')
-}
-
-function normalizeTitle(s: string): string {
-  return s
-    .toLowerCase()
-    .replace(/[-\u2010-\u2015\u2212]/g, '-')
-    .replace(/\s+/g, ' ')
-    .trim()
 }
 
 export declare namespace fetchChangelog {


### PR DESCRIPTION
Closes #557

## Summary

- Parse directives in the txt pipeline (`remark-directive`); unhandled ones round-trip unchanged
- Render `::changelog` through the configured adapter, honoring `{limit=N}` like the rendered page
- Fetch failures degrade to an HTML comment + warning instead of failing the build

## Test Plan

### Before

<img width="523" height="183" alt="image" src="https://github.com/user-attachments/assets/67097660-949e-4020-bb97-ec841c9c1006" />

### After

<img width="876" height="502" alt="image" src="https://github.com/user-attachments/assets/aff9310c-855d-415c-af32-5789336feccf" />

