### PR TITLE
ci: don't run prerelease/release jobs on forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,11 +11,13 @@ concurrency:
 jobs:
   verify:
     name: Verify
+    if: ${{ github.repository_owner == 'wevm' }}
     uses: ./.github/workflows/verify.yml
     secrets: inherit
 
   build-twoslash-rust:
     name: Build twoslash-rust
+    if: ${{ github.repository_owner == 'wevm' }}
     needs: verify
     strategy:
       fail-fast: false
@@ -58,6 +60,7 @@ jobs:
 
   changesets:
     name: Changesets
+    if: ${{ github.repository_owner == 'wevm' }}
     needs: build-twoslash-rust
     permissions:
       contents: write

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 jobs:
   # Fast path: publish vocs and create-vocs immediately (no Rust build needed)
   publish-core:
+    if: ${{ github.repository_owner == 'wevm' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -22,6 +23,7 @@ jobs:
 
   # Slow path: build Rust binaries then publish twoslash-rust packages
   build-twoslash-rust:
+    if: ${{ github.repository_owner == 'wevm' }}
     strategy:
       fail-fast: false
       matrix:
@@ -62,6 +64,7 @@ jobs:
           if-no-files-found: error
 
   publish-twoslash-rust:
+    if: ${{ github.repository_owner == 'wevm' }}
     needs: build-twoslash-rust
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Guard `prerelease.yml` and `main.yml` jobs with `github.repository_owner == 'wevm'` so fork pushes no longer trigger prerelease publishing and Rust matrix builds. 