### PR TITLE
feat: warm ai search index on first request

### DIFF
--- a/.changeset/tidy-moons-warm.md
+++ b/.changeset/tidy-moons-warm.md
@@ -1,0 +1,5 @@
+---
+'vocs': patch
+---
+
+Warmed the local AI search index on the first request of a server instance and made `/api/search` briefly wait for a pending index before answering `indexing: true`.

--- a/src/internal/retriever.test.ts
+++ b/src/internal/retriever.test.ts
@@ -643,8 +643,9 @@ describe('end-to-end (mock embedder)', () => {
         body: JSON.stringify({ query: 'installation' }),
       })
 
-    // First request returns immediately while the index builds in the background.
-    const first = await Retriever.handleSearchRequest(makeRequest(), config)
+    // First request returns immediately while the index builds in the background
+    // (`pendingWaitMs: 0` disables the grace wait to observe the 202).
+    const first = await Retriever.handleSearchRequest(makeRequest(), config, { pendingWaitMs: 0 })
     expect(first.status).toBe(202)
     const firstJson = (await first.json()) as { results: Retriever.Result[]; indexing: boolean }
     expect(firstJson.indexing).toBe(true)
@@ -657,6 +658,32 @@ describe('end-to-end (mock embedder)', () => {
     const secondJson = (await second.json()) as { results: Retriever.Result[]; indexing: boolean }
     expect(secondJson.indexing).toBe(false)
     expect(Array.isArray(secondJson.results)).toBe(true)
+  })
+
+  it('answers 202 when the build outlasts the grace wait', async () => {
+    const embedding = Embedding.from({
+      type: 'slow',
+      model: 'slow',
+      async embed() {
+        return new Promise(() => {}) as never // never resolves
+      },
+    })
+    const config = Config.define({
+      rootDir: dir,
+      ai: { retriever: Retriever.local({ embedding, cache: false }) },
+    })
+
+    const response = await Retriever.handleSearchRequest(
+      new Request('http://localhost/api/search', {
+        method: 'POST',
+        body: JSON.stringify({ query: 'installation' }),
+      }),
+      config,
+      { pendingWaitMs: 25 },
+    )
+    expect(response.status).toBe(202)
+    const json = (await response.json()) as { indexing: boolean }
+    expect(json.indexing).toBe(true)
   })
 
   it('dev (NODE_ENV=development) loads the prebuilt index instead of building', async () => {
@@ -746,13 +773,11 @@ describe('end-to-end (mock embedder)', () => {
       })
     const options = { loadManifest: async () => manifest }
 
+    // The manifest loads within the grace wait, so the first request answers
+    // 200 directly instead of 202 (`indexing: true`).
     const first = await Retriever.handleSearchRequest(makeRequest(), config, options)
-    expect(first.status).toBe(202)
-    await Retriever.getServerIndex(config)
-
-    const second = await Retriever.handleSearchRequest(makeRequest(), config, options)
-    expect(second.status).toBe(200)
-    const json = (await second.json()) as { results: Retriever.Result[] }
+    expect(first.status).toBe(200)
+    const json = (await first.json()) as { results: Retriever.Result[] }
     expect(json.results.length).toBeGreaterThan(0)
     // Only the query was embedded — the index came from the bundled manifest.
     expect(purposes).toEqual(['query'])
@@ -803,8 +828,10 @@ describe('end-to-end (mock embedder)', () => {
         body: JSON.stringify({ query: 'installation' }),
       })
 
-    // First request kicks off the build and reports indexing.
-    expect((await Retriever.handleSearchRequest(makeRequest(), config)).status).toBe(202)
+    // First request kicks off the build and reports indexing (grace wait
+    // disabled — the fast failure would otherwise answer 503 directly).
+    const first = await Retriever.handleSearchRequest(makeRequest(), config, { pendingWaitMs: 0 })
+    expect(first.status).toBe(202)
     await expect(Retriever.getServerIndex(config)).rejects.toThrow('embedding unavailable')
 
     // Subsequent requests surface the failure and don't retrigger the build

--- a/src/internal/retriever.ts
+++ b/src/internal/retriever.ts
@@ -469,6 +469,12 @@ export declare namespace handleSearchRequest {
   type Options = {
     /** Source of the prebuilt manifest (e.g. baked into the server bundle). */
     loadManifest?: ManifestLoader | undefined
+    /**
+     * How long to wait for a pending index build before answering `202`.
+     *
+     * @default 1500
+     */
+    pendingWaitMs?: number | undefined
   }
 }
 
@@ -1247,6 +1253,13 @@ const serverIndexCache = new Map<string, ServerIndexEntry>()
 /** Minimum wait before a failed index build may be retried. */
 const failedBuildRetryMs = 30_000
 
+/**
+ * How long a search request waits for a pending index build before answering
+ * `202`. Matches the client's poll cadence, so a fast manifest load (the
+ * common cold-start case) answers on the first request instead.
+ */
+const pendingWaitMsDefault = 1_500
+
 function indexCacheKey(config: Config.Config, priv: LocalPrivateConfig): string {
   return `${config.rootDir}:${priv.embedding.type}:${priv.embedding.model}`
 }
@@ -1526,13 +1539,18 @@ async function handleLocalSearchRequest(
     typeof body.limit === 'number' ? Math.max(1, Math.min(20, Math.floor(body.limit))) : undefined
 
   // Kick off (or reuse) the in-process index. This loads the prebuilt manifest
-  // when present and cold-builds otherwise — either way we never block the
-  // request: while pending, respond with `indexing: true` and let the client
-  // keep showing keyword results (and retry shortly). A failed build answers
-  // 503 (instead of 202) so the client stops polling; the entry is retried
-  // after a backoff.
+  // when present and cold-builds otherwise. While pending, wait briefly — a
+  // manifest load (the common cold-start case) usually finishes within the
+  // grace window — then respond with `indexing: true` so the client keeps
+  // showing keyword results (and retries shortly). A failed build answers 503
+  // (instead of 202) so the client stops polling; the entry is retried after
+  // a backoff.
   const index = ensureServerIndex(config, options)
   index.promise.catch(() => {}) // avoid unhandled rejection on the background build
+  if (index.status === 'pending') {
+    const waitMs = options.pendingWaitMs ?? pendingWaitMsDefault
+    if (waitMs > 0) await Promise.race([index.promise.catch(() => {}), sleep(waitMs)])
+  }
   if (index.status === 'error') return json({ error: 'Search failed' }, 503)
   if (index.status === 'pending')
     return json({ results: [], indexing: true }, 202, { 'Cache-Control': 'no-store' })
@@ -1583,6 +1601,14 @@ function json(data: unknown, status: number, headers?: Record<string, string>): 
   return new Response(JSON.stringify(data), {
     headers: { 'Content-Type': 'application/json', ...headers },
     status,
+  })
+}
+
+/** Resolves after `ms` without holding the process open (Node-only `unref`). */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms)
+    ;(timer as unknown as { unref?: () => void }).unref?.()
   })
 }
 

