### PR TITLE
feat(config): typed `head` config

### DIFF
--- a/.changeset/head-config-overrides.md
+++ b/.changeset/head-config-overrides.md
@@ -1,0 +1,5 @@
+---
+'vocs': minor
+---
+
+Added `head` config for overriding, extending, or disabling generated head tags (`meta` typed by unhead's flat schema, plus `link`/`script`/`style`; object, `false`, or per-route function), and route-aware `sitemap.include`/`sitemap.lastmod` options.

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "tailwindcss-logical": "^4.1.0",
     "tsx": "^4.21.0",
     "twoslash": "^0.3.6",
+    "unhead": "^3.1.7",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0",
     "unplugin-icons": "^22.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,6 +266,9 @@ importers:
       twoslash:
         specifier: ^0.3.6
         version: 0.3.6(typescript@6.0.2)
+      unhead:
+        specifier: ^3.1.7
+        version: 3.1.7(esbuild@0.27.2)(rolldown@1.0.2)(rollup@4.57.1)(vite@8.0.14(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.27.2))
       unified:
         specifier: ^11.0.5
         version: 11.0.5
@@ -3167,6 +3170,9 @@ packages:
     resolution: {integrity: sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==}
     engines: {node: '>=16.9.0'}
 
+  hookable@6.1.1:
+    resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -4631,6 +4637,14 @@ packages:
     resolution: {integrity: sha512-jxytwMHhsbdpBXxLAcuu0fzlQeXCNnWdDyRHpvWsUl8vd98UwYdl9YTyn8/HcpcJPC3pwUveefsa3zTxyD/ERg==}
     engines: {node: '>=20.18.1'}
 
+  unhead@3.1.7:
+    resolution: {integrity: sha512-Db1M8yQmxdzhQFMmlZ6cr/ZlpGPRabTMDPBE4GGBv69TYUNP6jV8z54H8PTU08gMsWXVtqPBs9VwCldjrqknGw==}
+    peerDependencies:
+      vite: '>=6.4.2'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
@@ -4692,6 +4706,39 @@ packages:
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
     engines: {node: '>=18.12.0'}
+
+  unplugin@3.3.0:
+    resolution: {integrity: sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@farmfe/core': '*'
+      '@rspack/core': '*'
+      bun-types-no-globals: '*'
+      esbuild: '*'
+      rolldown: '*'
+      rollup: '*'
+      unloader: '*'
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      '@farmfe/core':
+        optional: true
+      '@rspack/core':
+        optional: true
+      bun-types-no-globals:
+        optional: true
+      esbuild:
+        optional: true
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+      unloader:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -8149,6 +8196,8 @@ snapshots:
 
   hono@4.12.22: {}
 
+  hookable@6.1.1: {}
+
   html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
     dependencies:
       '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
@@ -9884,6 +9933,22 @@ snapshots:
 
   undici@7.24.0: {}
 
+  unhead@3.1.7(esbuild@0.27.2)(rolldown@1.0.2)(rollup@4.57.1)(vite@8.0.14(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.27.2)):
+    dependencies:
+      hookable: 6.1.1
+      unplugin: 3.3.0(esbuild@0.27.2)(rolldown@1.0.2)(rollup@4.57.1)(vite@8.0.14(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.27.2))
+    optionalDependencies:
+      vite: 8.0.14(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - unloader
+      - webpack
+
   unified@11.0.5:
     dependencies:
       '@types/unist': 3.0.3
@@ -9959,6 +10024,18 @@ snapshots:
       acorn: 8.15.0
       picomatch: 4.0.3
       webpack-virtual-modules: 0.6.2
+
+  unplugin@3.3.0(esbuild@0.27.2)(rolldown@1.0.2)(rollup@4.57.1)(vite@8.0.14(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.27.2)):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      esbuild: 0.27.2
+      rolldown: 1.0.2
+      rollup: 4.57.1
+      vite: 8.0.14(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      webpack: 5.104.1(esbuild@0.27.2)
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:

--- a/site/src/pages/features/head.mdx
+++ b/site/src/pages/features/head.mdx
@@ -111,21 +111,34 @@ export default defineConfig({
 })
 ```
 
-Use [`head`](/reference/site-config#head) to disable generated tags globally or per route. This is useful for evergreen docs pages where you do not want article freshness metadata:
+Use [`head`](/reference/site-config#head) to override or disable generated tags. Set a `meta` field to a value to override it, or to `false` to omit it:
 
 ```ts [vocs.config.ts]
 import { defineConfig } from 'vocs/config'
 
 export default defineConfig({
   head: {
-    meta: {
-      articleModifiedTime: (path) => !path.startsWith('/docs') // [!code focus]
-    }
+    meta: { // [!code focus:5]
+      ogType: 'article',
+      twitterCard: 'summary',
+      articleModifiedTime: false,
+    },
   }
 })
 ```
 
-The same pattern works for core generated tags such as `title`, `description`, `robots`, `canonical`, `base`, and `icons`.
+Pass a function to vary tags by route — return tags for matching paths, `false` to disable all generated tags, or `undefined` to keep the defaults:
+
+```ts [vocs.config.ts]
+import { defineConfig } from 'vocs/config'
+
+export default defineConfig({
+  head(path) { // [!code focus:4]
+    if (path.startsWith('/preview')) return false
+    if (path.startsWith('/blog')) return { meta: { ogType: 'article' } }
+  }
+})
+```
 
 ### Load a Third-Party Script
 

--- a/site/src/pages/reference/site-config.mdx
+++ b/site/src/pages/reference/site-config.mdx
@@ -90,51 +90,62 @@ export default defineConfig({
 
 ### `head`
 
-- **Type:** `object`
+- **Type:** `false | HeadTags | (path: string, context: { frontmatter }) => HeadTags | false | undefined`
 
-Controls built-in `<head>` tags. Each field accepts `boolean` or a route-aware function. Omitted fields default to `true`.
+Controls the document `<head>`. `meta` overrides or extends the generated `<meta>` tags — set a field to a value to override it, or to `false` to omit it. `link`, `script`, and `style` append tags. Set `head: false` to disable all generated tags.
 
 ```ts
 export default defineConfig({
   head: {
-    canonical: (path) => !path.startsWith('/preview'),
-    icons: false,
     meta: {
-      articleModifiedTime: (path) => !path.startsWith('/docs'),
-      twitterImage: false
-    }
+      ogType: 'article',
+      twitterCard: 'summary',
+      articleModifiedTime: false
+    },
+    link: [{ rel: 'preconnect', href: 'https://fonts.gstatic.com' }],
+    script: [{ src: 'https://analytics.example.com/script.js', async: true }]
   }
 })
 ```
 
-Available `head` fields:
+Pass a function to vary tags by route. Return tags, `false` to disable all generated tags, or `undefined` to keep the defaults:
 
-| Field | Tag |
+```ts
+export default defineConfig({
+  head(path) {
+    if (path.startsWith('/preview')) return false
+    if (path.startsWith('/blog')) return { meta: { ogType: 'article' } }
+  }
+})
+```
+
+String overrides cascade into related defaults: `title` and `meta.description` feed the `og:` and `twitter:` variants, `canonical` feeds `og:url`, and `meta.ogImage` feeds `twitter:image`. Setting a field to `false` omits only that tag.
+
+Top-level fields:
+
+| Field | Behavior |
 |---|---|
-| `base` | `<base>` |
-| `canonical` | `<link rel="canonical">` |
-| `description` | `<meta name="description">` |
-| `icons` | `<link rel="icon">` |
-| `robots` | `<meta name="robots">` |
-| `title` | `<title>` |
+| `base` | `<base>` href. Set a value to override, or `false` to omit. |
+| `canonical` | `<link rel="canonical">` href. Set a value to override, or `false` to omit. |
+| `icons` | `<link rel="icon">` tags. Set `false` to omit (values come from [`iconUrl`](#iconurl)). |
+| `link` | Additional `<link>` tags. |
+| `meta` | `<meta>` tag overrides and additions (see below). |
+| `script` | Additional `<script>` tags — external (`src`) or inline (`textContent`, or `innerHTML` for JSON-LD objects). |
+| `style` | Additional `<style>` tags (`textContent`). |
+| `title` | `<title>` text (bypasses [`titleTemplate`](#titletemplate)). Set a value to override, or `false` to omit. |
 
-Available `head.meta` fields:
+`meta` accepts any key from [unhead's flat meta schema](https://unhead.unjs.io/docs/head/api/composables/use-seo-meta): camelCase keys map to the corresponding `name` or `property` attribute (e.g. `themeColor` → `<meta name="theme-color">`, `ogImageWidth` → `<meta property="og:image:width">`), so you can also add tags Vocs doesn't generate:
 
-| Field | Tag |
-|---|---|
-| `author` | `<meta name="author">` |
-| `articleAuthor` | `<meta property="article:author">` |
-| `articleModifiedTime` | `<meta property="article:modified_time">` |
-| `ogDescription` | `<meta property="og:description">` |
-| `ogImage` | `<meta property="og:image">` |
-| `ogSiteName` | `<meta property="og:site_name">` |
-| `ogTitle` | `<meta property="og:title">` |
-| `ogType` | `<meta property="og:type">` |
-| `ogUrl` | `<meta property="og:url">` |
-| `twitterCard` | `<meta name="twitter:card">` |
-| `twitterDescription` | `<meta name="twitter:description">` |
-| `twitterImage` | `<meta property="twitter:image">` |
-| `twitterTitle` | `<meta name="twitter:title">` |
+```ts
+export default defineConfig({
+  head: {
+    meta: {
+      appleMobileWebAppTitle: 'Acme',
+      themeColor: '#161616'
+    }
+  }
+})
+```
 
 ## URLs And Deployment
 

--- a/src/internal/config-serializer.test.ts
+++ b/src/internal/config-serializer.test.ts
@@ -5,11 +5,10 @@ import { deserialize, serialize } from './config-serializer.js'
 describe('config serializer', () => {
   test('round trips route-aware head and title callbacks', () => {
     const config = define({
-      head: {
-        canonical: (path) => path !== '/preview',
-        meta: {
-          articleModifiedTime: (path) => !path.startsWith('/docs'),
-        },
+      head: (path) => {
+        if (path === '/preview') return false
+        if (path.startsWith('/blog')) return { meta: { ogType: 'article' } }
+        return undefined
       },
       titleTemplate: (path) => (path.startsWith('/docs') ? '%s · Docs' : '%s · Site'),
     })
@@ -17,8 +16,7 @@ describe('config serializer', () => {
     const result = deserialize(serialize(config))
 
     expect(typeof result.titleTemplate).toBe('function')
-    expect(typeof result.head?.canonical).toBe('function')
-    expect(typeof result.head?.meta?.articleModifiedTime).toBe('function')
+    expect(typeof result.head).toBe('function')
     expect(
       typeof result.titleTemplate === 'function' &&
         result.titleTemplate('/docs/intro', {
@@ -28,13 +26,11 @@ describe('config serializer', () => {
         }),
     ).toBe('%s · Docs')
     expect(
-      typeof result.head?.canonical === 'function' &&
-        result.head.canonical('/preview', { frontmatter: undefined }),
+      typeof result.head === 'function' && result.head('/preview', { frontmatter: undefined }),
     ).toBe(false)
     expect(
-      typeof result.head?.meta?.articleModifiedTime === 'function' &&
-        result.head.meta.articleModifiedTime('/docs/intro', { frontmatter: undefined }),
-    ).toBe(false)
+      typeof result.head === 'function' && result.head('/blog/post', { frontmatter: undefined }),
+    ).toEqual({ meta: { ogType: 'article' } })
   })
 
   test('round trips route-aware sitemap callbacks', () => {

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -5,6 +5,7 @@ import type {
   Options as MiniSearchOptions,
   SearchOptions as MiniSearchSearchOptions,
 } from 'minisearch'
+import type { Link, MetaFlat, Script, StringInnerContent, Style } from 'unhead/types'
 import type * as Changelog from './changelog.js'
 import type * as Feedback from './feedback.js'
 import * as Langs from './langs.js'
@@ -20,12 +21,7 @@ import type { MaybePartial, UnionOmit } from './types.js'
 
 export type ThemeValue<value> = { light: value; dark: value }
 
-export type RoutePredicate<context = undefined> =
-  | boolean
-  | ((
-      path: string,
-      context: context extends undefined ? { frontmatter?: Frontmatter | undefined } : context,
-    ) => boolean)
+export type RoutePredicate<context> = boolean | ((path: string, context: context) => boolean)
 
 export type TitleTemplate =
   | string
@@ -38,39 +34,41 @@ export type TitleTemplate =
       },
     ) => string | undefined)
 
-export type HeadOptions = {
-  /** Controls the generated `<base>` tag. */
-  base?: RoutePredicate | undefined
-  /** Controls the generated canonical link tag. */
-  canonical?: RoutePredicate | undefined
-  /** Controls the generated description meta tag. */
-  description?: RoutePredicate | undefined
-  /** Controls the generated icon link tags. */
-  icons?: RoutePredicate | undefined
-  /**
-   * Controls built-in metadata tags. Set an entry to `false` to disable that tag, or use a
-   * function to enable/disable it per route.
-   */
-  meta?: {
-    author?: RoutePredicate | undefined
-    articleAuthor?: RoutePredicate | undefined
-    articleModifiedTime?: RoutePredicate | undefined
-    ogDescription?: RoutePredicate | undefined
-    ogImage?: RoutePredicate | undefined
-    ogSiteName?: RoutePredicate | undefined
-    ogTitle?: RoutePredicate | undefined
-    ogType?: RoutePredicate | undefined
-    ogUrl?: RoutePredicate | undefined
-    twitterCard?: RoutePredicate | undefined
-    twitterDescription?: RoutePredicate | undefined
-    twitterImage?: RoutePredicate | undefined
-    twitterTitle?: RoutePredicate | undefined
-  }
-  /** Controls the generated robots meta tag. */
-  robots?: RoutePredicate | undefined
-  /** Controls the generated `<title>` tag. */
-  title?: RoutePredicate | undefined
+/**
+ * `<meta>` tags, keyed by unhead's flat meta schema (e.g. `ogTitle`, `twitterCard`,
+ * `themeColor`). Set a value to override the generated tag (or add a new one), or
+ * `false` to omit it.
+ */
+export type HeadMeta = {
+  [key in keyof MetaFlat]?: MetaFlat[key] | false | undefined
 }
+
+export type HeadTags = {
+  /** `<base>` href. Set a value to override, or `false` to omit. */
+  base?: string | false | undefined
+  /** `<link rel="canonical">` href. Set a value to override, or `false` to omit. */
+  canonical?: string | false | undefined
+  /** `<link rel="icon">` tags. Set `false` to omit (values come from `iconUrl`). */
+  icons?: false | undefined
+  /** Additional `<link>` tags. */
+  link?: Link[] | undefined
+  /** `<meta>` tag overrides and additions. */
+  meta?: HeadMeta | undefined
+  /** Additional `<script>` tags. */
+  script?: Script[] | undefined
+  /** Additional `<style>` tags. */
+  style?: (Style & StringInnerContent)[] | undefined
+  /** `<title>` text (bypasses `titleTemplate`). Set a value to override, or `false` to omit. */
+  title?: string | false | undefined
+}
+
+export type HeadOptions =
+  | false
+  | HeadTags
+  | ((
+      path: string,
+      context: { frontmatter?: Frontmatter | undefined },
+    ) => HeadTags | false | undefined)
 
 export type SitemapOptions = {
   /**

--- a/src/react/Head.test.tsx
+++ b/src/react/Head.test.tsx
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type * as Config from '../internal/config.js'
-import { Head, resolveHeadOption, resolveMetaOption, resolveTitleTemplate } from './Head.js'
+import { Head, resolveHead, resolveTitleTemplate } from './Head.js'
 import * as MdxPageContext from './MdxPageContext.js'
 
 const mocks = vi.hoisted(() => ({
@@ -44,61 +44,29 @@ describe('Head', () => {
     expect(resolveTitleTemplate(config, '/', 'Acme Docs', undefined)).toBeUndefined()
   })
 
-  test('resolves path-aware meta config', () => {
+  test('resolves head object config', () => {
     const config = {
-      head: {
-        meta: {
-          articleModifiedTime: (path) => !path.startsWith('/docs'),
-          twitterImage: false,
-        },
+      head: { meta: { description: 'Custom', twitterImage: false } },
+    } satisfies Pick<Config.Config, 'head'>
+
+    expect(resolveHead(config, '/docs', undefined)).toEqual({
+      meta: { description: 'Custom', twitterImage: false },
+    })
+    expect(resolveHead({}, '/docs', undefined)).toEqual({})
+  })
+
+  test('resolves path-aware head config', () => {
+    const config = {
+      head: (path) => {
+        if (path.startsWith('/preview')) return false
+        if (path.startsWith('/blog')) return { meta: { ogType: 'article' } }
+        return undefined
       },
     } satisfies Pick<Config.Config, 'head'>
 
-    expect(resolveMetaOption(config, 'articleModifiedTime', '/docs/intro', undefined)).toBe(false)
-    expect(resolveMetaOption(config, 'articleModifiedTime', '/blog/post', undefined)).toBe(true)
-    expect(resolveMetaOption(config, 'twitterImage', '/blog/post', undefined)).toBe(false)
-    expect(resolveMetaOption(config, 'ogTitle', '/blog/post', undefined)).toBe(true)
-  })
-
-  test('resolves path-aware core head config', () => {
-    const config = {
-      head: {
-        canonical: (path) => path !== '/preview',
-        description: false,
-      },
-    } satisfies Pick<Config.Config, 'head'>
-
-    expect(resolveHeadOption(config, 'canonical', '/preview', undefined)).toBe(false)
-    expect(resolveHeadOption(config, 'canonical', '/docs', undefined)).toBe(true)
-    expect(resolveHeadOption(config, 'description', '/docs', undefined)).toBe(false)
-    expect(resolveHeadOption(config, 'title', '/docs', undefined)).toBe(true)
-  })
-
-  test('renders route-aware title and omits disabled meta tags', () => {
-    mocks.path = '/docs/intro'
-    mocks.config = createConfig({
-      head: {
-        meta: {
-          articleModifiedTime: (path) => !path.startsWith('/docs'),
-          ogImage: false,
-          twitterImage: false,
-        },
-      },
-      titleTemplate: (path) => (path.startsWith('/docs') ? '%s · Acme Docs' : '%s · Acme'),
-    })
-
-    const html = renderHead({
-      description: 'Intro page',
-      lastModified: '2026-01-01T00:00:00.000Z',
-      title: 'Intro',
-    })
-
-    expect(html).toContain('<title>Intro · Acme Docs</title>')
-    expect(html).not.toContain('article:modified_time')
-    expect(html).not.toContain('property="og:image"')
-    expect(html).not.toContain('property="twitter:image"')
-    expect(html).toContain('property="og:title" content="Intro"')
-    expect(html).toContain('name="twitter:title" content="Intro"')
+    expect(resolveHead(config, '/preview/draft', undefined)).toBe(false)
+    expect(resolveHead(config, '/blog/post', undefined)).toEqual({ meta: { ogType: 'article' } })
+    expect(resolveHead(config, '/docs', undefined)).toEqual({})
   })
 
   test('renders default metadata when head config is omitted', () => {
@@ -116,17 +84,98 @@ describe('Head', () => {
     expect(html).toContain('property="article:author" content="Jane"')
     expect(html).toContain('property="article:modified_time"')
     expect(html).toContain('property="og:image"')
-    expect(html).toContain('property="twitter:image"')
+    expect(html).toContain('name="twitter:image"')
   })
 
-  test('omits disabled core head tags', () => {
+  test('renders arbitrary meta tags from unhead vocabulary', () => {
+    mocks.config = createConfig({
+      head: {
+        meta: {
+          appleMobileWebAppTitle: 'Acme',
+          ogImageWidth: 1200,
+          themeColor: '#161616',
+        },
+      },
+    })
+
+    const html = renderHead({ title: 'Post' })
+
+    expect(html).toContain('name="apple-mobile-web-app-title" content="Acme"')
+    expect(html).toContain('property="og:image:width" content="1200"')
+    expect(html).toContain('name="theme-color" content="#161616"')
+  })
+
+  test('renders link, script, and style tags', () => {
+    mocks.config = createConfig({
+      head: {
+        link: [
+          { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: 'anonymous' },
+          { rel: 'alternate', type: 'application/rss+xml', href: '/feed.xml' },
+        ],
+        script: [
+          { src: 'https://analytics.example.com/script.js', async: true },
+          { textContent: 'console.log("hi")' },
+          { type: 'application/ld+json', innerHTML: { '@type': 'WebSite', name: 'Acme' } },
+        ],
+        style: [{ textContent: ':root{--brand:#161616}' }],
+      },
+    })
+
+    const html = renderHead({ title: 'Post' })
+
+    expect(html).toContain(
+      '<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous"/>',
+    )
+    expect(html).toContain('<link rel="alternate" type="application/rss+xml" href="/feed.xml"/>')
+    expect(html).toContain('<script src="https://analytics.example.com/script.js" async="">')
+    expect(html).toContain('<script>console.log("hi")</script>')
+    expect(html).toContain(
+      '<script type="application/ld+json">{"@type":"WebSite","name":"Acme"}</script>',
+    )
+    expect(html).toContain('<style>:root{--brand:#161616}</style>')
+  })
+
+  test('overrides tag values and cascades into downstream defaults', () => {
+    mocks.config = createConfig({
+      head: {
+        canonical: 'https://example.com/custom',
+        meta: {
+          description: 'Custom description',
+          ogType: 'article',
+        },
+      },
+    })
+
+    const html = renderHead({ description: 'Frontmatter description', title: 'Post' })
+
+    expect(html).toContain('name="description" content="Custom description"')
+    expect(html).toContain('property="og:description" content="Custom description"')
+    expect(html).toContain('name="twitter:description" content="Custom description"')
+    expect(html).toContain('rel="canonical" href="https://example.com/custom"')
+    expect(html).toContain('property="og:url" content="https://example.com/custom"')
+    expect(html).toContain('property="og:type" content="article"')
+  })
+
+  test('title override bypasses title template and cascades', () => {
+    mocks.config = createConfig({ head: { title: 'Custom Title' } })
+
+    const html = renderHead({ title: 'Post' })
+
+    expect(html).toContain('<title>Custom Title</title>')
+    expect(html).toContain('property="og:title" content="Custom Title"')
+    expect(html).toContain('name="twitter:title" content="Custom Title"')
+  })
+
+  test('omits disabled tags', () => {
     mocks.config = createConfig({
       head: {
         base: false,
         canonical: false,
-        description: false,
         icons: false,
-        robots: false,
+        meta: {
+          description: false,
+          robots: false,
+        },
         title: false,
       },
       iconUrl: '/favicon.svg',
@@ -143,7 +192,47 @@ describe('Head', () => {
     expect(html).not.toContain('rel="canonical"')
     expect(html).not.toContain('rel="icon"')
     expect(html).not.toContain('name="robots"')
+    // `false` only omits the tag itself; downstream defaults remain.
     expect(html).toContain('property="og:title" content="Hidden title"')
+    expect(html).toContain('property="og:description" content="Hidden description"')
+  })
+
+  test('renders route-aware head config', () => {
+    mocks.path = '/docs/intro'
+    mocks.config = createConfig({
+      head: (path) =>
+        path.startsWith('/docs')
+          ? { meta: { articleModifiedTime: false, ogImage: false, twitterImage: false } }
+          : undefined,
+      titleTemplate: (path) => (path.startsWith('/docs') ? '%s · Acme Docs' : '%s · Acme'),
+    })
+
+    const html = renderHead({
+      description: 'Intro page',
+      lastModified: '2026-01-01T00:00:00.000Z',
+      title: 'Intro',
+    })
+
+    expect(html).toContain('<title>Intro · Acme Docs</title>')
+    expect(html).not.toContain('article:modified_time')
+    expect(html).not.toContain('property="og:image"')
+    expect(html).not.toContain('name="twitter:image"')
+    expect(html).toContain('property="og:title" content="Intro"')
+    expect(html).toContain('name="twitter:title" content="Intro"')
+  })
+
+  test('disables all generated tags with `head: false`', () => {
+    mocks.config = createConfig({ head: false, iconUrl: '/favicon.svg' })
+
+    const html = renderHead({ description: 'Hidden', title: 'Hidden' })
+
+    expect(html).not.toContain('<title>')
+    expect(html).not.toContain('name="description"')
+    expect(html).not.toContain('rel="icon"')
+    expect(html).not.toContain('og:')
+    expect(html).not.toContain('twitter:')
+    // Functional tags are unaffected.
+    expect(html).toContain('name="color-scheme"')
   })
 })
 

--- a/src/react/Head.tsx
+++ b/src/react/Head.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import type { Meta, MetaFlat } from 'unhead/types'
+import { unpackMeta } from 'unhead/utils'
 import { useRouter } from 'waku'
 import type * as Config from '../internal/config.js'
 import * as MdxPageContext from './MdxPageContext.js'
@@ -14,18 +16,31 @@ export function Head() {
 
   const staticScheme = colorScheme !== 'light dark'
 
-  const title = frontmatter?.title ?? config.title
-  const titleTemplate = resolveTitleTemplate(config, pathname, title, frontmatter)
-  const fullTitle = titleTemplate ? titleTemplate.replace('%s', title) : title
+  const resolved = resolveHead(config, pathname, frontmatter)
+  const disabled = resolved === false
+  const head = disabled ? {} : resolved
+  const meta = head.meta ?? {}
 
-  const description = frontmatter?.description ?? config.description
-  const isHeadEnabled = (key: keyof Omit<Config.HeadOptions, 'meta'>) =>
-    resolveHeadOption(config, key, pathname, frontmatter)
-  const isMetaEnabled = (key: keyof NonNullable<Config.HeadOptions['meta']>) =>
-    resolveMetaOption(config, key, pathname, frontmatter)
+  const baseTitle = frontmatter?.title ?? config.title
+  const baseDescription = frontmatter?.description ?? config.description
+
+  // String overrides cascade into downstream defaults (e.g. `description` feeds
+  // `og:description`); `false` only omits the tag itself.
+  const titleSource = typeof head.title === 'string' ? head.title : baseTitle
+  const descriptionSource =
+    typeof meta.description === 'string' ? meta.description : baseDescription
 
   const fullPathname = basePath && basePath !== '/' ? `${basePath}${pathname}` : pathname
-  const canonicalUrl = baseUrl ? `${baseUrl}${fullPathname}` : undefined
+  const canonicalDefault = baseUrl ? `${baseUrl}${fullPathname}` : undefined
+  const canonicalSource = typeof head.canonical === 'string' ? head.canonical : canonicalDefault
+
+  const fullTitle = (() => {
+    if (head.title === false) return undefined
+    // Explicit `title` bypasses `titleTemplate`.
+    if (typeof head.title === 'string') return head.title
+    const titleTemplate = resolveTitleTemplate(config, pathname, baseTitle, frontmatter)
+    return titleTemplate ? titleTemplate.replace('%s', baseTitle) : baseTitle
+  })()
 
   const ogImageTemplate = (() => {
     if (typeof ogImageUrl === 'function') return ogImageUrl(pathname, { baseUrl })
@@ -34,15 +49,46 @@ export function Head() {
     return `${baseUrl ?? ''}/api/og?title=%title&description=%description`
   })()
 
-  const ogImage = ogImageTemplate
+  const ogImageDefault = ogImageTemplate
     ? ogImageTemplate
         .replace(
           '%logo',
           `${baseUrl ?? ''}${typeof logoUrl === 'string' ? logoUrl : (logoUrl?.dark ?? '')}`,
         )
-        .replace('%title', encodeURIComponent(title ?? ''))
-        .replace('%description', encodeURIComponent(description ?? ''))
+        .replace('%title', encodeURIComponent(titleSource ?? ''))
+        .replace('%description', encodeURIComponent(descriptionSource ?? ''))
     : undefined
+  const ogImageSource = typeof meta.ogImage === 'string' ? meta.ogImage : ogImageDefault
+
+  const tag = (value: string | false | undefined, fallback: string | undefined) => {
+    if (value === false) return undefined
+    return value ?? fallback
+  }
+
+  const base = tag(head.base, baseUrl)
+  const canonical = tag(head.canonical, canonicalDefault)
+  const icons = head.icons !== false
+
+  const metaTags = unpackMeta(
+    compactMeta({
+      robots: frontmatter?.robots ?? (import.meta.env.PROD ? 'index, follow' : 'noindex, nofollow'),
+      description: baseDescription,
+      author: frontmatter?.author,
+      ogType: 'website',
+      ogTitle: titleSource,
+      ogSiteName: config.title,
+      ogUrl: baseUrl ? (canonicalSource ?? baseUrl) : undefined,
+      ogDescription: descriptionSource,
+      ogImage: ogImageDefault,
+      articleAuthor: frontmatter?.author ? [frontmatter.author] : undefined,
+      articleModifiedTime: frontmatter?.lastModified,
+      twitterCard: 'summary_large_image',
+      twitterTitle: titleSource,
+      twitterDescription: descriptionSource,
+      twitterImage: ogImageSource,
+      ...meta,
+    }) as MetaFlat,
+  ) as Meta[]
 
   return (
     <>
@@ -58,82 +104,127 @@ export function Head() {
 
       <meta name="color-scheme" content={colorScheme} />
 
-      {/* Robots  */}
-      {isHeadEnabled('robots') && (
-        <meta
-          name="robots"
-          content={
-            frontmatter?.robots ?? (import.meta.env.PROD ? 'index, follow' : 'noindex, nofollow')
-          }
-        />
-      )}
+      {!disabled && (
+        <>
+          {/* Title */}
+          {fullTitle && <title key="title">{fullTitle}</title>}
 
-      {/* Title & Description */}
-      {fullTitle && isHeadEnabled('title') && <title key="title">{fullTitle}</title>}
-      {description && isHeadEnabled('description') && (
-        <meta name="description" content={description} />
-      )}
+          {/* Base URL */}
+          {base && <base href={base} />}
 
-      {/* Base URL */}
-      {baseUrl && isHeadEnabled('base') && <base href={baseUrl} />}
+          {/* Canonical */}
+          {canonical && <link rel="canonical" href={canonical} />}
 
-      {/* Canonical */}
-      {canonicalUrl && isHeadEnabled('canonical') && <link rel="canonical" href={canonicalUrl} />}
+          {/* Icons */}
+          {icons && iconUrl && typeof iconUrl === 'string' && (
+            <link rel="icon" href={iconUrl} type={getIconType(iconUrl)} />
+          )}
+          {icons && iconUrl && typeof iconUrl !== 'string' && (
+            <link rel="icon" href={iconUrl.light} type={getIconType(iconUrl.light)} />
+          )}
+          {icons && iconUrl && typeof iconUrl !== 'string' && (
+            <link
+              rel="icon"
+              href={iconUrl.dark}
+              type={getIconType(iconUrl.dark)}
+              media="(prefers-color-scheme: dark)"
+            />
+          )}
 
-      {/* Icons */}
-      {iconUrl && typeof iconUrl === 'string' && isHeadEnabled('icons') && (
-        <link rel="icon" href={iconUrl} type={getIconType(iconUrl)} />
-      )}
-      {iconUrl && typeof iconUrl !== 'string' && isHeadEnabled('icons') && (
-        <link rel="icon" href={iconUrl.light} type={getIconType(iconUrl.light)} />
-      )}
-      {iconUrl && typeof iconUrl !== 'string' && isHeadEnabled('icons') && (
-        <link
-          rel="icon"
-          href={iconUrl.dark}
-          type={getIconType(iconUrl.dark)}
-          media="(prefers-color-scheme: dark)"
-        />
-      )}
+          {/* Meta */}
+          {metaTags.map((tag, index) => {
+            const {
+              charset: charSet,
+              content,
+              'http-equiv': httpEquiv,
+              media,
+              name,
+              property,
+            } = tag
+            return (
+              <meta
+                key={`${name ?? property ?? httpEquiv ?? charSet}-${index}`}
+                charSet={charSet}
+                httpEquiv={httpEquiv}
+                name={name}
+                property={property}
+                content={content != null ? String(content) : undefined}
+                media={media}
+              />
+            )
+          })}
 
-      {/* Standard SEO */}
-      {frontmatter?.author && isMetaEnabled('author') && (
-        <meta name="author" content={frontmatter.author} />
-      )}
+          {/* Links */}
+          {head.link?.map((tag, index) => (
+            <link
+              key={`${tag.rel}-${tag.href}-${index}`}
+              {...(toReactProps(tag) as React.JSX.IntrinsicElements['link'])}
+            />
+          ))}
 
-      {/* Open Graph */}
-      {isMetaEnabled('ogType') && <meta property="og:type" content="website" />}
-      {title && isMetaEnabled('ogTitle') && <meta property="og:title" content={title} />}
-      {config.title && isMetaEnabled('ogSiteName') && (
-        <meta property="og:site_name" content={config.title} />
-      )}
-      {baseUrl && isMetaEnabled('ogUrl') && (
-        <meta property="og:url" content={canonicalUrl ?? baseUrl} />
-      )}
-      {description && isMetaEnabled('ogDescription') && (
-        <meta property="og:description" content={description} />
-      )}
-      {ogImage && isMetaEnabled('ogImage') && <meta property="og:image" content={ogImage} />}
+          {/* Scripts */}
+          {head.script?.map((tag, index) => {
+            const props = toReactProps(tag) as React.JSX.IntrinsicElements['script']
+            const html = innerContent(tag)
+            const key = `${tag.src ?? html}-${index}`
+            if (html == null) return <script key={key} {...props} />
+            return (
+              <script
+                key={key}
+                {...props}
+                // biome-ignore lint/security/noDangerouslySetInnerHtml: user-provided inline script from config
+                dangerouslySetInnerHTML={{ __html: html }}
+              />
+            )
+          })}
 
-      {/* Article metadata */}
-      {frontmatter?.author && isMetaEnabled('articleAuthor') && (
-        <meta property="article:author" content={frontmatter.author} />
-      )}
-      {frontmatter?.lastModified && isMetaEnabled('articleModifiedTime') && (
-        <meta property="article:modified_time" content={frontmatter.lastModified} />
-      )}
-
-      {/* Twitter */}
-      {isMetaEnabled('twitterCard') && <meta name="twitter:card" content="summary_large_image" />}
-      {title && isMetaEnabled('twitterTitle') && <meta name="twitter:title" content={title} />}
-      {description && isMetaEnabled('twitterDescription') && (
-        <meta name="twitter:description" content={description} />
-      )}
-      {ogImage && isMetaEnabled('twitterImage') && (
-        <meta property="twitter:image" content={ogImage} />
+          {/* Styles */}
+          {head.style?.map((tag) => {
+            const props = toReactProps(tag) as React.JSX.IntrinsicElements['style']
+            const html = innerContent(tag)
+            if (html == null) return null
+            return (
+              <style
+                key={html}
+                {...props}
+                // biome-ignore lint/security/noDangerouslySetInnerHtml: user-provided inline style from config
+                dangerouslySetInnerHTML={{ __html: html }}
+              />
+            )
+          })}
+        </>
       )}
     </>
   )
+}
+
+/** unhead types use HTML attribute casing; React needs camelCase for these. */
+const reactPropName: Record<string, string> = {
+  charset: 'charSet',
+  crossorigin: 'crossOrigin',
+  fetchpriority: 'fetchPriority',
+  hreflang: 'hrefLang',
+  'http-equiv': 'httpEquiv',
+  imagesizes: 'imageSizes',
+  imagesrcset: 'imageSrcSet',
+  nomodule: 'noModule',
+  referrerpolicy: 'referrerPolicy',
+}
+
+function toReactProps(tag: object) {
+  const props: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(tag)) {
+    if (key === 'innerHTML' || key === 'textContent') continue
+    if (value == null || value === false) continue
+    props[reactPropName[key] ?? key] = value
+  }
+  return props
+}
+
+function innerContent(tag: { innerHTML?: unknown; textContent?: unknown }) {
+  const content = tag.innerHTML ?? tag.textContent
+  if (content == null) return undefined
+  return typeof content === 'string' ? content : JSON.stringify(content)
 }
 
 export function resolveTitleTemplate(
@@ -149,26 +240,25 @@ export function resolveTitleTemplate(
   return title?.includes(config.title) ? undefined : titleTemplate
 }
 
-export function resolveHeadOption(
+/**
+ * Resolves the `head` config into per-tag overrides for the given route.
+ * `false` (or a function returning `false`) disables every generated tag.
+ */
+export function resolveHead(
   config: Pick<Config.Config, 'head'>,
-  key: keyof Omit<Config.HeadOptions, 'meta'>,
   path: string,
   frontmatter: Config.Frontmatter | undefined,
-) {
-  const option = config.head?.[key]
-  if (typeof option === 'function') return option(path, { frontmatter })
-  return option ?? true
+): Config.HeadTags | false {
+  const head = typeof config.head === 'function' ? config.head(path, { frontmatter }) : config.head
+  if (head === false) return false
+  return head ?? {}
 }
 
-export function resolveMetaOption(
-  config: Pick<Config.Config, 'head'>,
-  key: keyof NonNullable<Config.HeadOptions['meta']>,
-  path: string,
-  frontmatter: Config.Frontmatter | undefined,
-) {
-  const option = config.head?.meta?.[key]
-  if (typeof option === 'function') return option(path, { frontmatter })
-  return option ?? true
+/** Drops disabled (`false`) and empty values before unpacking. */
+function compactMeta(meta: Config.HeadMeta) {
+  return Object.fromEntries(
+    Object.entries(meta).filter(([, value]) => value !== false && value != null && value !== ''),
+  )
 }
 
 function getIconType(iconUrl: string) {


### PR DESCRIPTION
Reworks `head` config into typed tags: `meta` keyed by unhead's flat schema, plus `link`/`script`/`style` arrays. Accepts an object, `false` to disable, or a per-route function. Replaces the boolean-predicate shape from https://github.com/wevm/vocs/pull/568.
