### PR TITLE
fix: guard `::changelog` limit parsing against malformed values

### DIFF
--- a/.changeset/changelog-limit-guard.md
+++ b/.changeset/changelog-limit-guard.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed malformed `::changelog{limit}` values reaching the changelog fetcher as `NaN` instead of falling back to the default limit.

--- a/src/internal/llms.test.ts
+++ b/src/internal/llms.test.ts
@@ -511,6 +511,21 @@ const a = 1
       expect(content).not.toContain('vocs@2.0.0')
     })
 
+    test('falls back to the default on a malformed limit', async () => {
+      const result = await buildLlmsContent({
+        pages: [{ ...page, content: '---\ntitle: Changelog\n---\n\n::changelog{limit=abc}' }],
+        title: 'My Docs',
+        ...withChangelog(adapter),
+      })
+
+      // Behaves like no limit: all releases render.
+      const content = result.results[0]?.content ?? ''
+      expect(content).not.toContain('::changelog')
+      expect(content).toContain('## vocs@2.1.0 (2026-06-02)')
+      expect(content).toContain('## vocs@2.0.0 — Big Bang (2026-05-01)')
+      expect(content).toContain('## vocs@1.9.0 (2026-04-01)')
+    })
+
     test('replaces multiple directives on one page independently', async () => {
       const result = await buildLlmsContent({
         pages: [

--- a/src/internal/mdx.test.ts
+++ b/src/internal/mdx.test.ts
@@ -1,6 +1,7 @@
 import * as path from 'node:path'
 import type * as Estree from 'estree'
 import type * as MdAst from 'mdast'
+import remarkDirective from 'remark-directive'
 import remarkFrontmatter from 'remark-frontmatter'
 import remarkParse from 'remark-parse'
 import ruby from 'shiki/langs/ruby.mjs'
@@ -12,6 +13,7 @@ import {
   getCompileOptions,
   recmaMdxLayout,
   rehypeLinks,
+  remarkChangelog,
   remarkCodeTitle,
   remarkDefaultFrontmatter,
   remarkFilename,
@@ -381,6 +383,58 @@ describe('remarkRestoreUnknownTextDirectives', () => {
       { type: 'text', value: 'localhost' },
       { type: 'text', value: ':3003' },
     ])
+  })
+})
+
+describe('remarkChangelog', () => {
+  async function run(markdown: string) {
+    const tree = await runRemark(markdown, [remarkDirective, remarkChangelog])
+    return tree.children[0]?.data
+  }
+
+  it('respects the limit attribute', async () => {
+    expect(await run('::changelog{limit=10}')).toMatchInlineSnapshot(`
+      {
+        "hName": "div",
+        "hProperties": {
+          "data-v-changelog": "true",
+          "data-v-changelog-limit": "10",
+        },
+      }
+    `)
+  })
+
+  it('defaults the limit when omitted', async () => {
+    expect(await run('::changelog')).toMatchInlineSnapshot(`
+      {
+        "hName": "div",
+        "hProperties": {
+          "data-v-changelog": "true",
+          "data-v-changelog-limit": "999",
+        },
+      }
+    `)
+  })
+
+  it('falls back to the default on a malformed limit', async () => {
+    expect(await run('::changelog{limit=abc}')).toMatchInlineSnapshot(`
+      {
+        "hName": "div",
+        "hProperties": {
+          "data-v-changelog": "true",
+          "data-v-changelog-limit": "999",
+        },
+      }
+    `)
+    expect(await run('::changelog{limit=0}')).toMatchInlineSnapshot(`
+      {
+        "hName": "div",
+        "hProperties": {
+          "data-v-changelog": "true",
+          "data-v-changelog-limit": "999",
+        },
+      }
+    `)
   })
 })
 

--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -1511,7 +1511,9 @@ export function remarkChangelogMarkdown(
     UnistUtil.visit(tree, 'leafDirective', (node, index, parent) => {
       if (node.name !== 'changelog') return
       if (index === undefined || !parent) return
-      const limit = node.attributes?.['limit'] ? Number.parseInt(node.attributes['limit'], 10) : 999
+      // Malformed limits (NaN, zero, negative) fall back to the default.
+      const parsed = Number.parseInt(node.attributes?.['limit'] ?? '', 10)
+      const limit = Number.isInteger(parsed) && parsed > 0 ? parsed : 999
       found.push({ index, limit, parent })
     })
     if (found.length === 0) return

--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -1466,7 +1466,9 @@ export function remarkChangelog(): remarkChangelog.ReturnType {
       // biome-ignore lint/suspicious/noAssignInExpressions: _
       const data = node.data || (node.data = {})
 
-      const limit = node.attributes?.['limit'] ? Number.parseInt(node.attributes['limit'], 10) : 999
+      // Malformed limits (NaN, zero, negative) fall back to the default.
+      const parsed = Number.parseInt(node.attributes?.['limit'] ?? '', 10)
+      const limit = Number.isInteger(parsed) && parsed > 0 ? parsed : 999
 
       data.hName = 'div'
       data.hProperties = {

--- a/src/react/internal/Changelog.mdx.tsx
+++ b/src/react/internal/Changelog.mdx.tsx
@@ -11,9 +11,9 @@ export function Changelog(props: Changelog.Props): React.JSX.Element {
 }
 
 async function ChangelogAsync(props: Changelog.Props): Promise<React.JSX.Element> {
-  const limit = props['data-v-changelog-limit']
-    ? Number.parseInt(props['data-v-changelog-limit'], 10)
-    : 999
+  // Malformed limits (NaN, zero, negative) fall back to the default.
+  const parsed = Number.parseInt(props['data-v-changelog-limit'] ?? '', 10)
+  const limit = Number.isInteger(parsed) && parsed > 0 ? parsed : 999
 
   const releases = await Actions.fetchChangelog({ limit })
   return <Changelog_client releases={releases} />


### PR DESCRIPTION
Malformed `::changelog{limit}` values (e.g. `limit=abc`) parsed to `NaN` and flowed into `config.changelog.fetch({ limit })`, reaching the GitHub API as `per_page=NaN`. Non-positive values were passed through as-is.

Limits now parse with a positive-integer guard and fall back to the default (999) otherwise. Covers `remarkChangelog`, the `Changelog` MDX component, and `remarkChangelogMarkdown` from https://github.com/wevm/vocs/pull/558.
