### PR TITLE
fix: strip twoslash cache comments from search index text

### DIFF
--- a/.changeset/light-hats-tease.md
+++ b/.changeset/light-hats-tease.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed search indexing leaking persisted twoslash cache comments (giant base64 blobs) into section text, snippets, and embeddings.

--- a/src/internal/search.test.ts
+++ b/src/internal/search.test.ts
@@ -40,6 +40,22 @@ Some text.
     expect(sections.length).toBe(1)
   })
 
+  it('strips inline twoslash cache comments from code blocks', () => {
+    const content = `
+# Getting Started
+
+Set up your client.
+
+\`\`\`ts twoslash
+// @twoslash-cache: {"v":1,"hash":"abc123","data":"N4Igdg9gJgpgziAXAbVAFwJ4AcZJACwgDcYAnEAGhDRgA808AKAQwBsBLZuASgAIAzAK5gAxmnYQwvEaRjMaABUEAjDiIDCHGMBpQ4vACqHjps+YvT8zdlKvbbvdR5evAA+vMKw/F4wULwAvGE2MJFg0W7MIiIQwmgA8qQAglBQsnB2PjZ2+RlZOiG8hcXwdqHhSVEx8a3JqbykWCIAyiL4MAC2zJb0vnYASv1DI+N1Xe1xCRHtbpnGFmgQANbaZVMVDgdHy4ndHettKVAAfIxYzIajMDSkcIi8SqrsGi06nUiA"]}
+import { createPublicClient } from 'viem'
+\`\`\`
+`
+    const [section] = Search.extract(content, config).sections
+    expect(section?.text).not.toContain('@twoslash-cache')
+    expect(section?.text).toContain("import { createPublicClient } from 'viem'")
+  })
+
   it('extracts sections from headings', () => {
     const content = `
 # Getting Started

--- a/src/internal/search.ts
+++ b/src/internal/search.ts
@@ -14,7 +14,7 @@ import * as UnistUtil from 'unist-util-visit'
 import * as yaml from 'yaml'
 import type * as Config from './config.js'
 import * as MarkdownImports from './markdown-imports.js'
-import { extractSubheading, getPhrasingContentText } from './mdx.js'
+import { extractSubheading, getPhrasingContentText, remarkStripInlineCache } from './mdx.js'
 import * as OpenApiRegistry from './openapi/registry.js'
 import * as OpenApiSearch from './openapi/search.js'
 import * as Path from './path.js'
@@ -323,6 +323,9 @@ export function extract(source: string, config: Config.Config): extract.ReturnTy
     remarkGfm,
     remarkStripJsx,
     remarkStripDirectives,
+    // Persisted twoslash cache comments are giant base64 blobs; without this
+    // they leak into section text (and search snippets/embeddings).
+    remarkStripInlineCache,
     // User plugins extend the parser (e.g. `remark-math`) so syntax
     // recognized in the React build also parses during indexing.
     ...(config.markdown?.remarkPlugins ?? []),


### PR DESCRIPTION
Search indexing parsed raw MDX without stripping persisted `// @twoslash-cache: ...` comments, so the giant base64 blobs leaked into section text, snippets, and embeddings. Adds `remarkStripInlineCache` (already used for llms.txt output) to the search extraction pipeline.