--- a/src/waku/internal/middleware/ai-search-warmup.test.ts
+++ b/src/waku/internal/middleware/ai-search-warmup.test.ts
@@ -1,0 +1,93 @@
+import { Hono } from 'hono'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Mock Config.resolve / Retriever.ensureServerIndex so we can observe the
+// warm-up kick without a real vocs config or index build.
+vi.mock('../../../internal/config.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../internal/config.js')>(
+    '../../../internal/config.js',
+  )
+  return { ...actual, resolve: vi.fn() }
+})
+vi.mock('../../../internal/retriever.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../internal/retriever.js')>(
+    '../../../internal/retriever.js',
+  )
+  return { ...actual, ensureServerIndex: vi.fn() }
+})
+
+import * as Config from '../../../internal/config.js'
+import * as Retriever from '../../../internal/retriever.js'
+import { aiSearchWarmup } from './ai-search-warmup.js'
+
+const mockResolve = vi.mocked(Config.resolve)
+const mockEnsure = vi.mocked(Retriever.ensureServerIndex)
+
+afterEach(() => vi.resetAllMocks())
+
+/** Creates a Hono app with the warmup middleware and a catch-all handler. */
+function createApp() {
+  const app = new Hono()
+  app.use('*', aiSearchWarmup())
+  app.get('*', (c) => c.text('ok'))
+  return app
+}
+
+function localConfig() {
+  // `_localRetriever` presence is all the middleware checks.
+  return { _localRetriever: {} } as unknown as Config.Config
+}
+
+/** Lets the fire-and-forget warm-up chain settle. */
+function settle() {
+  return new Promise((resolve) => setTimeout(resolve, 10))
+}
+
+describe('aiSearchWarmup', () => {
+  it('kicks off the index build once, without blocking requests', async () => {
+    mockResolve.mockResolvedValue(localConfig())
+    mockEnsure.mockReturnValue({ status: 'ready', promise: Promise.resolve() } as never)
+
+    const app = createApp()
+    expect(await (await app.request('http://localhost/')).text()).toBe('ok')
+    await vi.waitFor(() => expect(mockEnsure).toHaveBeenCalledTimes(1))
+    expect(mockEnsure.mock.calls[0]?.[1]?.loadManifest).toBeTypeOf('function')
+
+    // Subsequent requests don't re-kick the warm-up.
+    await app.request('http://localhost/docs')
+    await settle()
+    expect(mockEnsure).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips when no local retriever is configured', async () => {
+    mockResolve.mockResolvedValue({} as Config.Config)
+
+    const app = createApp()
+    expect((await app.request('http://localhost/')).status).toBe(200)
+    await settle()
+    expect(mockEnsure).not.toHaveBeenCalled()
+  })
+
+  it('skips in development (dev loads the index lazily)', async () => {
+    const prev = process.env['NODE_ENV']
+    process.env['NODE_ENV'] = 'development'
+    try {
+      const app = createApp()
+      expect((await app.request('http://localhost/')).status).toBe(200)
+      await settle()
+      expect(mockResolve).not.toHaveBeenCalled()
+      expect(mockEnsure).not.toHaveBeenCalled()
+    } finally {
+      process.env['NODE_ENV'] = prev
+    }
+  })
+
+  it('serves requests even when warm-up fails', async () => {
+    mockResolve.mockRejectedValue(new Error('no config'))
+
+    const app = createApp()
+    expect((await app.request('http://localhost/')).status).toBe(200)
+    await settle()
+    expect(mockEnsure).not.toHaveBeenCalled()
+  })
+})

