### PR TITLE
fix: resolve hash-only anchors against the current page

### DIFF
--- a/.changeset/giant-words-deny.md
+++ b/.changeset/giant-words-deny.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed changelog `Versions` links navigating to the site root instead of scrolling to the release when `baseUrl` is set.

--- a/.changeset/giant-words-deny.md
+++ b/.changeset/giant-words-deny.md
@@ -2,4 +2,4 @@
 "vocs": patch
 ---
 
-Fixed changelog `Versions` links navigating to the site root instead of scrolling to the release when `baseUrl` is set.
+Fixed changelog version links, the skip-to-content link, and OpenAPI heading anchors navigating to the site root when `baseUrl` is set.

--- a/.changeset/giant-words-deny.md
+++ b/.changeset/giant-words-deny.md
@@ -2,4 +2,4 @@
 "vocs": patch
 ---
 
-Fixed changelog version links, the skip-to-content link, and OpenAPI heading anchors navigating to the site root when `baseUrl` is set.
+Fixed changelog version links, the skip-to-content link, and markdown and OpenAPI heading anchors navigating to the site root when `baseUrl` is set.

--- a/src/internal/mdx.test.ts
+++ b/src/internal/mdx.test.ts
@@ -11,6 +11,7 @@ import {
   deadLinks,
   getCompileOptions,
   recmaMdxLayout,
+  rehypeHeadingAnchors,
   rehypeLinks,
   remarkCodeTitle,
   remarkDefaultFrontmatter,
@@ -615,5 +616,66 @@ describe('rehypeLinks', () => {
 
     deadLinks.delete(vfile.path)
     OpenApiRegistry.invalidate()
+  })
+})
+
+describe('rehypeHeadingAnchors', () => {
+  function headingAnchor(
+    href: string,
+    properties: Record<string, unknown> = { className: ['heading-anchor'] },
+  ) {
+    return {
+      type: 'element' as const,
+      tagName: 'a',
+      properties: { ...properties, href } as Record<string, unknown>,
+      children: [],
+    }
+  }
+
+  function run(anchors: ReturnType<typeof headingAnchor>[], filePath: string) {
+    const config = Config.define({ rootDir: process.cwd() })
+    const tree = { type: 'root' as const, children: anchors }
+    const vfile = { path: path.join(process.cwd(), filePath) }
+    rehypeHeadingAnchors(config)()(tree as never, vfile as never)
+  }
+
+  it('resolves hash-only hrefs against the page path', () => {
+    const anchor = headingAnchor('#overview')
+    run([anchor], 'src/pages/guide/getting-started.mdx')
+    expect(anchor.properties['href']).toBe('/guide/getting-started#overview')
+  })
+
+  it('resolves index pages to their directory path', () => {
+    const nested = headingAnchor('#overview')
+    run([nested], 'src/pages/guide/index.mdx')
+    expect(nested.properties['href']).toBe('/guide#overview')
+
+    const root = headingAnchor('#overview')
+    run([root], 'src/pages/index.md')
+    expect(root.properties['href']).toBe('/#overview')
+  })
+
+  it('ignores anchors without the heading-anchor class', () => {
+    const anchor = headingAnchor('#overview', {})
+    run([anchor], 'src/pages/guide/getting-started.mdx')
+    expect(anchor.properties['href']).toBe('#overview')
+  })
+
+  it('ignores non-hash hrefs', () => {
+    const anchor = headingAnchor('/other-page#overview')
+    run([anchor], 'src/pages/guide/getting-started.mdx')
+    expect(anchor.properties['href']).toBe('/other-page#overview')
+  })
+
+  it('ignores files outside the pages directory', () => {
+    const anchor = headingAnchor('#overview')
+    run([anchor], 'other/getting-started.mdx')
+    expect(anchor.properties['href']).toBe('#overview')
+  })
+
+  it('ignores pages with dynamic segments', () => {
+    const anchor = headingAnchor('#overview')
+    run([anchor], 'src/pages/blog/[slug].mdx')
+    expect(anchor.properties['href']).toBe('#overview')
   })
 })

--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -270,6 +270,7 @@ export function getCompileOptions(
               },
             },
           ] as Pluggable,
+          rehypeHeadingAnchors(config),
           rehypeShiki({ ...codeHighlight, cacheDir, rootDir, srcDir, twoslash }),
           ...(markdown?.rehypePlugins ?? []),
           rehypeCodeInLink,
@@ -418,6 +419,44 @@ export function rehypeCodeInLink() {
           children: codeChildren,
         },
       ]
+    })
+  }
+}
+
+/**
+ * Rehype plugin that resolves hash-only heading anchor hrefs against the page path.
+ * A hash-only href resolves against the `<base>` tag and navigates to the site root
+ * when `baseUrl` is set.
+ */
+export function rehypeHeadingAnchors(config: Config.Config) {
+  const { rootDir, srcDir, pagesDir } = config
+  const pagesDirPath = path.resolve(rootDir, srcDir, pagesDir)
+
+  return () => (tree: HAst.Root, vfile: VFile) => {
+    if (!vfile.path) return
+
+    const relativePath = path.relative(pagesDirPath, path.resolve(vfile.path))
+    if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) return
+    // Dynamic segments only resolve at request time; leave those to the runtime `Link`.
+    if (relativePath.includes('[')) return
+
+    const pagePath =
+      `/${relativePath.split(path.sep).join('/')}`
+        .replace(/\.(md|mdx)$/, '')
+        .replace(/\/index$/, '') || '/'
+
+    UnistUtil.visit(tree, 'element', (node) => {
+      const element = node as HAst.Element
+      if (element.tagName !== 'a') return
+
+      const className = element.properties?.['className']
+      const classes = Array.isArray(className) ? className : [className]
+      if (!classes.includes('heading-anchor')) return
+
+      const href = element.properties?.['href']
+      if (typeof href !== 'string' || !href.startsWith('#')) return
+
+      element.properties['href'] = `${pagePath}${href}`
     })
   }
 }

