### PR TITLE
fix(openapi): collapse `x-tagGroups` sections

### DIFF
--- a/.changeset/tidy-rivers-collapse.md
+++ b/.changeset/tidy-rivers-collapse.md
@@ -1,0 +1,5 @@
+---
+'vocs': patch
+---
+
+Collapsed OpenAPI tag group sections when generated sidebar categories were configured as collapsed.

--- a/src/internal/openapi/openapi.ts
+++ b/src/internal/openapi/openapi.ts
@@ -55,9 +55,9 @@ export type SidebarExtras = {
    */
   intro?: SidebarItem[] | undefined
   /**
-   * Collapse the generated category groups by default. The group matching the
-   * active page still auto-expands, so deep links stay navigable. The generated
-   * `Introduction` entry is unaffected.
+   * Collapse the generated category groups and `x-tagGroups` sections by default.
+   * Groups containing the active page still auto-expand, so deep links stay
+   * navigable. The generated `Introduction` entry is unaffected.
    *
    * @default false
    */

--- a/src/internal/openapi/sidebar.test.ts
+++ b/src/internal/openapi/sidebar.test.ts
@@ -94,7 +94,7 @@ describe('toSidebar', () => {
     expect((sidebar[1] as { collapsed: boolean }).collapsed).toBe(true)
   })
 
-  test('nests claimed groups under static section headers from tagGroups', () => {
+  test('nests claimed groups under collapsible section headers from tagGroups', () => {
     const sectioned: Ir = {
       ...ir,
       groups: [
@@ -121,13 +121,11 @@ describe('toSidebar', () => {
     }
     const sidebar = toSidebar(sectioned, { collapsed: true })
     expect(sidebar.map((item) => item.text)).toEqual(['Introduction', 'Data API', 'Platform API'])
-    // Sections are static headers (not collapsible); nested groups keep the
-    // `collapsed` behavior.
     const section = sidebar[1] as {
       collapsed?: boolean
       items: { text?: string; collapsed?: boolean }[]
     } // prettier-ignore
-    expect(section.collapsed).toBeUndefined()
+    expect(section.collapsed).toBe(true)
     expect(section.items.map((item) => item.text)).toEqual(['pets'])
     expect(section.items[0]?.collapsed).toBe(true)
   })
@@ -171,7 +169,7 @@ describe('toSidebar', () => {
     }
     const sidebar = toSidebar(sectioned, { flatten: ['Data API'] })
     // `pets` renders top-level where its section would sit; `Platform API`
-    // keeps its section header.
+    // keeps its static section header.
     expect(sidebar.map((item) => item.text)).toEqual(['Introduction', 'pets', 'Platform API'])
     const pets = sidebar[1] as { collapsed?: boolean }
     const section = sidebar[2] as { collapsed?: boolean; items: { text?: string }[] }

--- a/src/internal/openapi/sidebar.ts
+++ b/src/internal/openapi/sidebar.ts
@@ -61,8 +61,8 @@ export function toSidebar(ir: Ir, options: toSidebar.Options = {}): SidebarItem<
   // group id, rendered after the group's "Overview" link.
   const groupExtras = options.groupExtras ?? new Map<string, SidebarItem[]>()
 
-  // Generated category groups start collapsed when `collapsed` is set (the
-  // active group still auto-expands at render). `Introduction` is unaffected.
+  // Generated category groups and sections start collapsed when `collapsed` is
+  // set. Active groups still auto-expand at render. `Introduction` is unaffected.
   const groupCollapsed = options.collapsed ?? false
 
   const groupItem = (group: Ir['groups'][number]): SidebarItem<true> => ({
@@ -89,9 +89,8 @@ export function toSidebar(ir: Ir, options: toSidebar.Options = {}): SidebarItem<
   const tagGroups = ir.tagGroups ?? []
   if (tagGroups.length === 0) return [introduction, ...ir.groups.map(groupItem)]
 
-  // `x-tagGroups` sections render as static headers (no `collapsed`, so not
-  // collapsible); the per-category `collapsed` behavior applies unchanged.
-  // Sections named in `flatten` spread their categories in place instead.
+  // `x-tagGroups` sections render as collapsible headers. Sections named in
+  // `flatten` spread their categories in place instead.
   const flatten = new Set(options.flatten ?? [])
   const groupById = new Map(ir.groups.map((group) => [group.id, group]))
   const claimed = new Set(tagGroups.flatMap((tagGroup) => tagGroup.groupIds))
@@ -101,7 +100,7 @@ export function toSidebar(ir: Ir, options: toSidebar.Options = {}): SidebarItem<
       return group ? [groupItem(group)] : []
     })
     if (flatten.has(tagGroup.name)) return items
-    return [{ text: tagGroup.name, items }]
+    return [{ text: tagGroup.name, collapsed: options.collapsed, items }]
   })
   return [
     introduction,
@@ -117,8 +116,8 @@ export declare namespace toSidebar {
     /** Extra items injected into a generated group, keyed by group id. */
     groupExtras?: Map<string, SidebarItem[]> | undefined
     /**
-     * Collapse the generated category groups by default (the active group still
-     * auto-expands). `Introduction` is unaffected. @default false
+     * Collapse generated category groups and `x-tagGroups` sections by default.
+     * Active groups still auto-expand. `Introduction` is unaffected. @default false
      */
     collapsed?: boolean | undefined
     /**


### PR DESCRIPTION
Makes OpenAPI `x-tagGroups` sections respect `sidebar.collapsed`, so secondary API groups start closed while active routes still expand for navigation.
