### PR TITLE
feat: add `VectorStore.cloudflare` remote vector store for local retriever

### DIFF
--- a/.changeset/olive-pans-argue.md
+++ b/.changeset/olive-pans-argue.md
@@ -1,0 +1,5 @@
+---
+'vocs': minor
+---
+
+Added `VectorStore.cloudflare()` to sync `Retriever.local` vectors to a Cloudflare Vectorize index instead of bundling them into the server bundle.

--- a/.changeset/tidy-moons-warm.md
+++ b/.changeset/tidy-moons-warm.md
@@ -1,0 +1,5 @@
+---
+'vocs': patch
+---
+
+Warmed the local AI search index on the first request of a server instance and made `/api/search` briefly wait for a pending index before answering `indexing: true`.

--- a/site/src/pages/features/search.mdx
+++ b/site/src/pages/features/search.mdx
@@ -267,6 +267,30 @@ export default defineConfig({
 
 If the reranker call fails, search **fails open** to the vector order, so results still come back.
 
+#### Store vectors in a remote database
+
+By default, the packed vector store is baked into the server bundle. On large sites that artifact can get big, so you can sync vectors to a remote database instead with `vectorStore`. `VectorStore.cloudflare()` uses [Cloudflare Vectorize](https://developers.cloudflare.com/vectorize/):
+
+```ts twoslash
+// [!code word:vectorStore]
+import { defineConfig, Embedding, Retriever, VectorStore } from 'vocs/config'
+
+export default defineConfig({
+  ai: {
+    retriever: Retriever.local({
+      embedding: Embedding.cloudflare(),
+      vectorStore: VectorStore.cloudflare({ index: 'my-docs' }),
+    }),
+  },
+})
+```
+
+Vocs still chunks and embeds locally. At build time vectors are synced into the Vectorize index (created on first sync; sync is incremental, so unchanged chunks are skipped and stale vectors are pruned), and at runtime each query searches the index over REST, so no vector artifact ships with the server bundle.
+
+`VectorStore.cloudflare()` reads `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` from the environment (the token needs the **Vectorize** Edit permission). Make them available at build time (to sync) and at runtime (to query). Like the rest of the retriever config, credentials stay server-side.
+
+Bring your own database with `VectorStore.from()`.
+
 #### Index external sources
 
 Embed other sites alongside your docs so their pages surface in search and link out to their absolute URL. Each URL is fetched at build time and auto-expanded: a `sitemap.xml` → every page it lists, an `llms.txt` → every same-origin page it links (off-site links are ignored), anything else → the page itself. Each source expands to at most 1,000 pages; raise `maxPages` per source to index more.

--- a/site/src/pages/reference/site-config.mdx
+++ b/site/src/pages/reference/site-config.mdx
@@ -871,7 +871,9 @@ Adds AI search on top of keyword search. Set it to a retriever created by one co
 
 - `Retriever.local()`: Vocs owns the pipeline. It embeds your pages at build time, packs them
   into a built-in static vector store, and queries them at runtime via a server endpoint (the
-  open-source, self-owned option).
+  open-source, self-owned option). Pass `vectorStore: VectorStore.cloudflare()` to sync vectors
+  to a remote [Cloudflare Vectorize](https://developers.cloudflare.com/vectorize/) index instead
+  of bundling them.
 - `Retriever.cloudflare()` / `Retriever.from()`: retrieval is delegated to a hosted backend.
 
 Retrievers hold secrets and are kept **server-side only** (never serialized to the browser).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -117,12 +117,31 @@ cli
           case 'packed':
             console.log(`[vocs]   packed vectors (${event.dimensions}d, ${event.format})`)
             break
+          case 'sync:start':
+            console.log(`[vocs]   syncing ${event.chunks} chunks to the remote vector store...`)
+            break
+          case 'sync:progress': {
+            const now = Date.now()
+            if (event.done === event.total || now - lastFetchLog > 1000) {
+              lastFetchLog = now
+              console.log(`[vocs]   upserted ${event.done}/${event.total}`)
+            }
+            break
+          }
+          case 'synced':
+            console.log(
+              `[vocs]   synced (${event.upserted} upserted, ${event.skipped} unchanged, ${event.deleted} pruned)`,
+            )
+            break
         }
       },
     })
     const elapsed = ((Date.now() - started) / 1000).toFixed(1)
+    const remote = config._localRetriever?.vectorStore.target === 'remote'
     console.log(
-      `[vocs] AI search index built in ${elapsed}s (${manifest.vectorStore.count} chunks, ${manifest.vectorStore.dimensions}d, ${manifest.vectorStore.format}).`,
+      remote
+        ? `[vocs] AI search index synced in ${elapsed}s (${manifest.vectorStore.count} chunks, ${manifest.vectorStore.dimensions}d, remote vector store).`
+        : `[vocs] AI search index built in ${elapsed}s (${manifest.vectorStore.count} chunks, ${manifest.vectorStore.dimensions}d, ${manifest.vectorStore.format}).`,
     )
 
     // Persist to the canonical cache path so `vocs dev` can serve semantic

--- a/src/internal/retriever.test.ts
+++ b/src/internal/retriever.test.ts
@@ -643,8 +643,9 @@ describe('end-to-end (mock embedder)', () => {
         body: JSON.stringify({ query: 'installation' }),
       })
 
-    // First request returns immediately while the index builds in the background.
-    const first = await Retriever.handleSearchRequest(makeRequest(), config)
+    // First request returns immediately while the index builds in the background
+    // (`pendingWaitMs: 0` disables the grace wait to observe the 202).
+    const first = await Retriever.handleSearchRequest(makeRequest(), config, { pendingWaitMs: 0 })
     expect(first.status).toBe(202)
     const firstJson = (await first.json()) as { results: Retriever.Result[]; indexing: boolean }
     expect(firstJson.indexing).toBe(true)
@@ -657,6 +658,32 @@ describe('end-to-end (mock embedder)', () => {
     const secondJson = (await second.json()) as { results: Retriever.Result[]; indexing: boolean }
     expect(secondJson.indexing).toBe(false)
     expect(Array.isArray(secondJson.results)).toBe(true)
+  })
+
+  it('answers 202 when the build outlasts the grace wait', async () => {
+    const embedding = Embedding.from({
+      type: 'slow',
+      model: 'slow',
+      async embed() {
+        return new Promise(() => {}) as never // never resolves
+      },
+    })
+    const config = Config.define({
+      rootDir: dir,
+      ai: { retriever: Retriever.local({ embedding, cache: false }) },
+    })
+
+    const response = await Retriever.handleSearchRequest(
+      new Request('http://localhost/api/search', {
+        method: 'POST',
+        body: JSON.stringify({ query: 'installation' }),
+      }),
+      config,
+      { pendingWaitMs: 25 },
+    )
+    expect(response.status).toBe(202)
+    const json = (await response.json()) as { indexing: boolean }
+    expect(json.indexing).toBe(true)
   })
 
   it('dev (NODE_ENV=development) loads the prebuilt index instead of building', async () => {
@@ -746,13 +773,11 @@ describe('end-to-end (mock embedder)', () => {
       })
     const options = { loadManifest: async () => manifest }
 
+    // The manifest loads within the grace wait, so the first request answers
+    // 200 directly instead of 202 (`indexing: true`).
     const first = await Retriever.handleSearchRequest(makeRequest(), config, options)
-    expect(first.status).toBe(202)
-    await Retriever.getServerIndex(config)
-
-    const second = await Retriever.handleSearchRequest(makeRequest(), config, options)
-    expect(second.status).toBe(200)
-    const json = (await second.json()) as { results: Retriever.Result[] }
+    expect(first.status).toBe(200)
+    const json = (await first.json()) as { results: Retriever.Result[] }
     expect(json.results.length).toBeGreaterThan(0)
     // Only the query was embedded — the index came from the bundled manifest.
     expect(purposes).toEqual(['query'])
@@ -803,8 +828,10 @@ describe('end-to-end (mock embedder)', () => {
         body: JSON.stringify({ query: 'installation' }),
       })
 
-    // First request kicks off the build and reports indexing.
-    expect((await Retriever.handleSearchRequest(makeRequest(), config)).status).toBe(202)
+    // First request kicks off the build and reports indexing (grace wait
+    // disabled — the fast failure would otherwise answer 503 directly).
+    const first = await Retriever.handleSearchRequest(makeRequest(), config, { pendingWaitMs: 0 })
+    expect(first.status).toBe(202)
     await expect(Retriever.getServerIndex(config)).rejects.toThrow('embedding unavailable')
 
     // Subsequent requests surface the failure and don't retrigger the build

--- a/src/internal/retriever.test.ts
+++ b/src/internal/retriever.test.ts
@@ -7,6 +7,7 @@ import * as ConfigSerializer from './config-serializer.js'
 import * as Embedding from './embedding.js'
 import * as Reranker from './reranker.js'
 import * as Retriever from './retriever.js'
+import * as VectorStore from './vector-store.js'
 
 const ctx = { basePath: '/' }
 
@@ -399,6 +400,20 @@ describe('resolveLocal (config split)', () => {
     )
     expect(resolved?.private.chunking.maxCharacters).toBe(100)
     expect(resolved?.private.chunking.overlapCharacters).toBe(99)
+  })
+
+  it('accepts a remote vector store (VectorStore.cloudflare)', () => {
+    const resolved = Retriever.resolveLocal(
+      {
+        embedding: Embedding.mock(),
+        vectorStore: VectorStore.cloudflare({ accountId: 'acc', apiToken: 'secret-token' }),
+      },
+      { basePath: '/' },
+    )
+    expect(resolved?.private.vectorStore.type).toBe('cloudflare')
+    expect(resolved?.private.vectorStore.target).toBe('remote')
+    // Adapter (and its credentials) stays in the private, never-serialized half.
+    expect(JSON.stringify(resolved?.public)).not.toContain('secret-token')
   })
 })
 
