### PR TITLE
fix(openapi): collapse long request bodies

### DIFF
--- a/.changeset/collapse-openapi-request-bodies.md
+++ b/.changeset/collapse-openapi-request-bodies.md
@@ -2,4 +2,4 @@
 'vocs': patch
 ---
 
-Collapse long OpenAPI request body examples behind an expand control.
+Collapsed long OpenAPI request body examples behind an expand control.

--- a/.changeset/collapse-openapi-request-bodies.md
+++ b/.changeset/collapse-openapi-request-bodies.md
@@ -1,0 +1,5 @@
+---
+'vocs': patch
+---
+
+Collapse long OpenAPI request body examples behind an expand control.

--- a/src/internal/openapi/sample.test.ts
+++ b/src/internal/openapi/sample.test.ts
@@ -146,6 +146,44 @@ describe('codeSamples', () => {
     expect(curl?.collapsed).toBeUndefined()
     expect(curl?.hiddenQueryCount).toBeUndefined()
   })
+
+  test('collapses long request bodies', () => {
+    const longBody: IrOperation = {
+      ...operation,
+      method: 'POST',
+      parameters: [],
+      requestBody: {
+        required: true,
+        content: [
+          {
+            mediaType: 'application/json',
+            example: Object.fromEntries(
+              Array.from({ length: 12 }, (_, index) => [`field${index}`, index]),
+            ),
+          },
+        ],
+      },
+    }
+    const curl = codeSamples(longBody).find((sample) => sample.id === 'shell/curl')
+    expect(curl?.truncatedBody).toBe(true)
+    expect(curl?.collapsed?.display.split('\n')).toHaveLength(12)
+    expect(curl?.display.split('\n').length).toBeGreaterThan(12)
+  })
+
+  test('does not collapse short request bodies', () => {
+    const shortBody: IrOperation = {
+      ...operation,
+      method: 'POST',
+      parameters: [],
+      requestBody: {
+        required: true,
+        content: [{ mediaType: 'application/json', example: { name: 'Ada' } }],
+      },
+    }
+    const curl = codeSamples(shortBody).find((sample) => sample.id === 'shell/curl')
+    expect(curl?.truncatedBody).toBeUndefined()
+    expect(curl?.collapsed).toBeUndefined()
+  })
 })
 
 describe('responseSamples', () => {

--- a/src/internal/openapi/sample.ts
+++ b/src/internal/openapi/sample.ts
@@ -48,6 +48,8 @@ export type CodeSample = {
   display: string
   /** Number of query parameters hidden in {@link collapsed}. */
   hiddenQueryCount?: number
+  /** Whether {@link collapsed} truncates a long request body. */
+  truncatedBody?: boolean
   /** Stable id, e.g. `shell/curl`. */
   id: string
   /** Display label for the language tab, e.g. `cURL`. */
@@ -64,6 +66,8 @@ export type CodeSample = {
 
 /** Query parameters above this count collapse behind a "Show more" toggle. */
 const collapseQueryThreshold = 2
+/** Request samples with bodies above this line count collapse by default. */
+const collapseBodyLineThreshold = 12
 
 /**
  * The set of clients we expose in the code-sample selector. Kept intentionally
@@ -125,6 +129,20 @@ export function codeSamples(
         }
         sample.hiddenQueryCount = queryCount - collapseQueryThreshold
       }
+    }
+    const collapsedDisplay = sample.collapsed?.display ?? display
+    if (request.postData && collapsedDisplay.split('\n').length > collapseBodyLineThreshold) {
+      const truncatedDisplay = collapsedDisplay
+        .split('\n')
+        .slice(0, collapseBodyLineThreshold)
+        .join('\n')
+      sample.collapsed = {
+        display: truncatedDisplay,
+        anchors: pathAnchors(truncatedDisplay, operation),
+        colorRanges: queryColorRanges(truncatedDisplay, operation),
+        lineAnchors: queryLineAnchors(truncatedDisplay, operation),
+      }
+      sample.truncatedBody = true
     }
     samples.push(sample)
   }

--- a/src/react/internal/openapi/CodeSample.client.tsx
+++ b/src/react/internal/openapi/CodeSample.client.tsx
@@ -24,8 +24,8 @@ export function CodeSample(props: CodeSample.Props) {
   const { samples, responses, action, anchors = true } = props
   const [sampleId, setSampleId] = useState(samples[0]?.id)
   const [status, setStatus] = useState(responses[0]?.status)
-  // When a request has many query params, the extras collapse by default.
-  const [queryExpanded, setQueryExpanded] = useState(false)
+  // Long requests and requests with many query params collapse by default.
+  const [expanded, setExpanded] = useState(false)
 
   const sample = samples.find((entry) => entry.id === sampleId) ?? samples[0]
   const response = responses.find((entry) => entry.status === status) ?? responses[0]
@@ -80,13 +80,12 @@ export function CodeSample(props: CodeSample.Props) {
           setStatus(match.status)
           return
         }
-        if (requestAnchors.hiddenIds.has(id)) setQueryExpanded(true)
+        if (requestAnchors.hiddenIds.has(id)) setExpanded(true)
       },
     })
   }, [anchors, responseAnchors, requestAnchors])
 
-  // Use the collapsed snippet variant (first few query params) unless expanded.
-  const view = sample?.collapsed && !queryExpanded ? sample.collapsed : sample
+  const view = sample?.collapsed && !expanded ? sample.collapsed : sample
 
   return (
     <div data-v-openapi-sample>
@@ -119,17 +118,18 @@ export function CodeSample(props: CodeSample.Props) {
             <button
               type="button"
               data-v-openapi-sample-more
-              onClick={() => setQueryExpanded((value) => !value)}
+              aria-expanded={expanded}
+              onClick={() => setExpanded((value) => !value)}
             >
-              {queryExpanded ? (
+              {expanded ? (
                 <>
                   <LucideChevronUp data-v-openapi-sample-more-icon />
-                  Show less
+                  {sample.truncatedBody ? 'Collapse' : 'Show less'}
                 </>
               ) : (
                 <>
                   <LucideChevronDown data-v-openapi-sample-more-icon />
-                  Show {sample.hiddenQueryCount} more
+                  {sample.truncatedBody ? 'Expand' : `Show ${sample.hiddenQueryCount} more`}
                 </>
               )}
             </button>

--- a/src/styles/openapi.css
+++ b/src/styles/openapi.css
@@ -534,7 +534,7 @@ button[data-v-openapi-property-example-value]:hover {
 [data-v-openapi-sample] [data-v-openapi-anchor]:hover {
   @apply vocs:bg-code-highlighted;
 }
-/* "Show more/less" toggle for the collapsed query parameters of a request. */
+/* Expand/collapse toggle for long requests and extra query parameters. */
 [data-v-openapi-sample-more] {
   @apply vocs:flex vocs:items-center vocs:gap-1.5 vocs:w-full vocs:bg-code-block vocs:px-code-block-px vocs:-mt-2 vocs:pb-3 vocs:text-[12px] vocs:font-medium vocs:text-secondary vocs:cursor-pointer;
 }


### PR DESCRIPTION
Long OpenAPI request samples with bodies now collapse to 12 lines by default and expose an accessible Expand/Collapse control. Existing query-parameter collapsing remains unchanged, and the patch includes coverage for both long and short request bodies plus a changeset.

Prompted by: @jxom