--- a/src/react/internal/Changelog.client.tsx
+++ b/src/react/internal/Changelog.client.tsx
@@ -3,6 +3,7 @@
 import { cx } from 'cva'
 import * as React from 'react'
 import { createPortal } from 'react-dom'
+import { Link } from 'waku'
 import LucideChevronDown from '~icons/lucide/chevron-down'
 import LucideExternalLink from '~icons/lucide/external-link'
 import LucideHistory from '~icons/lucide/history'
@@ -218,8 +219,8 @@ function VersionOutline(props: VersionOutline.Props): React.JSX.Element | null {
               data-version={release.version}
               className="vocs:scroll-my-4"
             >
-              <a
-                href={`#${release.version}`}
+              <Link
+                to={`#${release.version}`}
                 className={cx(
                   'vocs:block vocs:leading-snug vocs:py-1 vocs:pl-3 vocs:cursor-pointer vocs:font-mono vocs:text-xs vocs:transition-colors vocs:duration-100',
                   isActive ? 'vocs:text-accent' : 'vocs:text-secondary vocs:hover:text-link',
@@ -227,7 +228,7 @@ function VersionOutline(props: VersionOutline.Props): React.JSX.Element | null {
                 data-active={isActive}
               >
                 {release.version}
-              </a>
+              </Link>
             </li>
           )
         })}

--- a/src/react/internal/Changelog.client.tsx
+++ b/src/react/internal/Changelog.client.tsx
@@ -3,12 +3,12 @@
 import { cx } from 'cva'
 import * as React from 'react'
 import { createPortal } from 'react-dom'
-import { Link } from 'waku'
 import LucideChevronDown from '~icons/lucide/chevron-down'
 import LucideExternalLink from '~icons/lucide/external-link'
 import LucideHistory from '~icons/lucide/history'
 import type * as ChangelogTypes from '../../internal/changelog.js'
 import { Badge } from '../Badge.js'
+import { Link } from '../Link.js'
 
 const collapsedHeight = 600
 

--- a/src/react/internal/SkipToContent.client.tsx
+++ b/src/react/internal/SkipToContent.client.tsx
@@ -1,11 +1,17 @@
 'use client'
 
 import { cx } from 'cva'
+import { useRouter } from 'waku'
 
 export function SkipToContent(props: SkipToContent.Props) {
   const { className } = props
+  const { path } = useRouter()
 
   return (
+    // Native anchor (not the router `Link`) so fragment navigation moves the
+    // browser's sequential-focus point into the content — the whole point of
+    // a skip link. The href carries the page path because a hash-only href
+    // would resolve against the `<base>` tag and navigate to the site root.
     <a
       className={cx(
         'vocs:fixed vocs:top-3 vocs:left-3 vocs:z-50',
@@ -19,7 +25,7 @@ export function SkipToContent(props: SkipToContent.Props) {
         className,
       )}
       data-v-skip-to-content
-      href="#vocs-content"
+      href={`${path.split('#')[0]}#vocs-content`}
     >
       Skip to content
     </a>

--- a/src/react/internal/openapi/HeadingAnchor.tsx
+++ b/src/react/internal/openapi/HeadingAnchor.tsx
@@ -1,4 +1,5 @@
 import LucideLink from '~icons/lucide/link'
+import { Link } from '../../Link.js'
 
 /**
  * A copy-link anchor appended to an OpenAPI heading. Reuses the markdown
@@ -8,14 +9,14 @@ import LucideLink from '~icons/lucide/link'
  */
 export function HeadingAnchor(props: HeadingAnchor.Props) {
   return (
-    <a
-      href={`#${props.id}`}
+    <Link
+      to={`#${props.id}`}
       className={`heading-anchor${props.className ? ` ${props.className}` : ''}`}
       aria-label="Copy link and go to this section"
       title="Copy link and go to this section"
     >
       <LucideLink className="heading-anchor-icon vocs:size-[0.75em]" />
-    </a>
+    </Link>
   )
 }
 


### PR DESCRIPTION
## Summary

Setting `baseUrl` renders a `<base>` tag, so the browser resolves hash-only hrefs against the site root instead of the current page. The router `Link` already defends against this by resolving a hash-only `to` against the current route, but three components bypassed it with raw `<a href="#…">`:

- Changelog `Versions` panel → `Link`, like the page outline
- Skip-to-content → native anchor kept (fragment navigation must move the sequential-focus point), href now carries the page path
- OpenAPI heading anchors → `Link`, which also fixes the copied link pointing at the root

## Test Plan

### Changelog versions

Before: https://vocs.dev/changelog: clicking a version lands on `https://vocs.dev/#vocs@2.2.5` (site root, scroll lost).

https://github.com/user-attachments/assets/bbe4206b-6cdb-46d1-afed-329a30f915f3

After: stays on `/changelog#vocs@2.2.5` and scrolls to the release.

https://github.com/user-attachments/assets/cfb5fce5-549b-472c-87a5-3f63353ee7ec

### Skip-to-content

Before: https://vocs.dev/introduction/getting-started: tab + enter lands on `https://vocs.dev/#vocs-content`.

https://github.com/user-attachments/assets/4fc80a92-5dfa-4119-863d-964bf6a77e04

After: stays on the page, and the next tab continues inside the content.

https://github.com/user-attachments/assets/7e9c9cbc-ee8a-4100-9aaf-694de5aeb46b