@@ -879,5 +894,130 @@ describe('end-to-end (mock embedder)', () => {
       body: JSON.stringify({ query: '   ' }),
     })
     expect((await Retriever.handleSearchRequest(request, config)).status).toBe(400)
+  })
+})
+
+describe('end-to-end (remote vector store)', () => {
+  let dir: string
+
+  beforeEach(() => {
+    Retriever._resetServerIndexCache()
+    dir = makeSite()
+  })
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  /** In-memory remote vector store (stands in for e.g. Cloudflare Vectorize). */
+  function memoryRemoteStore() {
+    const vectors = new Map<string, { metadata: Record<string, unknown>; vector: Float32Array }>()
+    const syncs: { count: number; dimensions: number }[] = []
+    const store: VectorStore.RemoteAdapter = {
+      type: 'memory',
+      target: 'remote',
+      async sync(entries, { dimensions }) {
+        syncs.push({ count: entries.length, dimensions })
+        vectors.clear()
+        for (const e of entries) vectors.set(e.id, { metadata: e.metadata, vector: e.vector })
+        return { deleted: 0, skipped: 0, upserted: entries.length }
+      },
+      async query(query, { topK }) {
+        return [...vectors.entries()]
+          .map(([id, v]) => {
+            let score = 0
+            for (let i = 0; i < query.length; i++) score += (v.vector[i] ?? 0) * (query[i] ?? 0)
+            return { id, metadata: v.metadata, score }
+          })
+          .sort((a, b) => b.score - a.score)
+          .slice(0, topK)
+      },
+    }
+    return { store, syncs, vectors }
+  }
+
+  function remoteConfig(store: VectorStore.RemoteAdapter, reranker?: Reranker.Adapter) {
+    return Config.define({
+      rootDir: dir,
+      ai: {
+        retriever: Retriever.local({
+          embedding: Embedding.mock({ dimensions: 64 }),
+          cache: false,
+          vectorStore: store,
+          ...(reranker ? { reranker } : {}),
+        }),
+      },
+    })
+  }
+
+  it('buildIndex syncs vectors remotely and emits no local artifact', async () => {
+    const { store, syncs, vectors } = memoryRemoteStore()
+    const config = remoteConfig(store)
+
+    const events: Retriever.ProgressEvent['type'][] = []
+    const manifest = await Retriever.buildIndex(config, {
+      onProgress: (event) => events.push(event.type),
+    })
+
+    expect(syncs).toEqual([{ count: vectors.size, dimensions: 64 }])
+    expect(vectors.size).toBeGreaterThan(0)
+    // Chunk metadata + vectors live remotely — the manifest is metadata-only.
+    expect(manifest.chunks).toEqual([])
+    expect(manifest.vectors.count).toBe(0)
+    expect(manifest.vectorStore.count).toBe(vectors.size)
+    expect(events).toContain('sync:start')
+    expect(events).toContain('synced')
+    expect(events).not.toContain('packed')
+  })
+
+  it('retrieves through the remote store', async () => {
+    const { store } = memoryRemoteStore()
+    const config = remoteConfig(store)
+    await Retriever.buildIndex(config)
+
+    const results = await Retriever.retrieveLocal(config, { query: 'embeddings cache build time' })
+    expect(results.length).toBeGreaterThan(0)
+    expect(results.some((r) => r.href.includes('/search'))).toBe(true)
+  })
+
+  it('applies the reranker to remote candidates', async () => {
+    const calls: { count: number; query: string }[] = []
+    const reranker = Reranker.from({
+      type: 'spy',
+      model: 'spy',
+      async rerank(query, documents, context) {
+        calls.push({ count: documents.length, query })
+        return documents.map((_, index) => ({ index, score: 0.5 })).slice(0, context.topK)
+      },
+    })
+    const { store } = memoryRemoteStore()
+    const config = remoteConfig(store, reranker)
+    await Retriever.buildIndex(config)
+
+    const results = await Retriever.retrieveLocal(config, { query: 'installation' })
+    expect(calls[0]?.query).toBe('installation')
+    expect(calls[0]?.count).toBeGreaterThan(0)
+    // Uniform reranker scores → the lexical title boost decides the winner.
+    expect(results[0]?.title).toBe('Installation')
+  })
+
+  it('serves search requests without an indexing phase', async () => {
+    const { store } = memoryRemoteStore()
+    const config = remoteConfig(store)
+    await Retriever.buildIndex(config)
+
+    // Even the first request answers 200 — remote mode has no in-process
+    // index to warm, so there is never a 202 `indexing` response.
+    const response = await Retriever.handleSearchRequest(
+      new Request('http://localhost/api/search', {
+        method: 'POST',
+        body: JSON.stringify({ query: 'installation' }),
+      }),
+      config,
+      { pendingWaitMs: 0 },
+    )
+    expect(response.status).toBe(200)
+    const json = (await response.json()) as { indexing: boolean; results: Retriever.Result[] }
+    expect(json.indexing).toBe(false)
+    expect(json.results.length).toBeGreaterThan(0)
   })
 })

