### PR TITLE
chore: upgrade `waku` to `1.0.0-beta.6`

### DIFF
--- a/.changeset/waku-beta-6.md
+++ b/.changeset/waku-beta-6.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Upgraded to `waku@1.0.0-beta.6`.

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "react": "^19",
     "react-dom": "^19",
     "vite": "^8",
-    "waku": "^1.0.0-beta.3"
+    "waku": "^1.0.0-beta.6"
   },
   "peerDependenciesMeta": {
     "@vocs/twoslash-rust": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,16 +43,16 @@ catalogs:
       specifier: ^4.1.7
       version: 4.1.7
     waku:
-      specifier: 1.0.0-beta.3
-      version: 1.0.0-beta.3
+      specifier: 1.0.0-beta.6
+      version: 1.0.0-beta.6
     zile:
       specifier: 0.0.25
       version: 0.0.25
 
 overrides:
-  es-module-lexer: ^2.3.0
   '@vocs/twoslash-rust': workspace:*
   create-vocs: workspace:*
+  es-module-lexer: ^2.3.0
   yaml: 2.9.0
 
 importers:
@@ -353,7 +353,7 @@ importers:
         version: 4.1.7(@types/node@25.2.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@8.0.14(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       waku:
         specifier: 'catalog:'
-        version: 1.0.0-beta.3(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.27.2)))(react@19.2.4)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 1.0.0-beta.6(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.27.2)))(react@19.2.4)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       zile:
         specifier: 'catalog:'
         version: 0.0.25(typescript@6.0.2)
@@ -396,7 +396,7 @@ importers:
         version: link:..
       waku:
         specifier: 'catalog:'
-        version: 1.0.0-beta.3(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.27.2)))(react@19.2.4)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 1.0.0-beta.6(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.27.2)))(react@19.2.4)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
     devDependencies:
       '@hono/node-server':
         specifier: ^2.0.2
@@ -442,7 +442,7 @@ importers:
         version: link:..
       waku:
         specifier: 'catalog:'
-        version: 1.0.0-beta.3(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.27.2)))(react@19.2.4)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 1.0.0-beta.6(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.27.2)))(react@19.2.4)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -1064,6 +1064,12 @@ packages:
 
   '@hono/node-server@2.0.4':
     resolution: {integrity: sha512-Ut3y0dMMPWy6bZ2kVfx25EOVbZlm15dhF4mOsezMlhpNHy+4MkU1qN9Y6lnruYi4wPmFzimGX2X7LF/FwHli4A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
+
+  '@hono/node-server@2.0.8':
+    resolution: {integrity: sha512-GuCWzLxwg218fy1JaHculFsdcuY12hxit83V+algozTPnwhNjLrRL/Alg9OYjLZLoUZ1rw/S4CdTMsnkSKCmFA==}
     engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
@@ -4878,9 +4884,9 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
-  waku@1.0.0-beta.3:
-    resolution: {integrity: sha512-j8la6SzYX/pqqnjT/FTsr8de+jCwP4rthyV7IbRm/qEwECbUS0kXcG2VLs5TDGCumLnzq9uRl4iwocxG3+U8rQ==}
-    engines: {node: ^26.0.0 || ^24.0.0 || ^22.13.0}
+  waku@1.0.0-beta.6:
+    resolution: {integrity: sha512-IM5RCLgq9pvImyAu1clH3zAGAU3h5acgMcXbzUjnOihfAKAX71j68+bcJS2T3Zr4Am3oeRFSq5i689kT+zf/3w==}
+    engines: {node: ^26.0.0 || ^24.0.0 || ^22.15.0}
     hasBin: true
     peerDependencies:
       react: ~19.2.4
@@ -5711,6 +5717,10 @@ snapshots:
       hono: 4.12.22
 
   '@hono/node-server@2.0.4(hono@4.12.22)':
+    dependencies:
+      hono: 4.12.22
+
+  '@hono/node-server@2.0.8(hono@4.12.22)':
     dependencies:
       hono: 4.12.22
 
@@ -10094,9 +10104,9 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
-  waku@1.0.0-beta.3(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.27.2)))(react@19.2.4)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0):
+  waku@1.0.0-beta.6(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.27.2)))(react@19.2.4)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
-      '@hono/node-server': 2.0.4(hono@4.12.22)
+      '@hono/node-server': 2.0.8(hono@4.12.22)
       '@vitejs/plugin-react': 6.0.2(vite@8.0.14(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitejs/plugin-rsc': 0.5.26(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.27.2)))(react@19.2.4)(vite@8.0.14(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       dotenv: 17.4.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,7 @@ catalog:
   typescript: ^6.0.2
   vite: ^8.0.14
   vitest: ^4.1.7
-  waku: 1.0.0-beta.3
+  waku: 1.0.0-beta.6
   zile: 0.0.25
 
 overrides:

--- a/src/react/Link.tsx
+++ b/src/react/Link.tsx
@@ -81,5 +81,7 @@ export function Link(props: Link.Props) {
 }
 
 export namespace Link {
-  export type Props = React.ComponentProps<typeof WakuLink>
+  export type Props = Omit<React.ComponentProps<typeof WakuLink>, 'to'> & {
+    to: string
+  }
 }


### PR DESCRIPTION
Upgrades `waku` from `1.0.0-beta.3` to `1.0.0-beta.6`.

## Changes

- Bumped the `waku` catalog entry (`pnpm-workspace.yaml`) and peer dependency (`package.json`) to `1.0.0-beta.6`.
- **`src/react/Link.tsx`**: beta.6 changed `Link`'s `to` prop to `RouteHref | BuildRouteHrefTarget<Path>`. Vocs only ever passes string hrefs, so `Link.Props['to']` is narrowed back to `string`.

## Patches audit

All forked/wrapped waku modules under `src/waku/internal/patches` were checked against beta.6; no re-sync was required:

- `adapters/vercel-build-enhancer.ts` already matches beta.6 (`BuildOptions` shape, `INTERNAL_runFetch` serve code, `nodejs22.x` runtime, basePath-aware routes).
- `vite-plugins/fs-router-typegen.ts` already uses beta.6's OXC `parse`/`transformWithOxc` path; `PathsForPages`/`GetConfigResponse`/`RouteConfig`/`CreatePagesConfig` are all still exported.
- `adapters/node.ts`, `adapters/vercel.ts`, and `router.ts` consume APIs (`unstable_createServerEntryAdapter`, `waku/internals`, `createPages`, adapter defaults) that are unchanged or only additively extended in beta.6.
- `utils/path.ts`, `constants.ts`, and `api-routes.ts` are Vocs's own customized copies and import nothing from waku.

## Verification

- `pnpm check:types` passes.
- `pnpm test` — 570 passed. The only failures are pre-existing and unrelated (`experimental_rust.test.ts` fails because the native `@vocs/twoslash-rust` binary isn't available for `darwin-arm64` locally.
EOF
)