### PR TITLE
feat(mcp): add `submit_feedback` and markdown guidance

### DIFF
--- a/.changeset/quiet-tools-listen.md
+++ b/.changeset/quiet-tools-listen.md
@@ -1,0 +1,5 @@
+---
+'vocs': minor
+---
+
+Added agent guidance to Markdown page twins and a `submit_feedback` MCP tool for configured feedback adapters.

--- a/site/src/pages/features/agent-support.mdx
+++ b/site/src/pages/features/agent-support.mdx
@@ -36,6 +36,11 @@ https://docs.example.com/index.md
 
 This is useful for copying documentation into AI conversations or for custom integrations.
 
+When the [MCP server](/features/mcp-server) is enabled, each generated Markdown page starts
+with its endpoint and suggests using `search_docs`. If feedback is also configured,
+the prelude suggests the `submit_feedback` tool. These instructions are not repeated in
+`llms.txt` or `llms-full.txt`.
+
 ## llms.txt Files
 
 Vocs automatically generates [`llms.txt`](https://llmstxt.org/) files for LLM consumption:

--- a/site/src/pages/features/feedback.mdx
+++ b/site/src/pages/features/feedback.mdx
@@ -12,6 +12,9 @@ export default defineConfig({
 })
 ```
 
+When the [MCP server](/features/mcp-server) is also enabled, Vocs exposes a `submit_feedback`
+tool that sends agent feedback through the same adapter.
+
 ## Slack Adapter
 
 The Slack adapter sends feedback to a Slack channel via an [incoming webhook](https://api.slack.com/messaging/webhooks).

--- a/site/src/pages/features/mcp-server.mdx
+++ b/site/src/pages/features/mcp-server.mdx
@@ -6,7 +6,9 @@ import { Card, Cards } from 'vocs'
 
 Vocs includes a built-in [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server. When enabled, AI clients can read, search, and browse your docs — and optionally source repositories you choose to expose — from a single endpoint at `/api/mcp`.
 
-The server is read-only. Vocs supports Streamable HTTP (`POST /api/mcp`) and the older HTTP+SSE transport (`GET /api/mcp`).
+Documentation and source-code tools are read-only. When page feedback is configured, Vocs also
+exposes an additive `submit_feedback` tool. Vocs supports Streamable HTTP (`POST /api/mcp`) and
+the older HTTP+SSE transport (`GET /api/mcp`).
 
 ## Setup
 
@@ -65,6 +67,24 @@ export default defineConfig({
 This adds the source tools: `list_sources`, `list_source_files`, `read_source_file`, `get_file_tree`, and `search_source` (when the adapter supports it).
 
 Set `GITHUB_TOKEN` for higher rate limits and to enable authenticated code search.
+
+### Collect Feedback from Agents
+
+Configure both MCP and [page feedback](/features/feedback) to expose `submit_feedback`.
+
+```ts [vocs.config.ts]
+import { defineConfig, Feedback } from 'vocs/config'
+
+export default defineConfig({
+  feedback: Feedback.slack(), // [!code focus]
+  mcp: { enabled: true },
+})
+```
+
+The tool accepts `pagePath`, `helpful`, and optional `category` and `message` fields. Vocs derives
+the page URL and timestamp before forwarding the submission to the configured feedback adapter.
+Generated Markdown pages include the MCP server endpoint and point agents to `search_docs` and
+`submit_feedback`.
 
 ### Build a Custom Adapter
 

--- a/site/src/pages/reference/site-config.mdx
+++ b/site/src/pages/reference/site-config.mdx
@@ -929,6 +929,7 @@ See [Feedback](/features/feedback) for adapter setup and custom integrations.
 ```
 
 Configures Vocs' built-in MCP server. When enabled, Vocs serves the endpoint at `/api/mcp`.
+Configuring [`feedback`](#feedback) also adds the `submit_feedback` tool.
 
 ```ts
 import { McpSource, defineConfig } from 'vocs/config'

--- a/src/internal/llms.test.ts
+++ b/src/internal/llms.test.ts
@@ -5,7 +5,7 @@ import remarkDirective from 'remark-directive'
 import type { Pluggable } from 'unified'
 import { describe, expect, test } from 'vitest'
 import type * as Changelog from './changelog.js'
-import { buildLlmsContent } from './llms.js'
+import { buildLlmsContent, getMarkdownPagePrelude } from './llms.js'
 import {
   remarkChangelogMarkdown,
   remarkDefaultFrontmatter,
@@ -349,6 +349,25 @@ This is the home page.`,
     `)
   })
 
+  test('prepends guidance to page content without repeating it in llms-full.txt', async () => {
+    const pagePrelude =
+      "> **Can't find what you're looking for?** Use `search_docs` on the docs MCP server."
+    const result = await buildLlmsContent({
+      pages: [{ path: '/page', content: '---\ntitle: Page\n---\n\nContent.' }],
+      pagePrelude,
+      title: 'My Docs',
+      ...plugins,
+    })
+
+    expect(result.results[0]?.content).toMatchInlineSnapshot(`
+      "> **Can't find what you're looking for?** Use \`search_docs\` on the docs MCP server.
+
+      Content.
+      "
+    `)
+    expect(result.full).not.toContain(pagePrelude)
+  })
+
   test('description is included in output when provided', async () => {
     const result = await buildLlmsContent({
       pages: [{ path: '/', content: '---\ntitle: Home\n---\n\nWelcome to the docs.' }],
@@ -629,5 +648,28 @@ import Notes from '../../notes.md'
 
     expect(result.results[0]?.content).toContain('Some indexable prose about widgets.')
     expect(result.full).toContain('Some indexable prose about widgets.')
+  })
+})
+
+describe('getMarkdownPagePrelude', () => {
+  test('links to the configured MCP endpoint and feedback tool', () => {
+    const result = getMarkdownPagePrelude({
+      basePath: '/developers',
+      baseUrl: 'https://tempo.xyz',
+      feedback: true,
+      mcp: { enabled: true },
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+      "> **Can't find what you're looking for?** Use \`search_docs\` on the docs MCP server at \`https://tempo.xyz/developers/api/mcp\` to find what you need.
+      >
+      > **Have feedback?** Use \`submit_feedback\` on the same MCP server."
+    `)
+  })
+
+  test('omits the prelude when MCP is disabled', () => {
+    expect(
+      getMarkdownPagePrelude({ basePath: '/', feedback: true, mcp: { enabled: false } }),
+    ).toBeUndefined()
   })
 })

