### PR TITLE
fix(twoslash): honor project TypeScript config

### DIFF
--- a/.changeset/calm-twoslash-project.md
+++ b/.changeset/calm-twoslash-project.md
@@ -1,0 +1,5 @@
+---
+'vocs': patch
+---
+
+Fixed Twoslash loading TypeScript and retaining configured compiler options from the consuming project.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,13 +13,8 @@ const pkg = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.ur
 const cli = cac('vocs')
 
 async function getTypeScriptForTwoslash() {
-  try {
-    return await import('typescript')
-  } catch {
-    throw new Error(
-      'Using twoslash code blocks requires `typescript` to be installed in your project.',
-    )
-  }
+  const TypeScript = await import('./internal/twoslash/typescript.js')
+  return TypeScript.fromProject()
 }
 
 cli

--- a/src/internal/shiki-transformers.test.ts
+++ b/src/internal/shiki-transformers.test.ts
@@ -158,6 +158,35 @@ describe('twoslash', () => {
     highlighter.dispose()
   })
 
+  it('should preserve configured compiler options in check-only mode', async () => {
+    const highlighter = await createHighlighter({
+      themes: ['github-dark'],
+      langs: ['typescript'],
+    })
+
+    twoslashErrors.length = 0
+    resetTwoslashSnippets()
+
+    highlighter.codeToHtml('const value: string = undefined', {
+      lang: 'typescript',
+      theme: 'github-dark',
+      transformers: [
+        twoslash({
+          checkOnly: true,
+          explicitTrigger: false,
+          twoslashOptions: { compilerOptions: { strictNullChecks: false } },
+        }),
+      ],
+    })
+    checkTwoslashSnippets()
+
+    expect(twoslashErrors).toEqual([])
+
+    twoslashErrors.length = 0
+    resetTwoslashSnippets()
+    highlighter.dispose()
+  })
+
   it('should accept expected type errors in check-only mode', async () => {
     const highlighter = await createHighlighter({
       themes: ['github-dark'],

--- a/src/internal/shiki-transformers.ts
+++ b/src/internal/shiki-transformers.ts
@@ -1,4 +1,3 @@
-import { createRequire } from 'node:module'
 import * as path from 'node:path'
 import {
   createCommentNotationTransformer,
@@ -22,6 +21,7 @@ import * as TwoslashChecker from './twoslash/checker.js'
 import * as InlineCache from './twoslash/inline-cache.js'
 import * as Renderer from './twoslash/renderer.js'
 import * as TypesCache from './twoslash/types-cache.js'
+import * as TypeScript from './twoslash/typescript.js'
 
 export {
   transformerNotationDiff as notationDiff,
@@ -220,7 +220,6 @@ export type TwoslashError = {
 export const twoslashErrors: TwoslashError[] = []
 
 const cwd = typeof process !== 'undefined' && typeof process.cwd === 'function' ? process.cwd() : ''
-const require = createRequire(import.meta.url)
 
 let twoslasher: TwoslashInstance | undefined
 let twoslasherCalls = 0
@@ -406,6 +405,10 @@ function checkOnlyTwoslasher(options: {
     const twoslashOptions = {
       ...options.twoslashOptions,
       ...executeOptions,
+      compilerOptions: {
+        ...options.twoslashOptions?.compilerOptions,
+        ...executeOptions?.compilerOptions,
+      },
       handbookOptions: {
         ...options.twoslashOptions?.handbookOptions,
         ...executeOptions?.handbookOptions,
@@ -462,14 +465,8 @@ export function resetTwoslasher() {
 function getTypeScript(): TS {
   if (typescript) return typescript
 
-  try {
-    typescript = require('typescript') as TS
-    return typescript
-  } catch {
-    throw new Error(
-      'Using twoslash code blocks requires `typescript` to be installed in your project.',
-    )
-  }
+  typescript = TypeScript.fromProject()
+  return typescript
 }
 
 export function emptyLine(): ShikiTransformer {

--- a/src/internal/twoslash/checker.ts
+++ b/src/internal/twoslash/checker.ts
@@ -1,4 +1,3 @@
-import { createRequire } from 'node:module'
 import * as path from 'node:path'
 import {
   defaultCompilerOptions,
@@ -9,8 +8,8 @@ import {
   type TwoslashOptions,
 } from 'twoslash/core'
 import type * as TypeScript from 'typescript'
+import * as TypeScriptLoader from './typescript.js'
 
-const require = createRequire(import.meta.url)
 const filenameRegex = /^[\t\v\f ]*\/\/\s?@filename: (.+)$/gm
 const supportedExtensions = new Set(['js', 'jsx', 'json', 'ts', 'tsx'])
 
@@ -403,7 +402,7 @@ function getExtension(fileName: string): string {
 }
 
 function getTypeScript(): TS {
-  return require('typescript') as TS
+  return TypeScriptLoader.fromProject()
 }
 
 function getCompilerOptionDeclarations(tsModule: TS): Parameters<typeof findFlagNotations>[2] {

--- a/src/internal/twoslash/typescript.test.ts
+++ b/src/internal/twoslash/typescript.test.ts
@@ -1,0 +1,26 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { afterEach, expect, it } from 'vitest'
+import * as TypeScript from './typescript.js'
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true })
+})
+
+it('loads TypeScript from the project root', () => {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-typescript-'))
+  roots.push(rootDir)
+
+  const packageDir = path.join(rootDir, 'node_modules/typescript')
+  fs.mkdirSync(packageDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(packageDir, 'package.json'),
+    JSON.stringify({ name: 'typescript', main: 'index.js' }),
+  )
+  fs.writeFileSync(path.join(packageDir, 'index.js'), "module.exports = { version: 'project' }")
+
+  expect(TypeScript.fromProject({ rootDir }).version).toBe('project')
+})

--- a/src/internal/twoslash/typescript.ts
+++ b/src/internal/twoslash/typescript.ts
@@ -1,0 +1,22 @@
+import { createRequire } from 'node:module'
+import * as path from 'node:path'
+import type { TS } from 'twoslash/core'
+
+export function fromProject(options: fromProject.Options = {}): TS {
+  const { rootDir = process.cwd() } = options
+
+  try {
+    const require = createRequire(path.join(rootDir, 'package.json'))
+    return require('typescript') as TS
+  } catch {
+    throw new Error(
+      'Using twoslash code blocks requires `typescript` to be installed in your project.',
+    )
+  }
+}
+
+export declare namespace fromProject {
+  type Options = {
+    rootDir?: string | undefined
+  }
+}


### PR DESCRIPTION
Load TypeScript from the consuming project and preserve configured compiler options in check-only mode, preventing monorepo version mismatches and lost path aliases.
