### PR TITLE
Add route-aware head and sitemap config

### DIFF
--- a/site/src/pages/features/head.mdx
+++ b/site/src/pages/features/head.mdx
@@ -96,6 +96,37 @@ export default function BlogLayout({ children }: { children: ReactNode }) {
 }
 ```
 
+### Customize Generated Tags by Route
+
+Use [`titleTemplate`](/reference/site-config#titletemplate) as a function when a section needs a different title suffix:
+
+```ts [vocs.config.ts]
+import { defineConfig } from 'vocs/config'
+
+export default defineConfig({
+  titleTemplate: (path) => { // [!code focus:4]
+    if (path === '/docs' || path.startsWith('/docs/')) return '%s · Acme Docs'
+    return '%s · Acme'
+  }
+})
+```
+
+Use [`head`](/reference/site-config#head) to disable generated tags globally or per route. This is useful for evergreen docs pages where you do not want article freshness metadata:
+
+```ts [vocs.config.ts]
+import { defineConfig } from 'vocs/config'
+
+export default defineConfig({
+  head: {
+    meta: {
+      articleModifiedTime: (path) => !path.startsWith('/docs') // [!code focus]
+    }
+  }
+})
+```
+
+The same pattern works for core generated tags such as `title`, `description`, `robots`, `canonical`, `base`, and `icons`.
+
 ### Load a Third-Party Script
 
 React 19 hoists `<script async>` into `<head>` and de-duplicates it across pages, so an analytics snippet is just an element. Put it on a single page, or in the root layout to load it everywhere:
@@ -124,7 +155,7 @@ Only `async` scripts are hoisted. An inline blocking script — e.g. one that mu
 <Cards>
   <Card
     title="Site Configuration"
-    description="title, description, iconUrl, baseUrl, and ogImageUrl that drive the built-in tags."
+    description="titleTemplate, head, iconUrl, baseUrl, and ogImageUrl that drive the built-in tags."
     icon="settings"
     to="/reference/site-config"
   />

--- a/site/src/pages/reference/site-config.mdx
+++ b/site/src/pages/reference/site-config.mdx
@@ -65,7 +65,7 @@ export default defineConfig({
 
 ### `titleTemplate`
 
-- **Type:** `string`
+- **Type:** `string | ((path: string, context: { title?: string, siteTitle: string, frontmatter?: Frontmatter }) => string | undefined)`
 - **Default:** `%s – ${title}`
 
 Template used to build each page's `<title>`. Use `%s` as a placeholder for the page title.
@@ -76,6 +76,65 @@ export default defineConfig({
   titleTemplate: '%s · Acme Docs'
 })
 ```
+
+Use a function to vary the title template by route:
+
+```ts
+export default defineConfig({
+  titleTemplate: (path) => {
+    if (path === '/docs' || path.startsWith('/docs/')) return '%s · Acme Docs'
+    return '%s · Acme'
+  }
+})
+```
+
+### `head`
+
+- **Type:** `object`
+
+Controls built-in `<head>` tags. Each field accepts `boolean` or a route-aware function. Omitted fields default to `true`.
+
+```ts
+export default defineConfig({
+  head: {
+    canonical: (path) => !path.startsWith('/preview'),
+    icons: false,
+    meta: {
+      articleModifiedTime: (path) => !path.startsWith('/docs'),
+      twitterImage: false
+    }
+  }
+})
+```
+
+Available `head` fields:
+
+| Field | Tag |
+|---|---|
+| `base` | `<base>` |
+| `canonical` | `<link rel="canonical">` |
+| `description` | `<meta name="description">` |
+| `icons` | `<link rel="icon">` |
+| `robots` | `<meta name="robots">` |
+| `title` | `<title>` |
+
+Available `head.meta` fields:
+
+| Field | Tag |
+|---|---|
+| `author` | `<meta name="author">` |
+| `articleAuthor` | `<meta property="article:author">` |
+| `articleModifiedTime` | `<meta property="article:modified_time">` |
+| `ogDescription` | `<meta property="og:description">` |
+| `ogImage` | `<meta property="og:image">` |
+| `ogSiteName` | `<meta property="og:site_name">` |
+| `ogTitle` | `<meta property="og:title">` |
+| `ogType` | `<meta property="og:type">` |
+| `ogUrl` | `<meta property="og:url">` |
+| `twitterCard` | `<meta name="twitter:card">` |
+| `twitterDescription` | `<meta name="twitter:description">` |
+| `twitterImage` | `<meta property="twitter:image">` |
+| `twitterTitle` | `<meta name="twitter:title">` |
 
 ## URLs And Deployment
 
