### PR TITLE
feat(openapi): support `x-tagGroups` controls

### DIFF
--- a/.changeset/openapi-exclude.md
+++ b/.changeset/openapi-exclude.md
@@ -1,0 +1,5 @@
+---
+'vocs': patch
+---
+
+Added `exclude` to OpenAPI entries to hide tags or `x-tagGroups` sections from the generated reference (sidebar, pages, search, and the interactive client).

--- a/.changeset/tag-groups-sidebar.md
+++ b/.changeset/tag-groups-sidebar.md
@@ -1,0 +1,5 @@
+---
+'vocs': patch
+---
+
+Added `x-tagGroups` support to the OpenAPI reference sidebar (claimed tags nest under named sections, unclaimed tags stay top-level), with `sidebar.flatten` to render chosen sections' tags as top-level items.

--- a/site/src/pages/features/openapi.mdx
+++ b/site/src/pages/features/openapi.mdx
@@ -62,6 +62,52 @@ export default defineConfig({
 
 Then author the page in your pages directory at the matching route (e.g. `src/pages/api/auth.mdx`).
 
+### Group Tags into Sections
+
+Declare `x-tagGroups` at the root of your spec ([Redoc convention](https://redocly.com/docs/api-reference-docs/specification-extensions/x-tag-groups/)) to nest the sidebar's tag groups under named section headers — useful when one document spans several APIs.
+
+```yaml [openapi.yaml]
+x-tagGroups: # [!code focus]
+  - name: Data API # [!code focus]
+    tags: [Tokens, Transactions, Blocks] # [!code focus]
+  - name: Platform API # [!code focus]
+    tags: [Organizations, API Keys] # [!code focus]
+```
+
+Grouping affects navigation only — each tag keeps its own page and URL. Tags not claimed by any group stay at the top level of the sidebar, after the sections.
+
+To keep a primary API prominent, name it in `sidebar.flatten` — its tags render as top-level items (as without tag groups) while the other sections keep their headers.
+
+```ts [vocs.config.ts]
+export default defineConfig({
+  openapi: [
+    {
+      spec: './openapi.yaml',
+      path: '/api',
+      sidebar: { // [!code focus]
+        flatten: ['Data API'], // [!code focus]
+      }, // [!code focus]
+    },
+  ],
+})
+```
+
+### Hide Tags or Sections
+
+Name tags or `x-tagGroups` sections in `exclude` to leave them out of the reference entirely — no sidebar items, category pages, or search entries, and their operations are stripped from the interactive client. The source spec is untouched, so a spec served separately (e.g. `/openapi.json`) still documents them.
+
+```ts [vocs.config.ts]
+export default defineConfig({
+  openapi: [
+    {
+      spec: './openapi.yaml',
+      path: '/api',
+      exclude: ['Platform API'], // [!code focus]
+    },
+  ],
+})
+```
+
 ### List Endpoints in a Page
 
 The `<OpenApi.Endpoints />` component renders the landing/domain accordion of operations anywhere in your MDX, useful for an introduction or overview page.

--- a/src/internal/openapi/openapi.ts
+++ b/src/internal/openapi/openapi.ts
@@ -69,6 +69,15 @@ export type SidebarExtras = {
    * @default true
    */
   backLink?: boolean | undefined
+  /**
+   * Names of `x-tagGroups` sections to flatten: their categories render as
+   * top-level sidebar items (as without tag groups) instead of nesting under
+   * the section header. Useful to keep a primary API prominent while secondary
+   * APIs stay grouped. Names not matching a section are ignored.
+   *
+   * @example ["Data API"]
+   */
+  flatten?: readonly string[] | undefined
 }
 
 /**
@@ -122,6 +131,17 @@ export type Config = {
    * @example "/api"
    */
   path?: string | undefined
+  /**
+   * Tag or `x-tagGroups` section names to leave out of the generated reference
+   * entirely: no sidebar items, no category pages, no search entries, and the
+   * operations are stripped from the spec handed to the interactive client.
+   * Excluding a section name excludes every tag it claims. Names matching
+   * nothing are ignored. The source spec is not modified — a spec served
+   * separately (e.g. `/openapi.json`) still contains the operations.
+   *
+   * @example ["Platform API"]
+   */
+  exclude?: readonly string[] | undefined
   /**
    * Extra sidebar items to add around the auto-generated section (e.g. links to
    * consumer-authored guide pages mounted under `path`).
@@ -191,7 +211,7 @@ export type SiteConfig = Config & {
  * ```
  */
 export function from(config: from.Options): SiteConfig {
-  const { spec, path, sidebar, pages } = config
+  const { spec, path, exclude, sidebar, pages } = config
 
   if (!spec) throw new Error('[vocs] `openapi` entry is missing a `spec`.')
   if (!path) throw new Error('[vocs] `openapi` entry is missing a `path`.')
@@ -199,6 +219,7 @@ export function from(config: from.Options): SiteConfig {
   return {
     spec,
     path: normalizePath(path),
+    ...(exclude ? { exclude } : {}),
     ...(sidebar ? { sidebar } : {}),
     ...(pages ? { pages } : {}),
   }

--- a/src/internal/openapi/parser.test.ts
+++ b/src/internal/openapi/parser.test.ts
@@ -188,6 +188,113 @@ describe('parse', () => {
     expect(fallback?.operations.map((op) => op.id)).toEqual(['health'])
   })
 
+  test('omits `tagGroups` when the document has no `x-tagGroups`', async () => {
+    const ir = await parse(OpenApi.from({ spec, path: '/api' }))
+    expect(ir.tagGroups).toBeUndefined()
+  })
+
+  test('resolves `x-tagGroups` to rendered group ids', async () => {
+    const ir = await parse(
+      OpenApi.from({
+        spec: {
+          ...spec,
+          'x-tagGroups': [
+            { name: 'Data API', tags: ['pets'] },
+            { name: 'Platform API', tags: ['store'] },
+          ],
+        },
+        path: '/api',
+      }),
+    )
+    expect(ir.tagGroups).toEqual([
+      { name: 'Data API', groupIds: ['pets'] },
+      { name: 'Platform API', groupIds: ['store'] },
+    ])
+  })
+
+  test('drops unknown tags, empty sections, and repeat claims from `x-tagGroups`', async () => {
+    const ir = await parse(
+      OpenApi.from({
+        spec: {
+          ...spec,
+          'x-tagGroups': [
+            // `missing` names no rendered group; `pets` resolves.
+            { name: 'Data API', tags: ['missing', 'pets'] },
+            // Both tags already claimed or unknown → section drops entirely.
+            { name: 'Empty', tags: ['pets', 'nope'] },
+            // Unnamed entries are ignored.
+            { tags: ['store'] },
+          ],
+        },
+        path: '/api',
+      }),
+    )
+    expect(ir.tagGroups).toEqual([{ name: 'Data API', groupIds: ['pets'] }])
+  })
+
+  test('omits `tagGroups` when no `x-tagGroups` entry resolves', async () => {
+    const ir = await parse(
+      OpenApi.from({
+        spec: { ...spec, 'x-tagGroups': [{ name: 'Ghost', tags: ['missing'] }] },
+        path: '/api',
+      }),
+    )
+    expect(ir.tagGroups).toBeUndefined()
+  })
+
+  test('excludes a tag by name, stripping its operations from the client spec', async () => {
+    const ir = await parse(OpenApi.from({ spec, path: '/api', exclude: ['store'] }))
+    expect(ir.groups.map((group) => group.name)).toEqual(['pets', 'default'])
+    const content = (ir.client as { content: Record<string, unknown> }).content
+    const paths = content['paths'] as Record<string, unknown>
+    expect(paths['/inventory']).toBeUndefined()
+    expect(paths['/pets']).toBeDefined()
+  })
+
+  test('excludes every tag an excluded `x-tagGroups` section claims', async () => {
+    const ir = await parse(
+      OpenApi.from({
+        spec: {
+          ...spec,
+          'x-tagGroups': [
+            { name: 'Data API', tags: ['pets'] },
+            { name: 'Platform API', tags: ['store'] },
+          ],
+        },
+        path: '/api',
+        exclude: ['Platform API'],
+      }),
+    )
+    expect(ir.groups.map((group) => group.name)).toEqual(['pets', 'default'])
+    expect(ir.tagGroups).toEqual([{ name: 'Data API', groupIds: ['pets'] }])
+    const content = (ir.client as { content: Record<string, unknown> }).content
+    expect((content['paths'] as Record<string, unknown>)['/inventory']).toBeUndefined()
+  })
+
+  test('keeps other methods on a path shared with an excluded tag', async () => {
+    const sharedSpec = {
+      openapi: '3.1.0',
+      info: { title: 'Shared', version: '1.0.0' },
+      paths: {
+        '/shared': {
+          get: { operationId: 'readShared', tags: ['a'], responses: { '200': {} } },
+          post: { operationId: 'writeShared', tags: ['b'], responses: { '201': {} } },
+        },
+      },
+    }
+    const ir = await parse(OpenApi.from({ spec: sharedSpec, path: '/api', exclude: ['a'] }))
+    expect(ir.groups.map((group) => group.name)).toEqual(['b'])
+    const content = (ir.client as { content: Record<string, unknown> }).content
+    const shared = (content['paths'] as Record<string, Record<string, unknown>>)['/shared']
+    expect(shared?.['get']).toBeUndefined()
+    expect(shared?.['post']).toBeDefined()
+  })
+
+  test('ignores exclude names matching nothing', async () => {
+    const ir = await parse(OpenApi.from({ spec, path: '/api', exclude: ['Ghost'] }))
+    expect(ir.groups.map((group) => group.name)).toEqual(['pets', 'store', 'default'])
+  })
+
   test('inlines remote specs with relative servers for the API client', async () => {
     const fetch_ = globalThis.fetch
     const remoteSpec = {

--- a/src/internal/openapi/parser.ts
+++ b/src/internal/openapi/parser.ts
@@ -47,6 +47,13 @@ export type Ir = {
   /** Operations grouped by category (tag or path segment). */
   groups: IrGroup[]
   /**
+   * Named sections of categories from `x-tagGroups` (Redoc convention), used to
+   * nest sidebar groups under section headers (e.g. `Data API`, `Platform
+   * API`). Present only when the document declares at least one group that
+   * resolves to a rendered category; navigation-only — pages stay per-category.
+   */
+  tagGroups?: IrTagGroup[] | undefined
+  /**
    * Doc-only "trait" pages: tags marked `x-traitTag: true` (Redoc convention),
    * which carry Markdown `description` content but no operations. The standalone
    * handler renders each as a guide page nested under `Introduction`.
@@ -88,6 +95,13 @@ export type IrGroup = {
   description?: string | undefined
   /** Operations belonging to this category. */
   operations: IrOperation[]
+}
+
+export type IrTagGroup = {
+  /** Display name of the section (e.g. `Data API`). */
+  name: string
+  /** Ids of the categories in this section, in authored order. */
+  groupIds: string[]
 }
 
 export type IrOperation = {
@@ -197,6 +211,11 @@ type Document = {
     'x-subtitle'?: string
     'x-parent'?: string
   }[]
+  /**
+   * Redoc convention: named sections of tags, rendered as sidebar section
+   * headers with the tags' groups nested inside.
+   */
+  'x-tagGroups'?: { name?: string; tags?: string[] }[]
   paths?: Record<string, PathItem>
   /**
    * OpenAPI 3.1 outbound webhook deliveries. Keyed by event name (an arbitrary
@@ -297,7 +316,13 @@ export async function parse(config: OpenApi.Config, options: parse.Options = {})
 
   const securitySchemes = document.components?.securitySchemes ?? {}
 
-  const { groups, injections } = await buildGroups(document, { baseUrl: openrpcBaseUrl })
+  const built = await buildGroups(document, { baseUrl: openrpcBaseUrl })
+  const { groups, tagGroups, excluded } = applyExclusions(
+    built.groups,
+    buildTagGroups(document, built.groups),
+    config.exclude,
+  )
+  const injections = built.injections
 
   // Inject JSON-RPC examples onto the host operation in the spec the
   // interactive client loads, so each "Try" can preselect its method's
@@ -307,14 +332,24 @@ export async function parse(config: OpenApi.Config, options: parse.Options = {})
   for (const injection of injections)
     injectRpcExamples(specification as Record<string, unknown>, injection)
 
+  // Excluded operations are stripped from the client spec too (forcing inline
+  // for URL specs), so the interactive client's own navigation can't leak
+  // them. Strip a clone: the input `specification` may be a caller-owned
+  // object also served elsewhere (e.g. `/openapi.json`), which must keep the
+  // excluded operations.
+  const clientSpecification = (
+    excluded.length > 0 ? structuredClone(specification) : specification
+  ) as Record<string, unknown>
+  stripOperations(clientSpecification, excluded)
+
   const shouldInlineClientSpec =
-    injections.length > 0 || (isUrl && shouldNormalizeClientServers(document, servers))
-  if (shouldInlineClientSpec) setClientServers(specification as Record<string, unknown>, servers)
+    injections.length > 0 ||
+    excluded.length > 0 ||
+    (isUrl && shouldNormalizeClientServers(document, servers))
+  if (shouldInlineClientSpec) setClientServers(clientSpecification, servers)
 
   const client =
-    isUrl && !shouldInlineClientSpec
-      ? { url: spec as string }
-      : { content: specification as Record<string, unknown> }
+    isUrl && !shouldInlineClientSpec ? { url: spec as string } : { content: clientSpecification }
 
   return {
     path: config.path ?? '/',
@@ -326,9 +361,37 @@ export async function parse(config: OpenApi.Config, options: parse.Options = {})
     },
     servers,
     groups,
+    ...(tagGroups ? { tagGroups } : {}),
     traits: buildTraits(document),
     securitySchemes,
   }
+}
+
+/**
+ * Resolves `x-tagGroups` entries against the built categories. Tags that don't
+ * resolve to a rendered category are dropped; a category claimed by multiple
+ * sections stays with the first (pages are per-category, so one sidebar home).
+ * Returns `undefined` when nothing resolves, so the sidebar stays flat.
+ */
+function buildTagGroups(document: Document, groups: IrGroup[]): IrTagGroup[] | undefined {
+  const entries = document['x-tagGroups']
+  if (!entries || entries.length === 0) return undefined
+
+  const idByName = new Map(groups.map((group) => [group.name, group.id]))
+  const claimed = new Set<string>()
+  const tagGroups: IrTagGroup[] = []
+  for (const entry of entries) {
+    if (!entry?.name) continue
+    const groupIds: string[] = []
+    for (const tag of entry.tags ?? []) {
+      const id = idByName.get(tag)
+      if (!id || claimed.has(id)) continue
+      claimed.add(id)
+      groupIds.push(id)
+    }
+    if (groupIds.length > 0) tagGroups.push({ name: entry.name, groupIds })
+  }
+  return tagGroups.length > 0 ? tagGroups : undefined
 }
 
 /**
@@ -356,6 +419,78 @@ function injectRpcExamples(specification: Record<string, unknown>, injection: Rp
   if (!content['application/json']) content['application/json'] = {}
   const media = content['application/json']
   media['examples'] = { ...(media['examples'] as Record<string, unknown>), ...injection.examples }
+}
+
+/** An operation removed by `exclude`, identified for stripping from the client spec. */
+type ExcludedOperation = { method: string; path: string; isWebhook: boolean }
+
+/**
+ * Applies the config `exclude` list: a name matching an `x-tagGroups` section
+ * excludes every category it claims; a name matching a category (tag) excludes
+ * that category. Excluded categories are dropped from `groups`, pruned from
+ * `tagGroups` (emptied sections are removed), and their operations returned
+ * for stripping from the client spec. Unmatched names are ignored.
+ */
+function applyExclusions(
+  groups: IrGroup[],
+  tagGroups: IrTagGroup[] | undefined,
+  exclude: readonly string[] | undefined,
+): { groups: IrGroup[]; tagGroups: IrTagGroup[] | undefined; excluded: ExcludedOperation[] } {
+  const names = new Set(exclude ?? [])
+  if (names.size === 0) return { groups, tagGroups, excluded: [] }
+
+  const excludedIds = new Set<string>()
+  for (const tagGroup of tagGroups ?? [])
+    if (names.has(tagGroup.name)) for (const id of tagGroup.groupIds) excludedIds.add(id)
+  for (const group of groups) if (names.has(group.name)) excludedIds.add(group.id)
+  if (excludedIds.size === 0) return { groups, tagGroups, excluded: [] }
+
+  const excluded = groups
+    .filter((group) => excludedIds.has(group.id))
+    .flatMap((group) =>
+      group.operations.map((operation) => ({
+        method: operation.method,
+        path: operation.path,
+        isWebhook: operation.isWebhook ?? false,
+      })),
+    )
+  const prunedTagGroups = (tagGroups ?? [])
+    .filter((tagGroup) => !names.has(tagGroup.name))
+    .map((tagGroup) => ({
+      ...tagGroup,
+      groupIds: tagGroup.groupIds.filter((id) => !excludedIds.has(id)),
+    }))
+    .filter((tagGroup) => tagGroup.groupIds.length > 0)
+  return {
+    groups: groups.filter((group) => !excludedIds.has(group.id)),
+    tagGroups: prunedTagGroups.length > 0 ? prunedTagGroups : undefined,
+    excluded,
+  }
+}
+
+/**
+ * Deletes excluded operations from the (upgraded) spec handed to the
+ * interactive client. A path item left with no methods is removed entirely.
+ */
+function stripOperations(
+  specification: Record<string, unknown>,
+  excluded: ExcludedOperation[],
+): void {
+  // JSON-RPC operations expanded from one host operation share its path+method.
+  const seen = new Set<string>()
+  for (const operation of excluded) {
+    const key = `${operation.isWebhook}:${operation.method}:${operation.path}`
+    if (seen.has(key)) continue
+    seen.add(key)
+
+    const target = specification[operation.isWebhook ? 'webhooks' : 'paths'] as
+      | Record<string, Record<string, unknown>>
+      | undefined
+    const item = target?.[operation.path]
+    if (!item || typeof item !== 'object') continue
+    delete item[operation.method.toLowerCase()]
+    if (!methods.some((method) => method in item)) delete target[operation.path]
+  }
 }
 
 /** Builds doc-only "trait" pages from tags marked `x-traitTag: true`. */

--- a/src/internal/openapi/registry.ts
+++ b/src/internal/openapi/registry.ts
@@ -53,8 +53,9 @@ export function sidebars(
     const entry = config?.openapi?.find((entry) => entry.path === path)
     const collapsed = entry?.sidebar?.collapsed
     const intro = entry?.sidebar?.intro
+    const flatten = entry?.sidebar?.flatten
     const backLink = entry?.sidebar?.backLink ?? true
-    result[path] = { backLink, items: Sidebar.toSidebar(ir, { collapsed, intro }) }
+    result[path] = { backLink, items: Sidebar.toSidebar(ir, { collapsed, intro, flatten }) }
   }
   return result
 }

--- a/src/internal/openapi/sidebar.test.ts
+++ b/src/internal/openapi/sidebar.test.ts
@@ -94,6 +94,100 @@ describe('toSidebar', () => {
     expect((sidebar[1] as { collapsed: boolean }).collapsed).toBe(true)
   })
 
+  test('nests claimed groups under static section headers from tagGroups', () => {
+    const sectioned: Ir = {
+      ...ir,
+      groups: [
+        ...ir.groups,
+        {
+          id: 'platform',
+          name: 'Platform',
+          operations: [
+            {
+              id: 'listkeys',
+              method: 'GET',
+              path: '/keys',
+              summary: 'List keys',
+              parameters: [],
+              responses: [],
+            },
+          ],
+        },
+      ],
+      tagGroups: [
+        { name: 'Data API', groupIds: ['pets'] },
+        { name: 'Platform API', groupIds: ['platform'] },
+      ],
+    }
+    const sidebar = toSidebar(sectioned, { collapsed: true })
+    expect(sidebar.map((item) => item.text)).toEqual(['Introduction', 'Data API', 'Platform API'])
+    // Sections are static headers (not collapsible); nested groups keep the
+    // `collapsed` behavior.
+    const section = sidebar[1] as {
+      collapsed?: boolean
+      items: { text?: string; collapsed?: boolean }[]
+    } // prettier-ignore
+    expect(section.collapsed).toBeUndefined()
+    expect(section.items.map((item) => item.text)).toEqual(['pets'])
+    expect(section.items[0]?.collapsed).toBe(true)
+  })
+
+  test('appends groups unclaimed by tagGroups at the top level', () => {
+    const sidebar = toSidebar({
+      ...ir,
+      groups: [
+        ...ir.groups,
+        { id: 'internal', name: 'Internal', operations: ir.groups[0]?.operations ?? [] },
+      ],
+      tagGroups: [{ name: 'Data API', groupIds: ['pets'] }],
+    })
+    expect(sidebar.map((item) => item.text)).toEqual(['Introduction', 'Data API', 'Internal'])
+  })
+
+  test('flattened tag groups render their categories in place at the top level', () => {
+    const sectioned: Ir = {
+      ...ir,
+      groups: [
+        ...ir.groups,
+        {
+          id: 'platform',
+          name: 'Platform',
+          operations: [
+            {
+              id: 'listkeys',
+              method: 'GET',
+              path: '/keys',
+              summary: 'List keys',
+              parameters: [],
+              responses: [],
+            },
+          ],
+        },
+      ],
+      tagGroups: [
+        { name: 'Data API', groupIds: ['pets'] },
+        { name: 'Platform API', groupIds: ['platform'] },
+      ],
+    }
+    const sidebar = toSidebar(sectioned, { flatten: ['Data API'] })
+    // `pets` renders top-level where its section would sit; `Platform API`
+    // keeps its section header.
+    expect(sidebar.map((item) => item.text)).toEqual(['Introduction', 'pets', 'Platform API'])
+    const pets = sidebar[1] as { collapsed?: boolean }
+    const section = sidebar[2] as { collapsed?: boolean; items: { text?: string }[] }
+    expect(pets.collapsed).toBe(false)
+    expect(section.collapsed).toBeUndefined()
+    expect(section.items.map((item) => item.text)).toEqual(['Platform'])
+  })
+
+  test('ignores flatten names that match no tag group', () => {
+    const sidebar = toSidebar(
+      { ...ir, tagGroups: [{ name: 'Data API', groupIds: ['pets'] }] },
+      { flatten: ['Nope'] },
+    )
+    expect(sidebar.map((item) => item.text)).toEqual(['Introduction', 'Data API'])
+  })
+
   test('injects groupExtras after a group Overview link', () => {
     const sidebar = toSidebar(ir, {
       groupExtras: new Map([['pets', [{ text: 'Rate limits', link: '/api/rate-limits' }]]]),

--- a/src/internal/openapi/sidebar.ts
+++ b/src/internal/openapi/sidebar.ts
@@ -32,7 +32,9 @@ export function methodVariant(method: string): BadgeVariant {
  * OpenAPI IR.
  *
  * Each category is its own page; operation links are in-page anchors on that
- * page (`/api/{group}#{operation}`).
+ * page (`/api/{group}#{operation}`). When the IR carries `tagGroups`, claimed
+ * categories nest under static section headers; unclaimed ones follow at the
+ * top level so no category silently disappears.
  */
 export function toSidebar(ir: Ir, options: toSidebar.Options = {}): SidebarItem<true>[] {
   // Strip a trailing slash so a root mount (`/`) doesn't yield `//group`.
@@ -63,28 +65,48 @@ export function toSidebar(ir: Ir, options: toSidebar.Options = {}): SidebarItem<
   // active group still auto-expands at render). `Introduction` is unaffected.
   const groupCollapsed = options.collapsed ?? false
 
+  const groupItem = (group: Ir['groups'][number]): SidebarItem<true> => ({
+    text: group.name,
+    collapsed: groupCollapsed,
+    items: [
+      // An "Overview" entry links to the category itself; the top-level item
+      // is a non-link header so its label doesn't compete with the operations.
+      { text: 'Overview', link: groupLink(group.id) },
+      ...((groupExtras.get(group.id) ?? []) as SidebarItem<true>[]),
+      ...group.operations.map((operation) => ({
+        text: operation.summary || `${operation.method} ${operation.path}`,
+        link: operationLink(operation, group.id),
+        // Webhooks are inbound deliveries, not callable endpoints — show a
+        // webhook glyph instead of the HTTP method (which is always POST).
+        badge:
+          operation.isWebhook && webhookIcon
+            ? { icon: webhookIcon, variant: methodVariant(operation.method) }
+            : { text: operation.method, variant: methodVariant(operation.method) },
+      })),
+    ],
+  })
+
+  const tagGroups = ir.tagGroups ?? []
+  if (tagGroups.length === 0) return [introduction, ...ir.groups.map(groupItem)]
+
+  // `x-tagGroups` sections render as static headers (no `collapsed`, so not
+  // collapsible); the per-category `collapsed` behavior applies unchanged.
+  // Sections named in `flatten` spread their categories in place instead.
+  const flatten = new Set(options.flatten ?? [])
+  const groupById = new Map(ir.groups.map((group) => [group.id, group]))
+  const claimed = new Set(tagGroups.flatMap((tagGroup) => tagGroup.groupIds))
+  const sections = tagGroups.flatMap((tagGroup) => {
+    const items = tagGroup.groupIds.flatMap((id) => {
+      const group = groupById.get(id)
+      return group ? [groupItem(group)] : []
+    })
+    if (flatten.has(tagGroup.name)) return items
+    return [{ text: tagGroup.name, items }]
+  })
   return [
     introduction,
-    ...ir.groups.map((group) => ({
-      text: group.name,
-      collapsed: groupCollapsed,
-      items: [
-        // An "Overview" entry links to the category itself; the top-level item
-        // is a non-link header so its label doesn't compete with the operations.
-        { text: 'Overview', link: groupLink(group.id) },
-        ...((groupExtras.get(group.id) ?? []) as SidebarItem<true>[]),
-        ...group.operations.map((operation) => ({
-          text: operation.summary || `${operation.method} ${operation.path}`,
-          link: operationLink(operation, group.id),
-          // Webhooks are inbound deliveries, not callable endpoints — show a
-          // webhook glyph instead of the HTTP method (which is always POST).
-          badge:
-            operation.isWebhook && webhookIcon
-              ? { icon: webhookIcon, variant: methodVariant(operation.method) }
-              : { text: operation.method, variant: methodVariant(operation.method) },
-        })),
-      ],
-    })),
+    ...sections,
+    ...ir.groups.filter((group) => !claimed.has(group.id)).map(groupItem),
   ]
 }
 
@@ -99,5 +121,10 @@ export declare namespace toSidebar {
      * auto-expands). `Introduction` is unaffected. @default false
      */
     collapsed?: boolean | undefined
+    /**
+     * Names of `x-tagGroups` sections whose categories render as top-level
+     * items (in place) instead of nesting under the section header.
+     */
+    flatten?: readonly string[] | undefined
   }
 }

--- a/src/server/openapi/state.ts
+++ b/src/server/openapi/state.ts
@@ -57,6 +57,7 @@ export async function prepare(
   const bottom = config.sidebar?.bottom ?? []
   const intro = [...traitIntro, ...(config.sidebar?.intro ?? [])]
   const collapsed = config.sidebar?.collapsed ?? false
+  const flatten = config.sidebar?.flatten
   const newGroups = [...extraGroups].map(([name, items]) => ({
     text: name,
     collapsed,
@@ -64,7 +65,7 @@ export async function prepare(
   }))
   const sidebar = [
     ...top,
-    ...Sidebar.toSidebar(ir, { intro, groupExtras, collapsed }),
+    ...Sidebar.toSidebar(ir, { intro, groupExtras, collapsed, flatten }),
     ...newGroups,
     ...bottom,
   ]


### PR DESCRIPTION
Add OpenAPI tag-group sections plus `sidebar.flatten` and `exclude` controls, so references can group, flatten, or hide API surfaces without changing the source spec.