--- a/src/internal/retriever.ts
+++ b/src/internal/retriever.ts
@@ -1004,7 +1004,8 @@ export type IndexManifest = {
 /**
  * A build-progress event emitted by {@link buildIndex}, in pipeline order:
  * `documents` → (`sources:start` → `sources:progress`* → `sources:done`) →
- * `chunked` → `embed:start` → `embed:progress`* → `packed`.
+ * `chunked` → `embed:start` → `embed:progress`* → then `packed` (static
+ * store) or `sync:start` → `sync:progress`* → `synced` (remote store).
  */
 export type ProgressEvent =
   | { type: 'documents'; local: number }
@@ -1015,6 +1016,9 @@ export type ProgressEvent =
   | { type: 'embed:start'; cached: number; toEmbed: number; total: number }
   | { type: 'embed:progress'; embedded: number; toEmbed: number }
   | { type: 'packed'; dimensions: number; format: VectorStore.Format }
+  | { type: 'sync:start'; chunks: number }
+  | { type: 'sync:progress'; done: number; total: number }
+  | { type: 'synced'; deleted: number; skipped: number; upserted: number }
 
 export declare namespace buildIndex {
   type Options = {
@@ -1089,30 +1093,60 @@ export async function buildIndex(
   cache.save()
 
   const dimensions = vectors[0]?.length ?? priv.embedding.dimensions ?? 0
+  const embedding: IndexManifest['embedding'] = {
+    type: priv.embedding.type,
+    model: priv.embedding.model,
+    dimensions,
+    normalized: true,
+  }
+  const toMetadata = (c: Chunk): ChunkMetadata => ({
+    id: c.id,
+    href: c.href,
+    title: c.title,
+    titles: c.titles,
+    category: c.category,
+    type: c.type,
+    snippet: c.text.slice(0, 240),
+    text: c.text,
+    ...(c.weight !== undefined && c.weight !== 1 ? { weight: c.weight } : {}),
+  })
+
+  // Remote store: push vectors + metadata up instead of packing an artifact.
+  // The returned manifest carries build metadata only — chunks live remotely.
+  if (priv.vectorStore.target === 'remote') {
+    const store = priv.vectorStore
+    let synced: VectorStore.RemoteSyncResult = { deleted: 0, skipped: 0, upserted: 0 }
+    if (chunks.length > 0) {
+      onProgress?.({ type: 'sync:start', chunks: chunks.length })
+      const entries = chunks.map((c, i) => {
+        const vector = vectors[i]
+        if (!vector) throw new Error('[vocs] embedding produced no vector for a chunk')
+        return { id: c.id, metadata: toMetadata(c), vector }
+      })
+      synced = await store.sync(entries, {
+        dimensions,
+        onProgress: (done, total) => onProgress?.({ type: 'sync:progress', done, total }),
+      })
+    }
+    onProgress?.({ type: 'synced', ...synced })
+    return {
+      version: 1,
+      embedding,
+      vectorStore: { format: 'float32', count: chunks.length, dimensions },
+      chunks: [],
+      vectors: VectorStore.pack([], 'float32'),
+    }
+  }
+
   const format = VectorStore.resolveFormat(priv.vectorStore.format, priv.runtime)
   const packed = VectorStore.pack(vectors, format)
   onProgress?.({ type: 'packed', format, dimensions })
 
   return {
     version: 1,
-    embedding: {
-      type: priv.embedding.type,
-      model: priv.embedding.model,
-      dimensions,
-      normalized: true,
-    },
+    embedding,
     vectorStore: { format, count: chunks.length, dimensions },
-    chunks: chunks.map((c) => ({
-      id: c.id,
-      href: c.href,
-      title: c.title,
-      titles: c.titles,
-      category: c.category,
-      type: c.type,
-      snippet: c.text.slice(0, 240),
-      text: c.text,
-      ...(c.weight !== undefined && c.weight !== 1 ? { weight: c.weight } : {}),
-    })),
+    chunks: chunks.map(toMetadata),
     vectors: packed,
   }
 }
@@ -1328,6 +1362,12 @@ async function resolveServerIndex(
   priv: LocalPrivateConfig,
   loadManifest?: ManifestLoader | undefined,
 ): Promise<ServerIndex> {
+  // Remote vector store: vectors live in the hosted database (synced at build
+  // time), so there is no in-process index to load — and never build one here,
+  // which would re-sync the store from a runtime instance.
+  if (priv.vectorStore.target === 'remote')
+    return { store: VectorStore.load(VectorStore.pack([], 'float32')), chunks: [] }
+
   // Baked-in manifest first (emitted into the server bundle at build time) —
   // serverless filesystems don't carry the cache directory or source pages, so
   // this is the only source that works everywhere.
@@ -1410,33 +1450,92 @@ function titleMatchBoost(queryTokens: readonly string[], title: string): number 
   return queryTokens.length === titleTokens.length ? 0.25 : 0.12
 }
 
-/** Embeds the query, searches the local store, dedupes by href. */
+/** Embeds and L2-normalizes a search query. */
+async function embedQuery(
+  priv: LocalPrivateConfig,
+  query: string,
+): Promise<Float32Array | undefined> {
+  const embedded = await priv.embedding.embed([query], { purpose: 'query' })
+  const raw = embedded[0]
+  return raw ? VectorStore.normalize(raw) : undefined
+}
+
+/** Maps remote-store metadata back into {@link ChunkMetadata} (skips malformed hits). */
+function chunkMetadataFromRemote(
+  metadata: Record<string, unknown> | undefined,
+): ChunkMetadata | undefined {
+  if (!metadata) return undefined
+  const href = str(metadata['href'])
+  const title = str(metadata['title'])
+  if (!href || !title) return undefined
+  const type = metadata['type']
+  return {
+    id: str(metadata['id']) ?? href,
+    href,
+    title,
+    titles: Array.isArray(metadata['titles'])
+      ? metadata['titles'].filter((t): t is string => typeof t === 'string')
+      : [],
+    category: typeof metadata['category'] === 'string' ? metadata['category'] : '',
+    type: type === 'page' || type === 'section' || type === 'nav' ? type : 'page',
+    snippet: typeof metadata['snippet'] === 'string' ? metadata['snippet'] : '',
+    ...(typeof metadata['text'] === 'string' ? { text: metadata['text'] } : {}),
+    ...(typeof metadata['weight'] === 'number' && metadata['weight'] !== 1
+      ? { weight: metadata['weight'] }
+      : {}),
+  }
+}
+
+/**
+ * Fetches vector candidates for a query — from the remote store (embed query →
+ * remote nearest-neighbor query) or the in-process static store (embed query →
+ * dot-product scan). `score` is the raw similarity; a reranker may replace it
+ * with a cross-encoder score.
+ */
+async function retrieveCandidates(
+  config: Config.Config,
+  priv: LocalPrivateConfig,
+  queryText: string,
+): Promise<{ meta: ChunkMetadata; score: number }[]> {
+  if (priv.vectorStore.target === 'remote') {
+    const query = await embedQuery(priv, queryText)
+    if (!query) return []
+    const hits = await priv.vectorStore.query(query, { topK: priv.retrieval.candidateK })
+    return hits
+      .map((hit) => {
+        const meta = chunkMetadataFromRemote(hit.metadata)
+        return meta ? { meta, score: hit.score } : undefined
+      })
+      .filter((hit): hit is { meta: ChunkMetadata; score: number } => hit !== undefined)
+  }
+
+  const index = await getServerIndex(config)
+  // Empty index (dev with no prebuilt manifest): skip the query embedding call
+  // and fall back to keyword-only search on the client.
+  if (index.chunks.length === 0) return []
+
+  const query = await embedQuery(priv, queryText)
+  if (!query) return []
+
+  const hits = VectorStore.search(index.store, query, priv.retrieval.candidateK)
+  return hits
+    .map((hit) => {
+      const meta = index.chunks[hit.index]
+      return meta ? { meta, score: hit.score } : undefined
+    })
+    .filter((hit): hit is { meta: ChunkMetadata; score: number } => hit !== undefined)
+}
+
+/** Embeds the query, searches the vector store, dedupes by href. */
 export async function retrieveLocal(
   config: Config.Config,
   options: retrieveLocal.Options,
 ): Promise<Result[]> {
   const priv = requireLocal(config)
   const limit = options.limit ?? priv.retrieval.topK
-  const index = await getServerIndex(config)
-  // Empty index (dev with no prebuilt manifest): skip the query embedding call
-  // and fall back to keyword-only search on the client.
-  if (index.chunks.length === 0) return []
 
-  const embedded = await priv.embedding.embed([options.query], { purpose: 'query' })
-  const raw = embedded[0]
-  if (!raw) return []
-  const query = VectorStore.normalize(raw)
-
-  const hits = VectorStore.search(index.store, query, priv.retrieval.candidateK)
-
-  // Vector candidates, paired with their chunk metadata. `score` is the raw
-  // similarity; a reranker (below) may replace it with a cross-encoder score.
-  let candidates = hits
-    .map((hit) => {
-      const meta = index.chunks[hit.index]
-      return meta ? { meta, score: hit.score } : undefined
-    })
-    .filter((hit): hit is { meta: ChunkMetadata; score: number } => hit !== undefined)
+  let candidates = await retrieveCandidates(config, priv, options.query)
+  if (candidates.length === 0) return []
 
   // Optional rerank: a cross-encoder reads each (query, passage) pair jointly
   // and re-scores the candidates for precision. On failure we keep the vector
@@ -1538,27 +1637,33 @@ async function handleLocalSearchRequest(
   const limit =
     typeof body.limit === 'number' ? Math.max(1, Math.min(20, Math.floor(body.limit))) : undefined
 
-  // Kick off (or reuse) the in-process index. This loads the prebuilt manifest
-  // when present and cold-builds otherwise. While pending, wait briefly — a
-  // manifest load (the common cold-start case) usually finishes within the
-  // grace window — then respond with `indexing: true` so the client keeps
-  // showing keyword results (and retries shortly). A failed build answers 503
-  // (instead of 202) so the client stops polling; the entry is retried after
-  // a backoff.
-  const index = ensureServerIndex(config, options)
-  index.promise.catch(() => {}) // avoid unhandled rejection on the background build
-  if (index.status === 'pending') {
-    const waitMs = options.pendingWaitMs ?? pendingWaitMsDefault
-    if (waitMs > 0) await Promise.race([index.promise.catch(() => {}), sleep(waitMs)])
+  // Static store only: kick off (or reuse) the in-process index. This loads
+  // the prebuilt manifest when present and cold-builds otherwise. While
+  // pending, wait briefly — a manifest load (the common cold-start case)
+  // usually finishes within the grace window — then respond with
+  // `indexing: true` so the client keeps showing keyword results (and retries
+  // shortly). A failed build answers 503 (instead of 202) so the client stops
+  // polling; the entry is retried after a backoff.
+  //
+  // A remote store has no in-process index (vectors are queried in the
+  // database), so there is never an `indexing` phase.
+  let index: ReturnType<typeof ensureServerIndex> | undefined
+  if (config._localRetriever.vectorStore.target === 'static') {
+    index = ensureServerIndex(config, options)
+    index.promise.catch(() => {}) // avoid unhandled rejection on the background build
+    if (index.status === 'pending') {
+      const waitMs = options.pendingWaitMs ?? pendingWaitMsDefault
+      if (waitMs > 0) await Promise.race([index.promise.catch(() => {}), sleep(waitMs)])
+    }
+    if (index.status === 'error') return json({ error: 'Search failed' }, 503)
+    if (index.status === 'pending')
+      return json({ results: [], indexing: true }, 202, { 'Cache-Control': 'no-store' })
   }
-  if (index.status === 'error') return json({ error: 'Search failed' }, 503)
-  if (index.status === 'pending')
-    return json({ results: [], indexing: true }, 202, { 'Cache-Control': 'no-store' })
 
   try {
     const t0 = Date.now()
-    const [{ store }, results] = await Promise.all([
-      index.promise,
+    const [store, results] = await Promise.all([
+      index?.promise.then((i) => i.store),
       retrieveLocal(config, { query, limit }),
     ])
     const searchMs = Date.now() - t0
@@ -1569,7 +1674,7 @@ async function handleLocalSearchRequest(
       {
         results,
         indexing: false,
-        embedding: { type, model, dimensions: store.dimensions || dimensions },
+        embedding: { type, model, dimensions: store?.dimensions || dimensions },
         ...(reranker ? { reranker: { type: reranker.type, model: reranker.model } } : {}),
         timings: { searchMs },
       },

--- a/src/internal/retriever.ts
+++ b/src/internal/retriever.ts
@@ -469,6 +469,12 @@ export declare namespace handleSearchRequest {
   type Options = {
     /** Source of the prebuilt manifest (e.g. baked into the server bundle). */
     loadManifest?: ManifestLoader | undefined
+    /**
+     * How long to wait for a pending index build before answering `202`.
+     *
+     * @default 1500
+     */
+    pendingWaitMs?: number | undefined
   }
 }
 
@@ -1247,6 +1253,13 @@ const serverIndexCache = new Map<string, ServerIndexEntry>()
 /** Minimum wait before a failed index build may be retried. */
 const failedBuildRetryMs = 30_000
 
+/**
+ * How long a search request waits for a pending index build before answering
+ * `202`. Matches the client's poll cadence, so a fast manifest load (the
+ * common cold-start case) answers on the first request instead.
+ */
+const pendingWaitMsDefault = 1_500
+
 function indexCacheKey(config: Config.Config, priv: LocalPrivateConfig): string {
   return `${config.rootDir}:${priv.embedding.type}:${priv.embedding.model}`
 }
@@ -1526,13 +1539,18 @@ async function handleLocalSearchRequest(
     typeof body.limit === 'number' ? Math.max(1, Math.min(20, Math.floor(body.limit))) : undefined
 
   // Kick off (or reuse) the in-process index. This loads the prebuilt manifest
-  // when present and cold-builds otherwise — either way we never block the
-  // request: while pending, respond with `indexing: true` and let the client
-  // keep showing keyword results (and retry shortly). A failed build answers
-  // 503 (instead of 202) so the client stops polling; the entry is retried
-  // after a backoff.
+  // when present and cold-builds otherwise. While pending, wait briefly — a
+  // manifest load (the common cold-start case) usually finishes within the
+  // grace window — then respond with `indexing: true` so the client keeps
+  // showing keyword results (and retries shortly). A failed build answers 503
+  // (instead of 202) so the client stops polling; the entry is retried after
+  // a backoff.
   const index = ensureServerIndex(config, options)
   index.promise.catch(() => {}) // avoid unhandled rejection on the background build
+  if (index.status === 'pending') {
+    const waitMs = options.pendingWaitMs ?? pendingWaitMsDefault
+    if (waitMs > 0) await Promise.race([index.promise.catch(() => {}), sleep(waitMs)])
+  }
   if (index.status === 'error') return json({ error: 'Search failed' }, 503)
   if (index.status === 'pending')
     return json({ results: [], indexing: true }, 202, { 'Cache-Control': 'no-store' })
@@ -1583,6 +1601,14 @@ function json(data: unknown, status: number, headers?: Record<string, string>): 
   return new Response(JSON.stringify(data), {
     headers: { 'Content-Type': 'application/json', ...headers },
     status,
+  })
+}
+
+/** Resolves after `ms` without holding the process open (Node-only `unref`). */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms)
+    ;(timer as unknown as { unref?: () => void }).unref?.()
   })
 }
 

--- a/src/internal/vector-store.test.ts
+++ b/src/internal/vector-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import * as VectorStore from './vector-store.js'
 
 describe('normalize', () => {
@@ -62,5 +62,155 @@ describe('resolveFormat', () => {
     expect(VectorStore.resolveFormat('auto', 'server')).toBe('float32')
     expect(VectorStore.resolveFormat('auto', 'client')).toBe('int8')
     expect(VectorStore.resolveFormat('int8', 'server')).toBe('int8')
+  })
+})
+
+describe('cloudflare (remote adapter)', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  /** In-memory Vectorize API fake backing the `fetch` mock. */
+  function mockVectorize() {
+    const state = {
+      created: false,
+      dimensions: undefined as number | undefined,
+      requests: [] as { body: string | undefined; method: string; path: string }[],
+      vectors: new Map<string, { metadata: Record<string, unknown>; values: number[] }>(),
+    }
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = new URL(String(input))
+      const method = init?.method ?? 'GET'
+      const body = typeof init?.body === 'string' ? init.body : undefined
+      state.requests.push({ body, method, path: url.pathname + url.search })
+
+      const base = '/client/v4/accounts/acc/vectorize/v2/indexes'
+      if (!url.pathname.startsWith(base)) return new Response('not found', { status: 404 })
+      const rest = url.pathname.slice(base.length)
+
+      // Create index.
+      if (rest === '' && method === 'POST') {
+        state.created = true
+        state.dimensions = JSON.parse(body ?? '{}').config?.dimensions
+        return Response.json({ success: true })
+      }
+      // Get index.
+      if (/^\/[^/]+$/.test(rest) && method === 'GET') {
+        if (!state.created) return new Response('not found', { status: 404 })
+        return Response.json({ result: { config: { dimensions: state.dimensions } } })
+      }
+      if (rest.endsWith('/list'))
+        return Response.json({
+          result: { isTruncated: false, vectors: [...state.vectors.keys()].map((id) => ({ id })) },
+        })
+      if (rest.endsWith('/upsert')) {
+        for (const line of (body ?? '').split('\n')) {
+          const { id, metadata, values } = JSON.parse(line)
+          state.vectors.set(id, { metadata, values })
+        }
+        return Response.json({ success: true })
+      }
+      if (rest.endsWith('/delete_by_ids')) {
+        for (const id of JSON.parse(body ?? '{}').ids ?? []) state.vectors.delete(id)
+        return Response.json({ success: true })
+      }
+      if (rest.endsWith('/query')) {
+        const { topK, vector } = JSON.parse(body ?? '{}')
+        const matches = [...state.vectors.entries()]
+          .map(([id, v]) => ({
+            id,
+            metadata: v.metadata,
+            score: v.values.reduce((sum, x, i) => sum + x * (vector[i] ?? 0), 0),
+          }))
+          .sort((a, b) => b.score - a.score)
+          .slice(0, topK)
+        return Response.json({ result: { matches } })
+      }
+      return new Response('bad request', { status: 400 })
+    })
+    return state
+  }
+
+  function entry(id: string, text: string, vector: number[]): VectorStore.RemoteEntry {
+    return {
+      id,
+      metadata: { href: `/${id}`, text, title: id },
+      vector: VectorStore.normalize(vector),
+    }
+  }
+
+  const credentials = { accountId: 'acc', apiToken: 'tok' }
+
+  it('throws on missing credentials', async () => {
+    const store = VectorStore.cloudflare({ accountId: '', apiToken: '' })
+    await expect(store.query(new Float32Array([1]), { topK: 5 })).rejects.toThrow(/accountId/)
+  })
+
+  it('creates the index on first sync and upserts all entries', async () => {
+    const state = mockVectorize()
+    const store = VectorStore.cloudflare(credentials)
+
+    const result = await store.sync([entry('a', 'alpha', [1, 0]), entry('b', 'beta', [0, 1])], {
+      dimensions: 2,
+    })
+
+    expect(state.created).toBe(true)
+    expect(state.dimensions).toBe(2)
+    expect(result).toEqual({ deleted: 0, skipped: 0, upserted: 2 })
+    expect(state.vectors.size).toBe(2)
+    // Content-addressed ids: 64 hex chars (Vectorize's id byte cap).
+    for (const id of state.vectors.keys()) expect(id).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('re-sync skips unchanged entries and prunes stale ones', async () => {
+    const state = mockVectorize()
+    const store = VectorStore.cloudflare(credentials)
+
+    await store.sync([entry('a', 'alpha', [1, 0]), entry('b', 'beta', [0, 1])], { dimensions: 2 })
+    const result = await store.sync([entry('a', 'alpha', [1, 0]), entry('c', 'gamma', [1, 1])], {
+      dimensions: 2,
+    })
+
+    expect(result).toEqual({ deleted: 1, skipped: 1, upserted: 1 })
+    expect(state.vectors.size).toBe(2)
+  })
+
+  it('rejects a dimension change against an existing index', async () => {
+    mockVectorize()
+    const store = VectorStore.cloudflare(credentials)
+    await store.sync([entry('a', 'alpha', [1, 0])], { dimensions: 2 })
+    await expect(store.sync([entry('a', 'alpha', [1, 0, 0])], { dimensions: 3 })).rejects.toThrow(
+      /dimensions/,
+    )
+  })
+
+  it('bounds oversized metadata under the Vectorize cap', async () => {
+    const state = mockVectorize()
+    const store = VectorStore.cloudflare(credentials)
+
+    await store.sync([entry('big', 'x'.repeat(20_000), [1, 0])], { dimensions: 2 })
+
+    const [stored] = [...state.vectors.values()]
+    const size = new TextEncoder().encode(JSON.stringify(stored?.metadata)).length
+    expect(size).toBeLessThanOrEqual(9216)
+    // Trimmed, not dropped.
+    expect(String(stored?.metadata['text']).length).toBeGreaterThan(0)
+  })
+
+  it('queries nearest vectors and caps topK at 50', async () => {
+    const state = mockVectorize()
+    const store = VectorStore.cloudflare(credentials)
+    await store.sync([entry('a', 'alpha', [1, 0]), entry('b', 'beta', [0, 1])], { dimensions: 2 })
+
+    const hits = await store.query(VectorStore.normalize([0.9, 0.1]), { topK: 100 })
+
+    expect(hits[0]?.metadata?.['href']).toBe('/a')
+    expect(hits[0]?.score ?? 0).toBeGreaterThan(hits[1]?.score ?? 0)
+    const queryRequest = state.requests.find((r) => r.path.endsWith('/query'))
+    expect(JSON.parse(queryRequest?.body ?? '{}').topK).toBe(50)
+  })
+
+  it('propagates query failures', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('nope', { status: 401 }))
+    const store = VectorStore.cloudflare(credentials)
+    await expect(store.query(new Float32Array([1]), { topK: 5 })).rejects.toThrow(/401/)
   })
 })

--- a/src/internal/vector-store.ts
+++ b/src/internal/vector-store.ts
@@ -1,16 +1,24 @@
 /**
- * Built-in static vector store for AI search — the default, open-source
- * alternative to a hosted vector DB (Pinecone, etc).
+ * Vector stores for AI search.
  *
- * Vectors are packed into a single typed-array matrix and base64-encoded, so the
- * whole index is one compact artifact that works server-side (Node) and, with
- * `int8` quantization, in the browser. Cosine similarity reduces to a dot
- * product because all vectors are normalized before packing.
+ * Two storage targets:
+ *
+ * - `static` (default) — the built-in, open-source alternative to a hosted
+ *   vector DB. Vectors are packed into a single typed-array matrix and
+ *   base64-encoded, so the whole index is one compact artifact that works
+ *   server-side (Node) and, with `int8` quantization, in the browser. Cosine
+ *   similarity reduces to a dot product because all vectors are normalized
+ *   before packing.
+ * - `remote` — vectors live in a hosted vector database (e.g. Cloudflare
+ *   Vectorize). The build syncs vectors up; the server queries the database at
+ *   runtime, so no index artifact ships with the server bundle.
  */
 
 export type Format = 'float32' | 'int8'
 
-export type Adapter = {
+export type Adapter = StaticAdapter | RemoteAdapter
+
+export type StaticAdapter = {
   /** Also emit a public/browser artifact (for `runtime: 'server'` deploys). */
   expose: boolean
   /** Storage format. `'auto'` resolves to `float32` (server) / `int8` (client). */
@@ -19,6 +27,55 @@ export type Adapter = {
   maxClientBytes: number | undefined
   /** Storage target backing the adapter. */
   target: 'static'
+  /** Adapter type identifier. */
+  type: string
+}
+
+/** Chunk vector + metadata synced into a remote store at build time. */
+export type RemoteEntry = {
+  /** Stable chunk identifier (adapters may derive their own storage id). */
+  id: string
+  /** Chunk metadata returned verbatim by `query` at runtime. */
+  metadata: Record<string, unknown>
+  /** L2-normalized embedding vector. */
+  vector: Float32Array
+}
+
+/** Nearest-neighbor match returned by a remote store. */
+export type RemoteHit = {
+  /** Storage identifier of the matched vector. */
+  id: string
+  /** Chunk metadata attached at sync time (if any). */
+  metadata: Record<string, unknown> | undefined
+  /** Similarity score (higher is more relevant). */
+  score: number
+}
+
+export type RemoteSyncResult = {
+  /** Stale vectors removed from the store. */
+  deleted: number
+  /** Vectors already up to date (not re-uploaded). */
+  skipped: number
+  /** New or changed vectors uploaded. */
+  upserted: number
+}
+
+export type RemoteAdapter = {
+  /** Returns the `topK` nearest vectors to a normalized query vector. */
+  query: (
+    vector: Float32Array,
+    options: { signal?: AbortSignal | undefined; topK: number },
+  ) => Promise<RemoteHit[]>
+  /** Syncs the full chunk set into the store (upserts new, prunes stale). */
+  sync: (
+    entries: readonly RemoteEntry[],
+    options: {
+      dimensions: number
+      onProgress?: ((done: number, total: number) => void) | undefined
+    },
+  ) => Promise<RemoteSyncResult>
+  /** Storage target backing the adapter. */
+  target: 'remote'
   /** Adapter type identifier. */
   type: string
 }
@@ -38,7 +95,7 @@ export type Adapter = {
  * ```
  */
 // biome-ignore lint/correctness/noUnusedVariables: re-exported below as `static`
-function staticStore(options: staticStore.Options = {}): Adapter {
+function staticStore(options: staticStore.Options = {}): StaticAdapter {
   return {
     type: 'static',
     target: 'static',
@@ -61,9 +118,293 @@ export declare namespace staticStore {
 
 export { staticStore as static }
 
+/**
+ * Cloudflare Vectorize vector store (remote). Vocs still chunks and embeds
+ * locally (with the configured `embedding` adapter); vectors are synced into a
+ * Vectorize index at build time and queried over REST at runtime, so no vector
+ * artifact ships with the server bundle.
+ *
+ * The index is created on first sync (cosine metric, dimensions inferred from
+ * the embedding). Sync is incremental: vector ids are content-addressed, so
+ * unchanged chunks are skipped and stale vectors are pruned. The API token
+ * needs the `Vectorize:Edit` permission.
+ *
+ * @example
+ * ```ts
+ * import { defineConfig, Embedding, Retriever, VectorStore } from 'vocs/config'
+ *
+ * export default defineConfig({
+ *   ai: {
+ *     retriever: Retriever.local({
+ *       embedding: Embedding.openai(),
+ *       vectorStore: VectorStore.cloudflare({ index: 'my-docs' }),
+ *     }),
+ *   },
+ * })
+ * ```
+ */
+export function cloudflare(options: cloudflare.Options = {}): RemoteAdapter {
+  const {
+    accountId = process.env['CLOUDFLARE_ACCOUNT_ID'],
+    apiToken = process.env['CLOUDFLARE_API_TOKEN'],
+    baseUrl = 'https://api.cloudflare.com/client/v4',
+    headers,
+    index = 'vocs-ai-search',
+  } = options
+
+  async function request(
+    path: string,
+    init: {
+      body?: string | undefined
+      contentType?: string | undefined
+      method?: string | undefined
+      signal?: AbortSignal | undefined
+    } = {},
+  ): Promise<Response> {
+    if (!accountId)
+      throw new Error(
+        '[vocs] VectorStore.cloudflare: missing `accountId` (or CLOUDFLARE_ACCOUNT_ID).',
+      )
+    if (!apiToken)
+      throw new Error(
+        '[vocs] VectorStore.cloudflare: missing `apiToken` (or CLOUDFLARE_API_TOKEN).',
+      )
+    const url = `${baseUrl.replace(/\/$/, '')}/accounts/${accountId}/vectorize/v2/indexes${path}`
+    return await fetch(url, {
+      method: init.method ?? 'GET',
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        ...(init.contentType ? { 'Content-Type': init.contentType } : {}),
+        ...headers,
+      },
+      ...(init.body !== undefined ? { body: init.body } : {}),
+      signal: init.signal ?? null,
+    })
+  }
+
+  /** Creates the index when missing; validates dimensions when present. */
+  async function ensureIndex(dimensions: number): Promise<void> {
+    const existing = await request(`/${index}`)
+    if (existing.ok) {
+      const json = (await existing.json()) as {
+        result?: { config?: { dimensions?: number | undefined } | undefined } | undefined
+      }
+      const remote = json.result?.config?.dimensions
+      if (remote !== undefined && remote !== dimensions)
+        throw new Error(
+          `[vocs] Vectorize index "${index}" has ${remote} dimensions, embedding produces ${dimensions}. Delete the index or configure a different \`index\` name.`,
+        )
+      return
+    }
+    if (existing.status !== 404)
+      throw new Error(
+        `[vocs] Vectorize get index failed (${existing.status}): ${await safeText(existing)}`,
+      )
+    const created = await request('', {
+      method: 'POST',
+      contentType: 'application/json',
+      body: JSON.stringify({ config: { dimensions, metric: 'cosine' }, name: index }),
+    })
+    if (!created.ok)
+      throw new Error(
+        `[vocs] Vectorize create index failed (${created.status}): ${await safeText(created)}`,
+      )
+  }
+
+  /** Enumerates all vector ids in the index, or `undefined` when unsupported. */
+  async function listIds(): Promise<Set<string> | undefined> {
+    const ids = new Set<string>()
+    let cursor: string | undefined
+    do {
+      const params = new URLSearchParams({ count: '1000' })
+      if (cursor) params.set('cursor', cursor)
+      const response = await request(`/${index}/list?${params}`)
+      if (!response.ok) {
+        console.warn(
+          `[vocs] Vectorize list vectors failed (${response.status}); skipping incremental sync (re-upserting all, no pruning).`,
+        )
+        return undefined
+      }
+      const json = (await response.json()) as {
+        result?:
+          | {
+              isTruncated?: boolean | undefined
+              nextCursor?: string | undefined
+              vectors?: { id?: string | undefined }[] | undefined
+            }
+          | undefined
+      }
+      for (const vector of json.result?.vectors ?? []) if (vector.id) ids.add(vector.id)
+      cursor = json.result?.isTruncated ? json.result?.nextCursor : undefined
+    } while (cursor)
+    return ids
+  }
+
+  return {
+    type: 'cloudflare',
+    target: 'remote',
+    async query(vector, { signal, topK }) {
+      const response = await request(`/${index}/query`, {
+        method: 'POST',
+        contentType: 'application/json',
+        body: JSON.stringify({
+          vector: Array.from(vector),
+          // Vectorize caps topK at 50 when returning metadata.
+          topK: Math.min(topK, 50),
+          returnValues: false,
+          returnMetadata: 'all',
+        }),
+        signal,
+      })
+      if (!response.ok)
+        throw new Error(
+          `[vocs] Vectorize query failed (${response.status}): ${await safeText(response)}`,
+        )
+      const json = (await response.json()) as {
+        result?:
+          | {
+              matches?:
+                | { id?: string | undefined; metadata?: unknown; score?: number | undefined }[]
+                | undefined
+            }
+          | undefined
+      }
+      return (json.result?.matches ?? []).map((match) => ({
+        id: match.id ?? '',
+        metadata:
+          typeof match.metadata === 'object' && match.metadata !== null
+            ? (match.metadata as Record<string, unknown>)
+            : undefined,
+        score: match.score ?? 0,
+      }))
+    },
+    async sync(entries, { dimensions, onProgress }) {
+      await ensureIndex(dimensions)
+
+      // Content-addressed ids: unchanged chunks keep their id across builds,
+      // so sync reduces to "upsert what's new, delete what's gone". Ids hash
+      // the bounded metadata so truncation stays stable across builds.
+      const local = new Map<string, RemoteEntry>()
+      for (const entry of entries) {
+        const bounded = { ...entry, metadata: boundMetadata(entry.metadata) }
+        local.set(await contentId(bounded), bounded)
+      }
+
+      const remote = await listIds()
+      const toUpsert = remote
+        ? [...local.keys()].filter((id) => !remote.has(id))
+        : [...local.keys()]
+      const toDelete = remote ? [...remote].filter((id) => !local.has(id)) : []
+
+      let upserted = 0
+      const batchSize = 500
+      for (let i = 0; i < toUpsert.length; i += batchSize) {
+        const batch = toUpsert.slice(i, i + batchSize)
+        const ndjson = batch
+          .map((id) => {
+            const entry = local.get(id)
+            if (!entry) return undefined
+            return JSON.stringify({
+              id,
+              metadata: entry.metadata,
+              values: Array.from(entry.vector),
+            })
+          })
+          .filter((line): line is string => line !== undefined)
+          .join('\n')
+        const response = await request(`/${index}/upsert`, {
+          method: 'POST',
+          contentType: 'application/x-ndjson',
+          body: ndjson,
+        })
+        if (!response.ok)
+          throw new Error(
+            `[vocs] Vectorize upsert failed (${response.status}): ${await safeText(response)}`,
+          )
+        upserted += batch.length
+        onProgress?.(upserted, toUpsert.length)
+      }
+
+      for (let i = 0; i < toDelete.length; i += 1000) {
+        const batch = toDelete.slice(i, i + 1000)
+        const response = await request(`/${index}/delete_by_ids`, {
+          method: 'POST',
+          contentType: 'application/json',
+          body: JSON.stringify({ ids: batch }),
+        })
+        if (!response.ok)
+          throw new Error(
+            `[vocs] Vectorize delete failed (${response.status}): ${await safeText(response)}`,
+          )
+      }
+
+      return {
+        deleted: toDelete.length,
+        skipped: local.size - toUpsert.length,
+        upserted: toUpsert.length,
+      }
+    },
+  }
+}
+
+export declare namespace cloudflare {
+  type Options = {
+    /** Cloudflare account id. @default process.env.CLOUDFLARE_ACCOUNT_ID */
+    accountId?: string | undefined
+    /** API token with the `Vectorize:Edit` permission. @default process.env.CLOUDFLARE_API_TOKEN */
+    apiToken?: string | undefined
+    /** API base URL. @default 'https://api.cloudflare.com/client/v4' */
+    baseUrl?: string | undefined
+    /** Extra request headers. */
+    headers?: Record<string, string> | undefined
+    /** Vectorize index name (created on first sync). @default 'vocs-ai-search' */
+    index?: string | undefined
+  }
+}
+
 /** Creates a vector-store adapter from a custom definition. */
 export function from(adapter: Adapter): Adapter {
   return adapter
+}
+
+/** Vectorize caps metadata at 10KiB/vector; trims the unbounded `text` field to fit. */
+function boundMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
+  const limit = 9216
+  let text = typeof metadata['text'] === 'string' ? metadata['text'] : undefined
+  for (;;) {
+    const out = text !== undefined ? { ...metadata, text } : metadata
+    const size = new TextEncoder().encode(JSON.stringify(out)).length
+    if (size <= limit || !text) return out
+    text = text.slice(0, Math.max(0, text.length - (size - limit)))
+  }
+}
+
+/**
+ * Content-addressed vector id: SHA-256 over chunk id, metadata, and vector
+ * bytes. 64 hex chars — exactly Vectorize's 64-byte id cap.
+ */
+async function contentId(entry: RemoteEntry): Promise<string> {
+  const prefix = new TextEncoder().encode(`${entry.id}\0${JSON.stringify(entry.metadata)}\0`)
+  const vector = new Uint8Array(
+    entry.vector.buffer,
+    entry.vector.byteOffset,
+    entry.vector.byteLength,
+  )
+  const bytes = new Uint8Array(prefix.length + vector.length)
+  bytes.set(prefix, 0)
+  bytes.set(vector, prefix.length)
+  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', bytes))
+  let hex = ''
+  for (const byte of digest) hex += byte.toString(16).padStart(2, '0')
+  return hex
+}
+
+async function safeText(response: Response): Promise<string> {
+  try {
+    return (await response.text()).slice(0, 200)
+  } catch {
+    return ''
+  }
 }
 
 /**
@@ -194,7 +535,10 @@ export function search(store: Store, query: Float32Array, topK: number): SearchR
 }
 
 /** Resolves `'auto'` to a concrete format for the given runtime. */
-export function resolveFormat(format: Adapter['format'], runtime: 'server' | 'client'): Format {
+export function resolveFormat(
+  format: StaticAdapter['format'],
+  runtime: 'server' | 'client',
+): Format {
   if (format !== 'auto') return format
   return runtime === 'client' ? 'int8' : 'float32'
 }

--- a/src/internal/vite-plugins.ts
+++ b/src/internal/vite-plugins.ts
@@ -822,8 +822,12 @@ export function aiSearch(config: Config.Config): PluginOption {
 
   const { rootDir, basePath } = config
   const localEnabled = Boolean(config._localRetriever)
+  const vectorStore = config._localRetriever?.vectorStore
+  // Remote store: build-time work is syncing vectors into the database; no
+  // index artifact (server manifest or public browser file) is emitted.
+  const remoteStore = vectorStore?.target === 'remote'
   const exposePublic =
-    ai?.runtime === 'client' || config._localRetriever?.vectorStore.expose === true
+    ai?.runtime === 'client' || (vectorStore?.target === 'static' && vectorStore.expose === true)
 
   let mode: 'development' | 'production' = 'development'
   let manifestPromise: Promise<Retriever.IndexManifest> | undefined
@@ -848,7 +852,9 @@ export function aiSearch(config: Config.Config): PluginOption {
           }
           await Retriever.saveIndex(config, manifest)
           logger.info(
-            `AI search index built (${manifest.vectorStore.count} chunks, ${manifest.vectorStore.format}).`,
+            remoteStore
+              ? `AI search index synced (${manifest.vectorStore.count} chunks, remote vector store).`
+              : `AI search index built (${manifest.vectorStore.count} chunks, ${manifest.vectorStore.format}).`,
             { timestamp: true },
           )
           return manifest
@@ -909,8 +915,10 @@ export function aiSearch(config: Config.Config): PluginOption {
     async load(id) {
       if (id === resolvedServerManifestId) {
         // Dev never builds; the server loads the manifest written by
-        // `vocs embeddings generate` from disk instead.
-        if (!localEnabled || mode === 'development' || skipSeeding()) return emptyManifestModule
+        // `vocs embeddings generate` from disk instead. A remote store needs
+        // no baked manifest either — the server queries the database directly.
+        if (!localEnabled || remoteStore || mode === 'development' || skipSeeding())
+          return emptyManifestModule
         const manifest = await buildManifest()
         // Emit as a gzipped asset. Inlining the JSON into the chunk bloats
         // server bundles (manifests can be tens of MB).
@@ -952,7 +960,7 @@ export const getAiSearchManifest = async () =>
       await fs.writeFile(path.join(dir, `ai-search-index-${publicHash}.json`), json, 'utf-8')
 
       const bytes = Buffer.byteLength(json)
-      const max = config._localRetriever?.vectorStore.maxClientBytes
+      const max = vectorStore?.target === 'static' ? vectorStore.maxClientBytes : undefined
       if (max && bytes > max)
         logger.warn(
           `AI search client index is ${(bytes / 1e6).toFixed(1)}MB, exceeds maxClientBytes (${(max / 1e6).toFixed(1)}MB). Consider int8 format or fewer chunks.`,

--- a/src/waku/internal/middleware/ai-search-warmup.test.ts
+++ b/src/waku/internal/middleware/ai-search-warmup.test.ts
@@ -1,0 +1,93 @@
+import { Hono } from 'hono'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Mock Config.resolve / Retriever.ensureServerIndex so we can observe the
+// warm-up kick without a real vocs config or index build.
+vi.mock('../../../internal/config.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../internal/config.js')>(
+    '../../../internal/config.js',
+  )
+  return { ...actual, resolve: vi.fn() }
+})
+vi.mock('../../../internal/retriever.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../internal/retriever.js')>(
+    '../../../internal/retriever.js',
+  )
+  return { ...actual, ensureServerIndex: vi.fn() }
+})
+
+import * as Config from '../../../internal/config.js'
+import * as Retriever from '../../../internal/retriever.js'
+import { aiSearchWarmup } from './ai-search-warmup.js'
+
+const mockResolve = vi.mocked(Config.resolve)
+const mockEnsure = vi.mocked(Retriever.ensureServerIndex)
+
+afterEach(() => vi.resetAllMocks())
+
+/** Creates a Hono app with the warmup middleware and a catch-all handler. */
+function createApp() {
+  const app = new Hono()
+  app.use('*', aiSearchWarmup())
+  app.get('*', (c) => c.text('ok'))
+  return app
+}
+
+function localConfig() {
+  // `_localRetriever` presence is all the middleware checks.
+  return { _localRetriever: {} } as unknown as Config.Config
+}
+
+/** Lets the fire-and-forget warm-up chain settle. */
+function settle() {
+  return new Promise((resolve) => setTimeout(resolve, 10))
+}
+
+describe('aiSearchWarmup', () => {
+  it('kicks off the index build once, without blocking requests', async () => {
+    mockResolve.mockResolvedValue(localConfig())
+    mockEnsure.mockReturnValue({ status: 'ready', promise: Promise.resolve() } as never)
+
+    const app = createApp()
+    expect(await (await app.request('http://localhost/')).text()).toBe('ok')
+    await vi.waitFor(() => expect(mockEnsure).toHaveBeenCalledTimes(1))
+    expect(mockEnsure.mock.calls[0]?.[1]?.loadManifest).toBeTypeOf('function')
+
+    // Subsequent requests don't re-kick the warm-up.
+    await app.request('http://localhost/docs')
+    await settle()
+    expect(mockEnsure).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips when no local retriever is configured', async () => {
+    mockResolve.mockResolvedValue({} as Config.Config)
+
+    const app = createApp()
+    expect((await app.request('http://localhost/')).status).toBe(200)
+    await settle()
+    expect(mockEnsure).not.toHaveBeenCalled()
+  })
+
+  it('skips in development (dev loads the index lazily)', async () => {
+    const prev = process.env['NODE_ENV']
+    process.env['NODE_ENV'] = 'development'
+    try {
+      const app = createApp()
+      expect((await app.request('http://localhost/')).status).toBe(200)
+      await settle()
+      expect(mockResolve).not.toHaveBeenCalled()
+      expect(mockEnsure).not.toHaveBeenCalled()
+    } finally {
+      process.env['NODE_ENV'] = prev
+    }
+  })
+
+  it('serves requests even when warm-up fails', async () => {
+    mockResolve.mockRejectedValue(new Error('no config'))
+
+    const app = createApp()
+    expect((await app.request('http://localhost/')).status).toBe(200)
+    await settle()
+    expect(mockEnsure).not.toHaveBeenCalled()
+  })
+})

--- a/src/waku/internal/middleware/ai-search-warmup.test.ts
+++ b/src/waku/internal/middleware/ai-search-warmup.test.ts
@@ -33,9 +33,9 @@ function createApp() {
   return app
 }
 
-function localConfig() {
-  // `_localRetriever` presence is all the middleware checks.
-  return { _localRetriever: {} } as unknown as Config.Config
+function localConfig(target: 'static' | 'remote' = 'static') {
+  // The middleware checks `_localRetriever` presence and the vector-store target.
+  return { _localRetriever: { vectorStore: { target } } } as unknown as Config.Config
 }
 
 /** Lets the fire-and-forget warm-up chain settle. */
@@ -61,6 +61,15 @@ describe('aiSearchWarmup', () => {
 
   it('skips when no local retriever is configured', async () => {
     mockResolve.mockResolvedValue({} as Config.Config)
+
+    const app = createApp()
+    expect((await app.request('http://localhost/')).status).toBe(200)
+    await settle()
+    expect(mockEnsure).not.toHaveBeenCalled()
+  })
+
+  it('skips for a remote vector store (no in-process index to warm)', async () => {
+    mockResolve.mockResolvedValue(localConfig('remote'))
 
     const app = createApp()
     expect((await app.request('http://localhost/')).status).toBe(200)

--- a/src/waku/internal/middleware/ai-search-warmup.ts
+++ b/src/waku/internal/middleware/ai-search-warmup.ts
@@ -1,0 +1,50 @@
+import type { MiddlewareHandler } from 'hono'
+
+/**
+ * Warms the local AI search index on the first request of a server instance.
+ *
+ * Serverless instances build their in-process index lazily, so without
+ * warming, the first `/api/search` on each cold instance answers
+ * `indexing: true`. Kicking the build off on the first request (usually a
+ * page load, well before the user opens search) hides that latency.
+ *
+ * The build runs within request context (required on Workers-style runtimes,
+ * which forbid I/O at module scope) and never blocks the request. Modules are
+ * imported lazily so server boot stays lean.
+ */
+export const aiSearchWarmup = (): MiddlewareHandler => {
+  let warmed = false
+  return (context, next) => {
+    if (!warmed) {
+      warmed = true
+      const build = warm()
+      // Keep the build alive past the response where supported (Workers).
+      try {
+        context.executionCtx?.waitUntil?.(build)
+      } catch {
+        // Hono throws when the runtime has no execution context (Node).
+      }
+    }
+    return next()
+  }
+}
+
+export default aiSearchWarmup
+
+/** Kicks the index build. Best-effort: `/api/search` surfaces real errors. */
+async function warm(): Promise<void> {
+  try {
+    // Dev never builds the index (see `resolveServerIndex`); load it lazily.
+    if (process.env['NODE_ENV'] === 'development') return
+    const [Config, Retriever, { loadAiSearchManifest }] = await Promise.all([
+      import('../../../internal/config.js'),
+      import('../../../internal/retriever.js'),
+      import('../ai-search.js'),
+    ])
+    const config = await Config.resolve({ server: true })
+    if (!config._localRetriever) return
+    await Retriever.ensureServerIndex(config, { loadManifest: loadAiSearchManifest }).promise
+  } catch {
+    // `ensureServerIndex` already logs build failures.
+  }
+}

--- a/src/waku/internal/middleware/ai-search-warmup.ts
+++ b/src/waku/internal/middleware/ai-search-warmup.ts
@@ -43,6 +43,8 @@ async function warm(): Promise<void> {
     ])
     const config = await Config.resolve({ server: true })
     if (!config._localRetriever) return
+    // Remote vector store: no in-process index to warm (queried in the database).
+    if (config._localRetriever.vectorStore.target === 'remote') return
     await Retriever.ensureServerIndex(config, { loadManifest: loadAiSearchManifest }).promise
   } catch {
     // `ensureServerIndex` already logs build failures.

--- a/src/waku/internal/middleware/index.ts
+++ b/src/waku/internal/middleware/index.ts
@@ -1,3 +1,4 @@
+export { default as aiSearchWarmup } from './ai-search-warmup.js'
 export { default as mdRouter } from './md-router.js'
 export { default as redirects } from './redirects.js'
 export { default as trailingSlash } from './trailing-slash.js'


### PR DESCRIPTION
Adds `VectorStore.cloudflare()`: `Retriever.local` syncs vectors to a Cloudflare Vectorize index at build time and queries it at runtime, keeping the vector artifact out of the server bundle. Also warms the static index on first request instead of answering `indexing: true`.
