### PR TITLE
perf: shrink serverless server output

### DIFF
--- a/.changeset/shiny-parrots-tap.md
+++ b/.changeset/shiny-parrots-tap.md
@@ -1,0 +1,5 @@
+---
+'vocs': patch
+---
+
+Reduced serverless bundle size: search indexes are emitted only into client output, and the AI search manifest and Waku build metadata are stored as gzipped sidecars.

--- a/src/internal/search.ts
+++ b/src/internal/search.ts
@@ -1,4 +1,3 @@
-import * as crypto from 'node:crypto'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import GithubSlugger from 'github-slugger'
@@ -235,20 +234,6 @@ export namespace SearchIndex {
       config?: Config.Config
       filePath: string
     }
-  }
-
-  /**
-   * Save a search index to a JSON file.
-   * Returns the hash used in the filename for cache busting.
-   */
-  export function saveToFile(index: SearchIndex, dir: string): string {
-    const json = index.toJSON()
-    const hash = crypto.createHash('md5').update(JSON.stringify(json)).digest('hex').slice(0, 12)
-
-    fs.mkdirSync(dir, { recursive: true })
-    fs.writeFileSync(path.join(dir, `search-index-${hash}.json`), JSON.stringify(json), 'utf-8')
-
-    return hash
   }
 
   /**

--- a/src/internal/vite-plugins.ts
+++ b/src/internal/vite-plugins.ts
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
+import { gzipSync } from 'node:zlib'
 import mdxPlugin from '@mdx-js/rollup'
 import tailwindcss, { type PluginOptions as TailwindOptions } from '@tailwindcss/vite'
 import type { PluginOption, ResolvedConfig, Rolldown, ViteDevServer } from 'vite'
@@ -654,6 +655,7 @@ export function search(config: Config.Config): PluginOption {
 
   let indexPromise: Promise<SearchIndex.SearchIndex> | undefined
   let indexHash: string | undefined
+  let indexJson: string | undefined
   let server: ViteDevServer | undefined
   let mode: 'development' | 'production' = 'development'
   const fileIds = new Map<string, string[]>()
@@ -741,7 +743,12 @@ export function search(config: Config.Config): PluginOption {
       // Only build index in production (dev builds in configureServer to avoid dep optimization issues)
       // Also skip if already built (multi-environment builds call this multiple times)
       if (mode !== 'production' || indexPromise) return
-      indexPromise = buildIndex()
+      indexPromise = buildIndex().then((index) => {
+        // Hash eagerly so `load` works regardless of environment build order.
+        indexJson = JSON.stringify(index.toJSON())
+        indexHash = crypto.createHash('md5').update(indexJson).digest('hex').slice(0, 12)
+        return index
+      })
     },
     configureServer(devServer) {
       server = devServer
@@ -769,10 +776,16 @@ export function search(config: Config.Config): PluginOption {
       return `export const getSearchIndex = async () => JSON.stringify(await (await fetch("${basePath.endsWith('/') ? basePath : basePath + '/'}assets/search-index-${indexHash}.json")).json())`
     },
     async writeBundle(options) {
-      const index = await indexPromise
-      if (!index) return
+      // Only emit into the public (client) output. Server copies would bloat
+      // serverless bundles; the index is always fetched over HTTP.
+      const environment = this.environment?.name
+      if (environment && environment !== 'client') return
+      await indexPromise
+      if (!indexJson || !indexHash) return
       const outDir = options.dir ?? path.resolve(rootDir, config.outDir)
-      indexHash = SearchIndex.saveToFile(index, path.resolve(outDir, 'assets'))
+      const dir = path.resolve(outDir, 'assets')
+      await fs.mkdir(dir, { recursive: true })
+      await fs.writeFile(path.join(dir, `search-index-${indexHash}.json`), indexJson, 'utf-8')
     },
     handleHotUpdate({ file }) {
       if (!file.endsWith('.md') && !file.endsWith('.mdx')) return
@@ -899,7 +912,19 @@ export function aiSearch(config: Config.Config): PluginOption {
         // `vocs embeddings generate` from disk instead.
         if (!localEnabled || mode === 'development' || skipSeeding()) return emptyManifestModule
         const manifest = await buildManifest()
-        return `export const getAiSearchManifest = async () => ${JSON.stringify(JSON.stringify(manifest))}`
+        // Emit as a gzipped asset. Inlining the JSON into the chunk bloats
+        // server bundles (manifests can be tens of MB).
+        const ref = this.emitFile({
+          type: 'asset',
+          name: 'ai-search-manifest.json.gz',
+          source: gzipSync(JSON.stringify(manifest), { level: 9 }),
+        })
+        return `
+import { readFileSync } from 'node:fs'
+import { gunzipSync } from 'node:zlib'
+export const getAiSearchManifest = async () =>
+  gunzipSync(readFileSync(new URL(import.meta.ROLLUP_FILE_URL_${ref}))).toString('utf8')
+`
       }
 
       if (id !== resolvedVirtualModuleId) return
@@ -915,6 +940,10 @@ export function aiSearch(config: Config.Config): PluginOption {
     },
     async writeBundle(options) {
       if (!exposePublic) return
+      // Only emit into the public (client) output. Server copies would bloat
+      // serverless bundles; the index is always fetched over HTTP.
+      const environment = this.environment?.name
+      if (environment && environment !== 'client') return
       const manifest = toPublicManifest(await buildManifest())
       const json = JSON.stringify(manifest)
       const outDir = options.dir ?? path.resolve(rootDir, config.outDir)

--- a/src/waku/internal/patches/adapters/vercel-build-enhancer.ts
+++ b/src/waku/internal/patches/adapters/vercel-build-enhancer.ts
@@ -1,5 +1,6 @@
-import { cpSync, existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
+import { gzipSync } from 'node:zlib'
 import { aiUserAgents, terminalUserAgents } from '../../../../internal/markdown-negotiation.js'
 
 export type BuildOptions = {
@@ -14,6 +15,37 @@ export type BuildOptions = {
 
 function escapeRegExp(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+const buildMetadataFile = '__waku_build_metadata.js'
+
+/**
+ * Rewrites Waku's build metadata (inlined RSC payloads, can be tens of MB)
+ * into a gzipped sidecar plus a tiny loader to shrink serverless bundles.
+ */
+function compressBuildMetadata(serverDir: string) {
+  const file = path.join(serverDir, buildMetadataFile)
+  if (!existsSync(file)) return
+  const code = readFileSync(file, 'utf-8')
+  const match = code.match(/^export const buildMetadata = new Map\((.*)\);\s*$/s)
+  const json = match?.[1]
+  if (!json) return
+  try {
+    if (!Array.isArray(JSON.parse(json))) return
+  } catch {
+    return
+  }
+  const gzFile = '__waku_build_metadata.json.gz'
+  writeFileSync(path.join(serverDir, gzFile), gzipSync(json, { level: 9 }))
+  writeFileSync(
+    file,
+    [
+      `import { readFileSync } from 'node:fs';`,
+      `import { gunzipSync } from 'node:zlib';`,
+      `export const buildMetadata = new Map(JSON.parse(gunzipSync(readFileSync(new URL('./${gzFile}', import.meta.url))).toString('utf8')));`,
+      '',
+    ].join('\n'),
+  )
 }
 
 function markdownRoutes({
@@ -90,6 +122,7 @@ export default getRequestListener(
     rmSync(serverlessDir, { recursive: true, force: true })
     mkdirSync(functionDistDir, { recursive: true })
     writeFileSync(path.resolve(distDir, SERVE_JS), serveCode)
+    compressBuildMetadata(path.resolve(distDir, 'server'))
     cpSync(path.resolve(distDir, 'server'), path.join(functionDistDir, 'server'), {
       recursive: true,
     })


### PR DESCRIPTION
Server bundles no longer duplicate the search index; the AI search manifest and Waku's `__waku_build_metadata.js` are now gzipped sidecars with tiny loaders. Cuts ~100MB from viem's Vercel function output.