--- a/src/waku/internal/middleware/ai-search-warmup.ts
+++ b/src/waku/internal/middleware/ai-search-warmup.ts
@@ -1,0 +1,50 @@
+import type { MiddlewareHandler } from 'hono'
+
+/**
+ * Warms the local AI search index on the first request of a server instance.
+ *
+ * Serverless instances build their in-process index lazily, so without
+ * warming, the first `/api/search` on each cold instance answers
+ * `indexing: true`. Kicking the build off on the first request (usually a
+ * page load, well before the user opens search) hides that latency.
+ *
+ * The build runs within request context (required on Workers-style runtimes,
+ * which forbid I/O at module scope) and never blocks the request. Modules are
+ * imported lazily so server boot stays lean.
+ */
+export const aiSearchWarmup = (): MiddlewareHandler => {
+  let warmed = false
+  return (context, next) => {
+    if (!warmed) {
+      warmed = true
+      const build = warm()
+      // Keep the build alive past the response where supported (Workers).
+      try {
+        context.executionCtx?.waitUntil?.(build)
+      } catch {
+        // Hono throws when the runtime has no execution context (Node).
+      }
+    }
+    return next()
+  }
+}
+
+export default aiSearchWarmup
+
+/** Kicks the index build. Best-effort: `/api/search` surfaces real errors. */
+async function warm(): Promise<void> {
+  try {
+    // Dev never builds the index (see `resolveServerIndex`); load it lazily.
+    if (process.env['NODE_ENV'] === 'development') return
+    const [Config, Retriever, { loadAiSearchManifest }] = await Promise.all([
+      import('../../../internal/config.js'),
+      import('../../../internal/retriever.js'),
+      import('../ai-search.js'),
+    ])
+    const config = await Config.resolve({ server: true })
+    if (!config._localRetriever) return
+    await Retriever.ensureServerIndex(config, { loadManifest: loadAiSearchManifest }).promise
+  } catch {
+    // `ensureServerIndex` already logs build failures.
+  }
+}

--- a/src/waku/internal/middleware/index.ts
+++ b/src/waku/internal/middleware/index.ts
@@ -1,3 +1,4 @@
+export { default as aiSearchWarmup } from './ai-search-warmup.js'
 export { default as mdRouter } from './md-router.js'
 export { default as redirects } from './redirects.js'
 export { default as trailingSlash } from './trailing-slash.js'


### PR DESCRIPTION
Warms the local AI search index on the first request of a server instance and makes `/api/search` wait up to 1.5s for a pending index before answering `202 { indexing: true }`.

Cold serverless instances lazily built their in-memory index, so the first search on each instance returned `indexing: true`. Warmup now starts in the background on first page traffic (via `waitUntil` where supported), and the short grace wait lets near-ready indexes answer with real results.
