### PR TITLE
fix(openapi): pretty-print structured examples

### DIFF
--- a/.changeset/pretty-openapi-examples.md
+++ b/.changeset/pretty-openapi-examples.md
@@ -1,0 +1,5 @@
+---
+'vocs': patch
+---
+
+Pretty-print structured OpenAPI parameter and property examples.

--- a/.changeset/pretty-openapi-examples.md
+++ b/.changeset/pretty-openapi-examples.md
@@ -2,4 +2,4 @@
 'vocs': patch
 ---
 
-Pretty-print structured OpenAPI parameter and property examples.
+Pretty-printed structured OpenAPI parameter and property examples.

--- a/src/react/internal/openapi/Operation.test.tsx
+++ b/src/react/internal/openapi/Operation.test.tsx
@@ -66,6 +66,27 @@ describe('Operation', () => {
     expect(html).toContain('required')
   })
 
+  test('pretty-prints structured parameter examples', () => {
+    const html = renderToStaticMarkup(
+      <Operation
+        operation={{
+          ...operation,
+          parameters: [
+            {
+              name: 'filter',
+              in: 'query',
+              example: { status: 'active', limit: 10 },
+              schema: { type: 'object' },
+            },
+          ],
+        }}
+      />,
+    )
+    expect(html).toContain(
+      '{\n  &quot;status&quot;: &quot;active&quot;,\n  &quot;limit&quot;: 10\n}',
+    )
+  })
+
   test('renders responses with status and schema', () => {
     expect(html).toContain('>200<')
     expect(html).toContain('A pet')
@@ -76,6 +97,22 @@ describe('Operation', () => {
 })
 
 describe('Schema', () => {
+  test('pretty-prints structured property examples', () => {
+    const html = renderToStaticMarkup(
+      <Schema
+        schema={{
+          type: 'object',
+          properties: {
+            payload: { type: 'object', example: { signature: '0xabc', type: 'transaction' } },
+          },
+        }}
+      />,
+    )
+    expect(html).toContain(
+      '{\n  &quot;signature&quot;: &quot;0xabc&quot;,\n  &quot;type&quot;: &quot;transaction&quot;\n}',
+    )
+  })
+
   test('renders nested object properties recursively', () => {
     const html = renderToStaticMarkup(
       <Schema

--- a/src/react/internal/openapi/Operation.tsx
+++ b/src/react/internal/openapi/Operation.tsx
@@ -18,6 +18,7 @@ import { HeadingAnchor } from './HeadingAnchor.js'
 import { TestRequestButton } from './Playground.client.js'
 import {
   enumValues,
+  formatExample,
   PropertyRow,
   Schema,
   schemaExample,
@@ -228,10 +229,7 @@ function parameterExample(parameter: {
   example?: unknown
   schema?: Record<string, unknown> | undefined
 }): string | undefined {
-  if (parameter.example !== undefined)
-    return typeof parameter.example === 'string'
-      ? parameter.example
-      : JSON.stringify(parameter.example)
+  if (parameter.example !== undefined) return formatExample(parameter.example)
   return schemaExample(parameter.schema)
 }
 

--- a/src/react/internal/openapi/Schema.tsx
+++ b/src/react/internal/openapi/Schema.tsx
@@ -137,15 +137,20 @@ function stringify(value: unknown): string {
   return JSON.stringify(value)
 }
 
+export function formatExample(value: unknown): string {
+  if (typeof value === 'string') return value
+  return JSON.stringify(value, null, 2)
+}
+
 /**
  * Extracts a representative example value from a schema (`example` or the first
  * entry of `examples`), returned as a display string.
  */
 export function schemaExample(schema: SchemaObject | undefined): string | undefined {
   if (!schema) return undefined
-  if ('example' in schema) return stringify(schema['example'])
+  if ('example' in schema) return formatExample(schema['example'])
   const examples = schema['examples']
-  if (Array.isArray(examples) && examples.length > 0) return stringify(examples[0])
+  if (Array.isArray(examples) && examples.length > 0) return formatExample(examples[0])
   return undefined
 }
 

--- a/src/styles/openapi.css
+++ b/src/styles/openapi.css
@@ -302,7 +302,7 @@
   @apply vocs:text-secondary;
 }
 [data-v-openapi-property-example-value] {
-  @apply vocs:font-mono vocs:text-primary vocs:break-all vocs:text-left;
+  @apply vocs:font-mono vocs:text-primary vocs:break-all vocs:text-left vocs:whitespace-pre-wrap;
 }
 /* When the sibling code sample renders a matching response example line, the
    example value becomes a button that reveals/flashes that line on click. */


### PR DESCRIPTION
Structured OpenAPI parameter and property examples now use the same indented JSON formatting as request and response samples. Preserve the generated newlines in the property example UI and cover both rendering paths with tests.

Prompted by: @jxom