--- a/src/internal/llms.ts
+++ b/src/internal/llms.ts
@@ -10,7 +10,7 @@ import * as OpenApiMarkdown from './openapi/markdown.js'
 import type * as Sidebar from './sidebar.js'
 
 export async function buildLlmsContent(options: buildLlmsContent.Options) {
-  const { title, description, rehypePlugins, remarkPlugins, sidebar } = options
+  const { title, description, pagePrelude, rehypePlugins, remarkPlugins, sidebar } = options
 
   // Dedupe by path (first occurrence wins), so consumer-authored source pages
   // take precedence over generated pages (e.g. OpenAPI) mounted at the same path.
@@ -84,8 +84,14 @@ export async function buildLlmsContent(options: buildLlmsContent.Options) {
   const sitemap = ['<!--', 'Sitemap:', ...nav, '-->', ''].join('\n')
   const short = [...llmsTxtContent, ...nav]
   const full = [...llmsTxtContent, sitemap, ...results.map((r) => r.content)]
+  const pageResults = pagePrelude
+    ? results.map((result) => ({
+        ...result,
+        content: `${pagePrelude}\n\n${result.content}`,
+      }))
+    : results
 
-  return { full: full.join('\n'), results, short: short.join('\n') }
+  return { full: full.join('\n'), results: pageResults, short: short.join('\n') }
 }
 
 export declare namespace buildLlmsContent {
@@ -93,6 +99,7 @@ export declare namespace buildLlmsContent {
     pages: Page[]
     title: string
     description?: string | undefined
+    pagePrelude?: string | undefined
     rehypePlugins: PluggableList
     remarkPlugins: PluggableList
     sidebar?: Config.Config['sidebar'] | undefined
@@ -109,6 +116,27 @@ export declare namespace buildLlmsContent {
     title?: string | undefined
     description?: string | undefined
   }
+}
+
+export function getMarkdownPagePrelude(config: getMarkdownPagePrelude.Options) {
+  if (!config.mcp?.enabled) return undefined
+
+  const baseUrl = config.baseUrl?.replace(/\/$/, '') ?? ''
+  const basePathValue = config.basePath.replace(/^\/+|\/+$/g, '')
+  const basePath = basePathValue ? `/${basePathValue}` : ''
+  const mcpUrl = `${baseUrl}${basePath}/api/mcp`
+  const lines = [
+    `> **Can't find what you're looking for?** Use \`search_docs\` on the docs MCP server at \`${mcpUrl}\` to find what you need.`,
+  ]
+
+  if (config.feedback)
+    lines.push('> **Have feedback?** Use `submit_feedback` on the same MCP server.')
+
+  return lines.join('\n>\n')
+}
+
+export declare namespace getMarkdownPagePrelude {
+  type Options = Pick<Config.Config, 'basePath' | 'baseUrl' | 'feedback' | 'mcp'>
 }
 
 /**

--- a/src/internal/mcp.test.ts
+++ b/src/internal/mcp.test.ts
@@ -3,9 +3,10 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as Config from './config.js'
 import * as Embedding from './embedding.js'
+import type * as Feedback from './feedback.js'
 import * as Mcp from './mcp.js'
 import * as Retriever from './retriever.js'
 
@@ -26,6 +27,7 @@ beforeEach(() => {
   )
 })
 afterEach(() => {
+  vi.restoreAllMocks()
   fs.rmSync(dir, { recursive: true, force: true })
 })
 
@@ -88,5 +90,77 @@ describe('search_docs', () => {
     expect(results).toHaveLength(1)
     expect(results[0]?.path).toBe('/deploy')
     expect(results[0]?.snippet).toContain('production hosting')
+  })
+})
+
+describe('submit_feedback', () => {
+  it('submits page feedback through the configured adapter', async () => {
+    const submit = vi.fn(async (_data: Feedback.FeedbackData) => {})
+    const config = Config.define({
+      rootDir: dir,
+      basePath: '/reference',
+      baseUrl: 'https://docs.example.com',
+      feedback: { type: 'test', submit },
+      mcp: { enabled: true },
+    })
+
+    const server = Mcp.createServer(config)
+    const client = await connect(server)
+    const tools = await client.listTools()
+    const result = await client.callTool({
+      name: 'submit_feedback',
+      arguments: {
+        pagePath: '/deploy',
+        helpful: false,
+        category: 'Outdated',
+        message: 'The deployment instructions are stale.',
+      },
+    })
+
+    expect(tools.tools.map((tool) => tool.name)).toContain('submit_feedback')
+    expect(result.isError).not.toBe(true)
+    expect(resultText(result)).toBe('Feedback submitted successfully.')
+    expect(submit).toHaveBeenCalledOnce()
+    expect(submit).toHaveBeenCalledWith({
+      helpful: false,
+      category: 'Outdated',
+      message: 'The deployment instructions are stale.',
+      pageUrl: 'https://docs.example.com/reference/deploy',
+      timestamp: expect.any(String),
+    })
+  })
+
+  it('is not registered without a feedback adapter', async () => {
+    const config = Config.define({ rootDir: dir, mcp: { enabled: true } })
+
+    const server = Mcp.createServer(config)
+    const client = await connect(server)
+    const tools = await client.listTools()
+
+    expect(tools.tools.map((tool) => tool.name)).not.toContain('submit_feedback')
+  })
+
+  it('returns an MCP error when the adapter rejects the submission', async () => {
+    const error = new Error('Adapter failed')
+    const submit = vi.fn(async (_data: Feedback.FeedbackData) => {
+      throw error
+    })
+    const log = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const config = Config.define({
+      rootDir: dir,
+      feedback: { type: 'test', submit },
+      mcp: { enabled: true },
+    })
+
+    const server = Mcp.createServer(config)
+    const client = await connect(server)
+    const result = await client.callTool({
+      name: 'submit_feedback',
+      arguments: { pagePath: '/', helpful: true },
+    })
+
+    expect(result.isError).toBe(true)
+    expect(resultText(result)).toBe('Failed to submit feedback.')
+    expect(log).toHaveBeenCalledWith('[vocs] mcp submit_feedback failed:', error)
   })
 })

--- a/src/internal/mcp.ts
+++ b/src/internal/mcp.ts
@@ -167,6 +167,52 @@ export function createServer(config: Config, options: createServer.Options = {})
     },
   )
 
+  if (config._feedback) {
+    const feedback = config._feedback
+    server.registerTool(
+      'submit_feedback',
+      {
+        title: 'Submit documentation feedback',
+        description: 'Submit feedback about a documentation page to the site maintainers.',
+        inputSchema: {
+          pagePath: z
+            .string()
+            .min(1)
+            .describe('The documentation page path returned by list_pages or search_docs'),
+          helpful: z.boolean().describe('Whether the page was helpful'),
+          category: z.string().optional().describe('A short feedback category'),
+          message: z.string().optional().describe('Additional feedback for the maintainers'),
+        },
+        annotations: {
+          readOnlyHint: false,
+          destructiveHint: false,
+          idempotentHint: false,
+          openWorldHint: true,
+        },
+      },
+      async ({ pagePath, helpful, category, message }) => {
+        try {
+          await feedback.submit({
+            helpful,
+            category,
+            message,
+            pageUrl: resolvePageUrl(config, pagePath),
+            timestamp: new Date().toISOString(),
+          })
+          return {
+            content: [{ type: 'text', text: 'Feedback submitted successfully.' }],
+          }
+        } catch (error) {
+          console.error('[vocs] mcp submit_feedback failed:', error)
+          return {
+            content: [{ type: 'text', text: 'Failed to submit feedback.' }],
+            isError: true,
+          }
+        }
+      },
+    )
+  }
+
   const sources = (config.mcp?.sources ?? []).map((s, i) => ({
     ...s,
     name: s.name ?? `source-${i}`,
@@ -332,6 +378,14 @@ export function createServer(config: Config, options: createServer.Options = {})
   }
 
   return server
+}
+
+function resolvePageUrl(config: Pick<Config, 'basePath' | 'baseUrl'>, pagePath: string) {
+  const baseUrl = config.baseUrl?.replace(/\/$/, '') ?? ''
+  const basePathValue = config.basePath.replace(/^\/+|\/+$/g, '')
+  const basePath = basePathValue ? `/${basePathValue}` : ''
+  const normalizedPagePath = `/${pagePath.replace(/^\/+/, '')}`
+  return `${baseUrl}${basePath}${normalizedPagePath}`
 }
 
 export declare namespace createServer {

--- a/src/internal/vite-plugins.ts
+++ b/src/internal/vite-plugins.ts
@@ -186,6 +186,7 @@ export function llms(config: Config.Config): PluginOption {
       pages: [...openapiPages, ...pages],
       title,
       description,
+      pagePrelude: Llms.getMarkdownPagePrelude(config),
       rehypePlugins,
       remarkPlugins,
       sidebar: config.sidebar,

--- a/src/waku/internal/middleware/md-router.ts
+++ b/src/waku/internal/middleware/md-router.ts
@@ -23,6 +23,7 @@ async function resolveContent() {
     pages: [...openapiPages, ...pages],
     title: config.title,
     description: config.description,
+    pagePrelude: Llms.getMarkdownPagePrelude(config),
     rehypePlugins,
     remarkPlugins,
     sidebar: config.sidebar,


### PR DESCRIPTION
Adds `submit_feedback` when feedback is configured and prepends actionable `search_docs` and feedback guidance, including the explicit MCP endpoint, to generated Markdown page twins.