@@ -107,6 +166,35 @@ export default defineConfig({
 ```
 
 If you omit the protocol, Vocs normalizes it to `https://`.
+
+### `sitemap`
+
+- **Type:** `false | { include?: boolean | ((path: string, context: { filePath: string }) => boolean), lastmod?: boolean | ((path: string, context: { filePath: string, lastmod: string }) => boolean | string | undefined) }`
+
+Controls generated `sitemap.xml` entries. Set `sitemap` to `false` to disable generated sitemap and robots files.
+
+Use `include` to omit routes from the generated sitemap:
+
+```ts
+export default defineConfig({
+  sitemap: {
+    include: (path) => !path.startsWith('/internal')
+  }
+})
+```
+
+Use `lastmod` to omit or override `<lastmod>` per route:
+
+```ts
+export default defineConfig({
+  sitemap: {
+    lastmod: (path, { lastmod }) => {
+      if (path === '/docs' || path.startsWith('/docs/')) return false
+      return lastmod
+    }
+  }
+})
+```
 
 ### `redirects`
 

--- a/src/internal/config-serializer.test.ts
+++ b/src/internal/config-serializer.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'vitest'
+import { define } from './config.js'
+import { deserialize, serialize } from './config-serializer.js'
+
+describe('config serializer', () => {
+  test('round trips route-aware head and title callbacks', () => {
+    const config = define({
+      head: {
+        canonical: (path) => path !== '/preview',
+        meta: {
+          articleModifiedTime: (path) => !path.startsWith('/docs'),
+        },
+      },
+      titleTemplate: (path) => (path.startsWith('/docs') ? '%s · Docs' : '%s · Site'),
+    })
+
+    const result = deserialize(serialize(config))
+
+    expect(typeof result.titleTemplate).toBe('function')
+    expect(typeof result.head?.canonical).toBe('function')
+    expect(typeof result.head?.meta?.articleModifiedTime).toBe('function')
+    expect(
+      typeof result.titleTemplate === 'function' &&
+        result.titleTemplate('/docs/intro', {
+          frontmatter: undefined,
+          siteTitle: 'Docs',
+          title: 'Intro',
+        }),
+    ).toBe('%s · Docs')
+    expect(
+      typeof result.head?.canonical === 'function' &&
+        result.head.canonical('/preview', { frontmatter: undefined }),
+    ).toBe(false)
+    expect(
+      typeof result.head?.meta?.articleModifiedTime === 'function' &&
+        result.head.meta.articleModifiedTime('/docs/intro', { frontmatter: undefined }),
+    ).toBe(false)
+  })
+
+  test('round trips route-aware sitemap callbacks', () => {
+    const config = define({
+      sitemap: {
+        include: (path) => !path.startsWith('/internal'),
+        lastmod: (path, { lastmod }) => (path.startsWith('/docs') ? false : lastmod),
+      },
+    })
+
+    const result = deserialize(serialize(config))
+
+    expect(typeof result.sitemap !== 'boolean' && typeof result.sitemap?.include).toBe('function')
+    expect(typeof result.sitemap !== 'boolean' && typeof result.sitemap?.lastmod).toBe('function')
+    expect(
+      typeof result.sitemap !== 'boolean' &&
+        typeof result.sitemap?.include === 'function' &&
+        result.sitemap.include('/internal/page', { filePath: 'internal/page.mdx' }),
+    ).toBe(false)
+    expect(
+      typeof result.sitemap !== 'boolean' &&
+        typeof result.sitemap?.lastmod === 'function' &&
+        result.sitemap.lastmod('/docs/intro', {
+          filePath: 'docs/intro.mdx',
+          lastmod: '2026-01-01',
+        }),
+    ).toBe(false)
+  })
+})

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -20,6 +20,79 @@ import type { MaybePartial, UnionOmit } from './types.js'
 
 export type ThemeValue<value> = { light: value; dark: value }
 
+export type RoutePredicate<context = undefined> =
+  | boolean
+  | ((
+      path: string,
+      context: context extends undefined ? { frontmatter?: Frontmatter | undefined } : context,
+    ) => boolean)
+
+export type TitleTemplate =
+  | string
+  | ((
+      path: string,
+      context: {
+        frontmatter?: Frontmatter | undefined
+        title: string | undefined
+        siteTitle: string
+      },
+    ) => string | undefined)
+
+export type HeadOptions = {
+  /** Controls the generated `<base>` tag. */
+  base?: RoutePredicate | undefined
+  /** Controls the generated canonical link tag. */
+  canonical?: RoutePredicate | undefined
+  /** Controls the generated description meta tag. */
+  description?: RoutePredicate | undefined
+  /** Controls the generated icon link tags. */
+  icons?: RoutePredicate | undefined
+  /**
+   * Controls built-in metadata tags. Set an entry to `false` to disable that tag, or use a
+   * function to enable/disable it per route.
+   */
+  meta?: {
+    author?: RoutePredicate | undefined
+    articleAuthor?: RoutePredicate | undefined
+    articleModifiedTime?: RoutePredicate | undefined
+    ogDescription?: RoutePredicate | undefined
+    ogImage?: RoutePredicate | undefined
+    ogSiteName?: RoutePredicate | undefined
+    ogTitle?: RoutePredicate | undefined
+    ogType?: RoutePredicate | undefined
+    ogUrl?: RoutePredicate | undefined
+    twitterCard?: RoutePredicate | undefined
+    twitterDescription?: RoutePredicate | undefined
+    twitterImage?: RoutePredicate | undefined
+    twitterTitle?: RoutePredicate | undefined
+  }
+  /** Controls the generated robots meta tag. */
+  robots?: RoutePredicate | undefined
+  /** Controls the generated `<title>` tag. */
+  title?: RoutePredicate | undefined
+}
+
+export type SitemapOptions = {
+  /**
+   * Controls which pages Vocs includes in the generated sitemap.
+   */
+  include?: RoutePredicate<{ filePath: string }> | undefined
+  /**
+   * Controls `<lastmod>` output. Return `false` to omit it, `true` to use Vocs' inferred date, or
+   * a string to provide a route-specific date.
+   */
+  lastmod?:
+    | boolean
+    | ((
+        path: string,
+        context: {
+          filePath: string
+          lastmod: string
+        },
+      ) => boolean | string | undefined)
+    | undefined
+}
+
 type SearchDocument = {
   category: string
   href: string
@@ -459,6 +532,10 @@ export type Config<partial extends boolean = false> = MaybePartial<
      */
     logoUrl?: string | ThemeValue<string> | undefined
     /**
+     * Controls generated `<head>` tags.
+     */
+    head?: HeadOptions | undefined
+    /**
      * Markdown configuration.
      */
     markdown?: MdxRollup.Options | undefined
@@ -598,6 +675,10 @@ export type Config<partial extends boolean = false> = MaybePartial<
      */
     search: MaybePartial<partial, SearchOptions>
     /**
+     * Controls generated `sitemap.xml` entries.
+     */
+    sitemap?: false | SitemapOptions | undefined
+    /**
      * Navigation displayed on the sidebar.
      */
     sidebar?:
@@ -632,7 +713,7 @@ export type Config<partial extends boolean = false> = MaybePartial<
      *
      * @default `%s – ${title}`
      */
-    titleTemplate: string
+    titleTemplate: TitleTemplate
     /**
      * Navigation displayed on the top.
      */
@@ -760,6 +841,7 @@ export function define(config: define.Options = {}): Config {
     codeHighlight,
     colorScheme = 'light dark',
     description,
+    head,
     iconUrl,
     logoUrl,
     markdown,
@@ -772,6 +854,7 @@ export function define(config: define.Options = {}): Config {
     rootDir = process.cwd(),
     search,
     sidebar,
+    sitemap,
     socials,
     srcDir = 'src',
     title = 'Docs',
@@ -854,6 +937,7 @@ export function define(config: define.Options = {}): Config {
     _localRetriever: existingLocal ?? localResolved?.private,
     _retriever: existingRetriever ?? retrieverResolved?.private,
     groupIcons: config.groupIcons,
+    head,
     iconUrl,
     logoUrl,
     markdown,
@@ -916,6 +1000,7 @@ export function define(config: define.Options = {}): Config {
       }
     })(),
     sidebar,
+    sitemap,
     socials,
     srcDir,
     title,

--- a/src/internal/vite-plugins.test.ts
+++ b/src/internal/vite-plugins.test.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path'
 import type { ResolvedConfig } from 'vite'
 import { afterEach, describe, expect, test } from 'vitest'
 import type * as Config from './config.js'
-import { sitemap } from './vite-plugins.js'
+import { resolveSitemapInclude, resolveSitemapLastmod, sitemap } from './vite-plugins.js'
 
 const tempDirs = new Set<string>()
 
@@ -61,6 +61,93 @@ describe('sitemap', () => {
       'Sitemap: https://example.com/sitemap.xml',
     )
   })
+
+  test('supports route-aware sitemap config', async () => {
+    const fixture = await createFixture()
+    await fs.mkdir(path.join(fixture.rootDir, 'src/pages/docs'), { recursive: true })
+    await fs.writeFile(path.join(fixture.rootDir, 'src/pages/docs/index.mdx'), '# Docs\n')
+    await fs.writeFile(path.join(fixture.rootDir, 'src/pages/blog.mdx'), '# Blog\n')
+    const plugin = createSitemapPlugin(fixture.rootDir, fixture.publicDir, {
+      sitemap: {
+        include: (path) => path !== '/blog',
+        lastmod: (path, { lastmod }) => (path.startsWith('/docs') ? false : lastmod),
+      },
+    })
+
+    await plugin.writeBundle({ dir: fixture.outDir })
+
+    const sitemapXml = await fs.readFile(path.join(fixture.outDir, 'sitemap.xml'), 'utf-8')
+    expect(sitemapXml).toContain('<loc>https://example.com/docs</loc>')
+    expect(sitemapXml).not.toContain('<loc>https://example.com/blog</loc>')
+    expect(sitemapXml).not.toMatch(
+      /<url>\n\s*<loc>https:\/\/example\.com\/docs<\/loc>\n\s*<lastmod>/,
+    )
+  })
+
+  test('supports lastmod overrides', async () => {
+    const fixture = await createFixture()
+    await fs.writeFile(path.join(fixture.rootDir, 'src/pages/changelog.mdx'), '# Changelog\n')
+    const plugin = createSitemapPlugin(fixture.rootDir, fixture.publicDir, {
+      sitemap: {
+        lastmod: (path, { lastmod }) => (path === '/changelog' ? '2025-01-01' : lastmod),
+      },
+    })
+
+    await plugin.writeBundle({ dir: fixture.outDir })
+
+    const sitemapXml = await fs.readFile(path.join(fixture.outDir, 'sitemap.xml'), 'utf-8')
+    expect(sitemapXml).toMatch(
+      /<url>\n\s*<loc>https:\/\/example\.com\/changelog<\/loc>\n\s*<lastmod>2025-01-01<\/lastmod>\n\s*<\/url>/,
+    )
+  })
+
+  test('disables generated sitemap and robots files', async () => {
+    const fixture = await createFixture()
+    const plugin = createSitemapPlugin(fixture.rootDir, fixture.publicDir, { sitemap: false })
+
+    await plugin.writeBundle({ dir: fixture.outDir })
+
+    await expect(fs.access(path.join(fixture.outDir, 'sitemap.xml'))).rejects.toThrow()
+    await expect(fs.access(path.join(fixture.outDir, 'robots.txt'))).rejects.toThrow()
+  })
+})
+
+describe('sitemap config helpers', () => {
+  test('resolves include config', () => {
+    expect(resolveSitemapInclude({ sitemap: false }, '/docs', 'docs/index.mdx')).toBe(false)
+    expect(resolveSitemapInclude({ sitemap: { include: false } }, '/docs', 'docs/index.mdx')).toBe(
+      false,
+    )
+    expect(
+      resolveSitemapInclude(
+        { sitemap: { include: (path) => path.startsWith('/docs') } },
+        '/docs',
+        'docs/index.mdx',
+      ),
+    ).toBe(true)
+  })
+
+  test('resolves lastmod config', () => {
+    expect(resolveSitemapLastmod({ sitemap: false }, '/docs', 'docs/index.mdx', '2026-01-01')).toBe(
+      undefined,
+    )
+    expect(
+      resolveSitemapLastmod(
+        { sitemap: { lastmod: false } },
+        '/docs',
+        'docs/index.mdx',
+        '2026-01-01',
+      ),
+    ).toBe(undefined)
+    expect(
+      resolveSitemapLastmod(
+        { sitemap: { lastmod: () => '2025-01-01' } },
+        '/docs',
+        'docs/index.mdx',
+        '2026-01-01',
+      ),
+    ).toBe('2025-01-01')
+  })
 })
 
 async function createFixture() {
@@ -78,11 +165,16 @@ async function createFixture() {
   return { outDir, publicDir, rootDir }
 }
 
-function createSitemapPlugin(rootDir: string, publicDir: string) {
+function createSitemapPlugin(
+  rootDir: string,
+  publicDir: string,
+  config: Partial<Config.Config> = {},
+) {
   const plugin = sitemap({
     baseUrl: 'https://example.com',
     pagesDir: 'pages',
     srcDir: 'src',
+    ...config,
   } as Config.Config) as unknown as {
     configResolved(config: ResolvedConfig): void
     writeBundle(options: { dir: string }): Promise<void>

--- a/src/internal/vite-plugins.ts
+++ b/src/internal/vite-plugins.ts
@@ -383,6 +383,8 @@ export function sitemap(config: Config.Config): PluginOption {
   }
 
   async function buildSitemapContent(): Promise<string | null> {
+    if (config.sitemap === false) return null
+
     const siteUrl = getSiteUrl()
     if (!siteUrl) {
       logger.warn('Sitemap generation skipped: baseUrl is not configured', { timestamp: true })
@@ -394,32 +396,29 @@ export function sitemap(config: Config.Config): PluginOption {
 
     const runner = TaskRunner.create(20)
 
-    const urls: { loc: string; lastmod: string }[] = []
+    const urls: { lastmod: string | undefined; loc: string }[] = []
     for (const page of pages) {
       // Skip files/directories starting with _
-      if (
-        page
-          .replace(pagesDir, '')
-          .split('/')
-          .some((part) => part.startsWith('_'))
-      )
-        continue
+      const filePath = path.relative(pagesDir, page).split(path.sep).join('/')
+      if (filePath.split('/').some((part) => part.startsWith('_'))) continue
 
       runner.run(async () => {
         const pagePath =
-          page
-            .replace(pagesDir, '')
+          `/${filePath}`
             .replace(/\.(mdx?|tsx?)$/, '')
             .replace(/\/index$/, '/')
             .replace(/\/$/, '') || '/'
+
+        if (!resolveSitemapInclude(config, pagePath, filePath)) return
 
         const loc = `${siteUrl.replace(/\/$/, '')}${pagePath}`
         const gitDate = Git.getLastModified(page)
         const lastmod = gitDate
           ? (gitDate.split('T')[0] as string)
           : ((await fs.stat(page)).mtime.toISOString().split('T')[0] as string)
+        const resolvedLastmod = resolveSitemapLastmod(config, pagePath, filePath, lastmod)
 
-        urls.push({ loc, lastmod })
+        urls.push({ loc, lastmod: resolvedLastmod })
       })
     }
 
@@ -433,9 +432,11 @@ export function sitemap(config: Config.Config): PluginOption {
         [
           `${indent}<url>`,
           `${indent}${indent}<loc>${loc}</loc>`,
-          `${indent}${indent}<lastmod>${lastmod}</lastmod>`,
+          lastmod ? `${indent}${indent}<lastmod>${lastmod}</lastmod>` : undefined,
           `${indent}</url>`,
-        ].join('\n'),
+        ]
+          .filter(Boolean)
+          .join('\n'),
       )
       .join('\n')
 
@@ -459,7 +460,7 @@ export function sitemap(config: Config.Config): PluginOption {
         const siteUrl = getSiteUrl()
 
         if (req.url === '/robots.txt') {
-          if (!siteUrl) {
+          if (!siteUrl || config.sitemap === false) {
             res.statusCode = 404
             res.end('robots.txt not available: baseUrl is not configured')
             return
@@ -491,7 +492,7 @@ export function sitemap(config: Config.Config): PluginOption {
 
       const siteUrl = getSiteUrl()
       const sitemapContent = await buildSitemapContent()
-      if (!sitemapContent || !siteUrl) return
+      if (!sitemapContent || !siteUrl || config.sitemap === false) return
 
       const writes: Promise<void>[] = []
       if (!(await hasPublicFile('sitemap.xml')))
@@ -509,6 +510,32 @@ export function sitemap(config: Config.Config): PluginOption {
       await Promise.all(writes)
     },
   }
+}
+
+export function resolveSitemapInclude(
+  config: Pick<Config.Config, 'sitemap'>,
+  pagePath: string,
+  filePath: string,
+) {
+  if (config.sitemap === false) return false
+  const include = config.sitemap?.include
+  if (typeof include === 'function') return include(pagePath, { filePath })
+  return include ?? true
+}
+
+export function resolveSitemapLastmod(
+  config: Pick<Config.Config, 'sitemap'>,
+  pagePath: string,
+  filePath: string,
+  lastmod: string,
+) {
+  if (config.sitemap === false) return undefined
+  const option = config.sitemap?.lastmod
+  const resolved =
+    typeof option === 'function' ? option(pagePath, { filePath, lastmod }) : (option ?? true)
+  if (typeof resolved === 'string') return resolved
+  if (resolved === false) return undefined
+  return lastmod
 }
 
 /**

--- a/src/react/Head.test.tsx
+++ b/src/react/Head.test.tsx
@@ -1,0 +1,196 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import type * as Config from '../internal/config.js'
+import { Head, resolveHeadOption, resolveMetaOption, resolveTitleTemplate } from './Head.js'
+import * as MdxPageContext from './MdxPageContext.js'
+
+const mocks = vi.hoisted(() => ({
+  config: {} as Config.Config,
+  path: '/',
+}))
+
+vi.mock('waku', () => ({
+  useRouter: () => ({ path: mocks.path }),
+}))
+
+vi.mock('virtual:vocs/config', () => ({
+  get config() {
+    return mocks.config
+  },
+}))
+
+beforeEach(() => {
+  mocks.path = '/'
+  mocks.config = createConfig()
+})
+
+describe('Head', () => {
+  test('resolves path-aware title templates', () => {
+    const config = {
+      title: 'Acme',
+      titleTemplate: (path) => (path.startsWith('/api') ? '%s · API' : '%s · Acme'),
+    } satisfies Pick<Config.Config, 'title' | 'titleTemplate'>
+
+    expect(resolveTitleTemplate(config, '/api/reference', 'Users', undefined)).toBe('%s · API')
+    expect(resolveTitleTemplate(config, '/guide', 'Install', undefined)).toBe('%s · Acme')
+  })
+
+  test('skips title template when title already includes site title', () => {
+    const config = {
+      title: 'Acme',
+      titleTemplate: '%s · Acme',
+    } satisfies Pick<Config.Config, 'title' | 'titleTemplate'>
+
+    expect(resolveTitleTemplate(config, '/', 'Acme Docs', undefined)).toBeUndefined()
+  })
+
+  test('resolves path-aware meta config', () => {
+    const config = {
+      head: {
+        meta: {
+          articleModifiedTime: (path) => !path.startsWith('/docs'),
+          twitterImage: false,
+        },
+      },
+    } satisfies Pick<Config.Config, 'head'>
+
+    expect(resolveMetaOption(config, 'articleModifiedTime', '/docs/intro', undefined)).toBe(false)
+    expect(resolveMetaOption(config, 'articleModifiedTime', '/blog/post', undefined)).toBe(true)
+    expect(resolveMetaOption(config, 'twitterImage', '/blog/post', undefined)).toBe(false)
+    expect(resolveMetaOption(config, 'ogTitle', '/blog/post', undefined)).toBe(true)
+  })
+
+  test('resolves path-aware core head config', () => {
+    const config = {
+      head: {
+        canonical: (path) => path !== '/preview',
+        description: false,
+      },
+    } satisfies Pick<Config.Config, 'head'>
+
+    expect(resolveHeadOption(config, 'canonical', '/preview', undefined)).toBe(false)
+    expect(resolveHeadOption(config, 'canonical', '/docs', undefined)).toBe(true)
+    expect(resolveHeadOption(config, 'description', '/docs', undefined)).toBe(false)
+    expect(resolveHeadOption(config, 'title', '/docs', undefined)).toBe(true)
+  })
+
+  test('renders route-aware title and omits disabled meta tags', () => {
+    mocks.path = '/docs/intro'
+    mocks.config = createConfig({
+      head: {
+        meta: {
+          articleModifiedTime: (path) => !path.startsWith('/docs'),
+          ogImage: false,
+          twitterImage: false,
+        },
+      },
+      titleTemplate: (path) => (path.startsWith('/docs') ? '%s · Acme Docs' : '%s · Acme'),
+    })
+
+    const html = renderHead({
+      description: 'Intro page',
+      lastModified: '2026-01-01T00:00:00.000Z',
+      title: 'Intro',
+    })
+
+    expect(html).toContain('<title>Intro · Acme Docs</title>')
+    expect(html).not.toContain('article:modified_time')
+    expect(html).not.toContain('property="og:image"')
+    expect(html).not.toContain('property="twitter:image"')
+    expect(html).toContain('property="og:title" content="Intro"')
+    expect(html).toContain('name="twitter:title" content="Intro"')
+  })
+
+  test('renders default metadata when head config is omitted', () => {
+    mocks.path = '/blog/post'
+
+    const html = renderHead({
+      author: 'Jane',
+      description: 'Blog post',
+      lastModified: '2026-01-01T00:00:00.000Z',
+      title: 'Post',
+    })
+
+    expect(html).toContain('<title>Post – Acme</title>')
+    expect(html).toContain('name="author" content="Jane"')
+    expect(html).toContain('property="article:author" content="Jane"')
+    expect(html).toContain('property="article:modified_time"')
+    expect(html).toContain('property="og:image"')
+    expect(html).toContain('property="twitter:image"')
+  })
+
+  test('omits disabled core head tags', () => {
+    mocks.config = createConfig({
+      head: {
+        base: false,
+        canonical: false,
+        description: false,
+        icons: false,
+        robots: false,
+        title: false,
+      },
+      iconUrl: '/favicon.svg',
+    })
+
+    const html = renderHead({
+      description: 'Hidden description',
+      title: 'Hidden title',
+    })
+
+    expect(html).not.toContain('<title>')
+    expect(html).not.toContain('name="description"')
+    expect(html).not.toContain('<base')
+    expect(html).not.toContain('rel="canonical"')
+    expect(html).not.toContain('rel="icon"')
+    expect(html).not.toContain('name="robots"')
+    expect(html).toContain('property="og:title" content="Hidden title"')
+  })
+})
+
+function renderHead(frontmatter: Config.Frontmatter | undefined) {
+  return renderToStaticMarkup(
+    <MdxPageContext.Provider frontmatter={frontmatter}>
+      <Head />
+    </MdxPageContext.Provider>,
+  )
+}
+
+function createConfig(config: Partial<Config.Config> = {}): Config.Config {
+  const baseConfig: Config.Config = {
+    accentColor: 'light-dark(black, white)',
+    basePath: '/',
+    baseUrl: 'https://example.com',
+    cacheDir: '/tmp/vocs-cache',
+    checkDeadlinks: true,
+    codeHighlight: {
+      langAlias: {},
+      langs: [],
+      themes: { dark: 'github-dark-dimmed', light: 'github-light' },
+    },
+    colorScheme: 'light dark',
+    description: 'Acme docs',
+    feedback: false,
+    outDir: 'dist',
+    pagesDir: 'pages',
+    renderStrategy: 'dynamic',
+    rootDir: '/site',
+    search: {
+      boost: {},
+      boostDocument: () => 1,
+      combineWith: 'AND',
+      fuzzy: 0.2,
+      prefix: true,
+      query: {
+        boost: {},
+        combineWith: 'AND',
+        fuzzy: 0.2,
+        prefix: true,
+      },
+    },
+    srcDir: 'src',
+    title: 'Acme',
+    titleTemplate: '%s – Acme',
+    trailingSlashRedirect: true,
+  }
+  return { ...baseConfig, ...config }
+}

--- a/src/react/Head.tsx
+++ b/src/react/Head.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useRouter } from 'waku'
+import type * as Config from '../internal/config.js'
 import * as MdxPageContext from './MdxPageContext.js'
 import { useConfig } from './useConfig.js'
 
@@ -14,10 +15,14 @@ export function Head() {
   const staticScheme = colorScheme !== 'light dark'
 
   const title = frontmatter?.title ?? config.title
-  const titleTemplate = title.includes(config.title) ? undefined : config.titleTemplate
+  const titleTemplate = resolveTitleTemplate(config, pathname, title, frontmatter)
   const fullTitle = titleTemplate ? titleTemplate.replace('%s', title) : title
 
   const description = frontmatter?.description ?? config.description
+  const isHeadEnabled = (key: keyof Omit<Config.HeadOptions, 'meta'>) =>
+    resolveHeadOption(config, key, pathname, frontmatter)
+  const isMetaEnabled = (key: keyof NonNullable<Config.HeadOptions['meta']>) =>
+    resolveMetaOption(config, key, pathname, frontmatter)
 
   const fullPathname = basePath && basePath !== '/' ? `${basePath}${pathname}` : pathname
   const canonicalUrl = baseUrl ? `${baseUrl}${fullPathname}` : undefined
@@ -54,31 +59,35 @@ export function Head() {
       <meta name="color-scheme" content={colorScheme} />
 
       {/* Robots  */}
-      <meta
-        name="robots"
-        content={
-          frontmatter?.robots ?? (import.meta.env.PROD ? 'index, follow' : 'noindex, nofollow')
-        }
-      />
+      {isHeadEnabled('robots') && (
+        <meta
+          name="robots"
+          content={
+            frontmatter?.robots ?? (import.meta.env.PROD ? 'index, follow' : 'noindex, nofollow')
+          }
+        />
+      )}
 
       {/* Title & Description */}
-      {fullTitle && <title key="title">{fullTitle}</title>}
-      {description && <meta name="description" content={description} />}
+      {fullTitle && isHeadEnabled('title') && <title key="title">{fullTitle}</title>}
+      {description && isHeadEnabled('description') && (
+        <meta name="description" content={description} />
+      )}
 
       {/* Base URL */}
-      {baseUrl && <base href={baseUrl} />}
+      {baseUrl && isHeadEnabled('base') && <base href={baseUrl} />}
 
       {/* Canonical */}
-      {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
+      {canonicalUrl && isHeadEnabled('canonical') && <link rel="canonical" href={canonicalUrl} />}
 
       {/* Icons */}
-      {iconUrl && typeof iconUrl === 'string' && (
+      {iconUrl && typeof iconUrl === 'string' && isHeadEnabled('icons') && (
         <link rel="icon" href={iconUrl} type={getIconType(iconUrl)} />
       )}
-      {iconUrl && typeof iconUrl !== 'string' && (
+      {iconUrl && typeof iconUrl !== 'string' && isHeadEnabled('icons') && (
         <link rel="icon" href={iconUrl.light} type={getIconType(iconUrl.light)} />
       )}
-      {iconUrl && typeof iconUrl !== 'string' && (
+      {iconUrl && typeof iconUrl !== 'string' && isHeadEnabled('icons') && (
         <link
           rel="icon"
           href={iconUrl.dark}
@@ -88,29 +97,78 @@ export function Head() {
       )}
 
       {/* Standard SEO */}
-      {frontmatter?.author && <meta name="author" content={frontmatter.author} />}
+      {frontmatter?.author && isMetaEnabled('author') && (
+        <meta name="author" content={frontmatter.author} />
+      )}
 
       {/* Open Graph */}
-      <meta property="og:type" content="website" />
-      {title && <meta property="og:title" content={title} />}
-      {config.title && <meta property="og:site_name" content={config.title} />}
-      {baseUrl && <meta property="og:url" content={canonicalUrl ?? baseUrl} />}
-      {description && <meta property="og:description" content={description} />}
-      {ogImage && <meta property="og:image" content={ogImage} />}
+      {isMetaEnabled('ogType') && <meta property="og:type" content="website" />}
+      {title && isMetaEnabled('ogTitle') && <meta property="og:title" content={title} />}
+      {config.title && isMetaEnabled('ogSiteName') && (
+        <meta property="og:site_name" content={config.title} />
+      )}
+      {baseUrl && isMetaEnabled('ogUrl') && (
+        <meta property="og:url" content={canonicalUrl ?? baseUrl} />
+      )}
+      {description && isMetaEnabled('ogDescription') && (
+        <meta property="og:description" content={description} />
+      )}
+      {ogImage && isMetaEnabled('ogImage') && <meta property="og:image" content={ogImage} />}
 
       {/* Article metadata */}
-      {frontmatter?.author && <meta property="article:author" content={frontmatter.author} />}
-      {frontmatter?.lastModified && (
+      {frontmatter?.author && isMetaEnabled('articleAuthor') && (
+        <meta property="article:author" content={frontmatter.author} />
+      )}
+      {frontmatter?.lastModified && isMetaEnabled('articleModifiedTime') && (
         <meta property="article:modified_time" content={frontmatter.lastModified} />
       )}
 
       {/* Twitter */}
-      <meta name="twitter:card" content="summary_large_image" />
-      {title && <meta name="twitter:title" content={title} />}
-      {description && <meta name="twitter:description" content={description} />}
-      {ogImage && <meta property="twitter:image" content={ogImage} />}
+      {isMetaEnabled('twitterCard') && <meta name="twitter:card" content="summary_large_image" />}
+      {title && isMetaEnabled('twitterTitle') && <meta name="twitter:title" content={title} />}
+      {description && isMetaEnabled('twitterDescription') && (
+        <meta name="twitter:description" content={description} />
+      )}
+      {ogImage && isMetaEnabled('twitterImage') && (
+        <meta property="twitter:image" content={ogImage} />
+      )}
     </>
   )
+}
+
+export function resolveTitleTemplate(
+  config: Pick<Config.Config, 'title' | 'titleTemplate'>,
+  path: string,
+  title: string | undefined,
+  frontmatter: Config.Frontmatter | undefined,
+) {
+  const titleTemplate =
+    typeof config.titleTemplate === 'function'
+      ? config.titleTemplate(path, { frontmatter, siteTitle: config.title, title })
+      : config.titleTemplate
+  return title?.includes(config.title) ? undefined : titleTemplate
+}
+
+export function resolveHeadOption(
+  config: Pick<Config.Config, 'head'>,
+  key: keyof Omit<Config.HeadOptions, 'meta'>,
+  path: string,
+  frontmatter: Config.Frontmatter | undefined,
+) {
+  const option = config.head?.[key]
+  if (typeof option === 'function') return option(path, { frontmatter })
+  return option ?? true
+}
+
+export function resolveMetaOption(
+  config: Pick<Config.Config, 'head'>,
+  key: keyof NonNullable<Config.HeadOptions['meta']>,
+  path: string,
+  frontmatter: Config.Frontmatter | undefined,
+) {
+  const option = config.head?.meta?.[key]
+  if (typeof option === 'function') return option(path, { frontmatter })
+  return option ?? true
 }
 
 function getIconType(iconUrl: string) {


### PR DESCRIPTION
## Motivation

Sites need route-specific control over generated SEO metadata and sitemap entries without patching Vocs internals.

## Summary

- Add route-aware `titleTemplate` callbacks.
- Add `head` controls for generated title, description, robots, canonical, base, icon, Open Graph, Twitter, and article tags.
- Add `sitemap` controls for disabling generation, filtering routes, and controlling `<lastmod>` output.
- Document the new config options and route-specific recipes.

## Key design considerations

- Existing behavior remains the default when options are omitted.
- Route callbacks use serializable config functions like existing dynamic config options.
- Sitemap controls apply before generated XML is written, avoiding post-build string rewrites.
