### PR TITLE
fix: prevent wrapped banners overlapping navigation

### DIFF
--- a/.changeset/tidy-banners-wrap.md
+++ b/.changeset/tidy-banners-wrap.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed banners with configured heights overlapping navigation when their content wrapped.

--- a/site/src/pages/reference/site-config.mdx
+++ b/site/src/pages/reference/site-config.mdx
@@ -349,7 +349,7 @@ type Banner =
       dismissable?: boolean
       /** Stable id used to remember dismissal in localStorage. Change to re-show. */
       dismissId?: string
-      /** CSS height of the banner (e.g. `'40px'`). */
+      /** Minimum CSS height of the banner (e.g. `'40px'`). */
       height?: string
       /** Wrap the banner content in a link. */
       href?: string

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -368,7 +368,7 @@ export type Config<partial extends boolean = false> = MaybePartial<
           dismissable?: boolean | undefined
           /** Unique ID for tracking dismissal in localStorage. If not provided, a hash of the content is used. */
           dismissId?: string | undefined
-          /** Height of the banner (CSS value, e.g., '28px'). */
+          /** Minimum height of the banner (CSS value, e.g., '28px'). */
           height?: string | undefined
           /** Optional link (internal or external) the banner navigates to when clicked. */
           href?: string | undefined

--- a/src/react/internal/Banner.client.test.tsx
+++ b/src/react/internal/Banner.client.test.tsx
@@ -1,0 +1,49 @@
+/** @vitest-environment jsdom */
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+import type * as Config from '../../internal/config.js'
+import { Banner } from './Banner.client.js'
+
+const mocks = vi.hoisted(() => ({
+  config: {} as Config.Config,
+}))
+
+vi.mock('virtual:vocs/config', () => ({
+  get config() {
+    return mocks.config
+  },
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  localStorage.clear()
+  mocks.config = {
+    banner: {
+      content: 'A banner that can wrap onto multiple lines.',
+      dismissable: false,
+      height: '30px',
+    },
+  } as Config.Config
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  document.documentElement.style.removeProperty('--vocs-spacing-banner')
+  vi.restoreAllMocks()
+})
+
+test('uses the configured height as a minimum', async () => {
+  await act(async () => root.render(<Banner />))
+
+  const banner = container.querySelector<HTMLElement>('[data-v-banner]')
+  expect(banner?.style.minHeight).toBe('30px')
+  expect(banner?.style.height).toBe('')
+})

--- a/src/react/internal/Banner.client.tsx
+++ b/src/react/internal/Banner.client.tsx
@@ -77,7 +77,7 @@ export function Banner() {
   const style: React.CSSProperties = {
     ...(banner.backgroundColor ? { backgroundColor: banner.backgroundColor } : {}),
     ...(banner.textColor ? { color: banner.textColor } : {}),
-    ...(banner.height ? { height: banner.height } : {}),
+    ...(banner.height ? { minHeight: banner.height } : {}),
   }
 
   const hasCustomColors = banner.backgroundColor || banner.textColor

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -268,7 +268,7 @@ aside[data-v][data-v-callout] {
 /* #region Banners */
 
 [data-v-banner] {
-  @apply vocs:fixed vocs:top-0 vocs:left-0 vocs:right-0 vocs:z-50 vocs:flex vocs:items-center vocs:justify-center vocs:gap-4 vocs:px-4 vocs:py-2 vocs:text-sm vocs:font-medium;
+  @apply vocs:fixed vocs:top-0 vocs:left-0 vocs:right-0 vocs:z-50 vocs:flex vocs:items-center vocs:justify-center vocs:gap-4 vocs:px-4 vocs:py-2 vocs:text-sm vocs:leading-[1.25] vocs:font-medium;
 
   &[data-v-context="note"] {
     @apply vocs:bg-note-tint vocs:text-note;
@@ -296,7 +296,7 @@ aside[data-v][data-v-callout] {
 }
 
 [data-v-banner-content] {
-  @apply vocs:flex vocs:items-center vocs:gap-1.5;
+  @apply vocs:flex vocs:flex-wrap vocs:items-center vocs:gap-x-1.5;
 }
 
 [data-v-banner-arrow] {


### PR DESCRIPTION
Allow configured-height banners to grow with wrapped content and reserve their measured height, preventing mobile navigation overlap. Closes https://github.com/wevm/vocs/issues/586.
