### PR TITLE
fix: sanitize remote vector metadata, drop holes in title breadcrumbs

### DIFF
--- a/.changeset/large-hats-brush.md
+++ b/.changeset/large-hats-brush.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed `titles` breadcrumbs containing holes when heading levels are skipped.

--- a/src/internal/search.test.ts
+++ b/src/internal/search.test.ts
@@ -667,7 +667,6 @@ Then do this.
           "title": "Step one",
           "titles": [
             "Getting Started",
-            undefined,
           ],
         },
         {
@@ -678,7 +677,6 @@ Then do this.
           "title": "Step two",
           "titles": [
             "Getting Started",
-            undefined,
           ],
         },
       ]

--- a/src/internal/search.ts
+++ b/src/internal/search.ts
@@ -386,7 +386,8 @@ export function extract(source: string, config: Config.Config): extract.ReturnTy
 
         // Update title stack based on heading depth
         titleStack.length = depth - 1
-        const titles = [...titleStack]
+        // Skipped heading levels leave holes; drop them from the breadcrumb.
+        const titles = [...titleStack].filter((t) => t !== undefined)
         titleStack[depth - 1] = title
 
         currentSection = {

--- a/src/internal/vector-store.test.ts
+++ b/src/internal/vector-store.test.ts
@@ -195,6 +195,38 @@ describe('cloudflare (remote adapter)', () => {
     expect(String(stored?.metadata['text']).length).toBeGreaterThan(0)
   })
 
+  it('sanitizes metadata to Vectorize types (string | number | boolean | string[])', async () => {
+    const state = mockVectorize()
+    const store = VectorStore.cloudflare(credentials)
+
+    await store.sync(
+      [
+        {
+          id: 'a',
+          // Sparse `titles` (skipped heading levels) serialize as nulls.
+          metadata: {
+            href: '/a',
+            nested: { drop: true },
+            none: null,
+            title: 'a',
+            titles: ['Guide', null, 'Steps'],
+            weight: 0.8,
+          },
+          vector: VectorStore.normalize([1, 0]),
+        },
+      ],
+      { dimensions: 2 },
+    )
+
+    const [stored] = [...state.vectors.values()]
+    expect(stored?.metadata).toEqual({
+      href: '/a',
+      title: 'a',
+      titles: ['Guide', 'Steps'],
+      weight: 0.8,
+    })
+  })
+
   it('queries nearest vectors and caps topK at 50', async () => {
     const state = mockVectorize()
     const store = VectorStore.cloudflare(credentials)

--- a/src/internal/vector-store.ts
+++ b/src/internal/vector-store.ts
@@ -286,7 +286,10 @@ export function cloudflare(options: cloudflare.Options = {}): RemoteAdapter {
       // the bounded metadata so truncation stays stable across builds.
       const local = new Map<string, RemoteEntry>()
       for (const entry of entries) {
-        const bounded = { ...entry, metadata: boundMetadata(entry.metadata) }
+        const bounded = {
+          ...entry,
+          metadata: boundMetadata(sanitizeMetadata(entry.metadata)),
+        }
         local.set(await contentId(bounded), bounded)
       }
 
@@ -365,6 +368,18 @@ export declare namespace cloudflare {
 /** Creates a vector-store adapter from a custom definition. */
 export function from(adapter: Adapter): Adapter {
   return adapter
+}
+
+/** Vectorize metadata values must be string | number | boolean | string[]; drops the rest. */
+function sanitizeMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(metadata)) {
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean')
+      out[key] = value
+    else if (Array.isArray(value))
+      out[key] = value.filter((item): item is string => typeof item === 'string')
+  }
+  return out
 }
 
 /** Vectorize caps metadata at 10KiB/vector; trims the unbounded `text` field to fit. */


### PR DESCRIPTION
Sanitizes remote vector store metadata to Vectorize-supported types (strings-only arrays) and stops skipped heading levels leaving holes in `titles` breadcrumbs. Found syncing a real index in https://github.com/wevm/vocs/pull/573.
