### PR TITLE
feat: add MDX component Markdown hooks

### DIFF
--- a/.changeset/brave-mice-walk.md
+++ b/.changeset/brave-mice-walk.md
@@ -1,0 +1,5 @@
+---
+"vocs": minor
+---
+
+Add `toMarkdown` hooks for custom MDX components in generated LLM Markdown.

--- a/site/src/pages/features/agent-support.mdx
+++ b/site/src/pages/features/agent-support.mdx
@@ -62,6 +62,35 @@ Vocs is a library for creating documentation websites.
 - [Agent Support](/features/agent-support): Machine-readable docs for AI agents
 ```
 
+## Custom Component Markdown
+
+Custom MDX components can provide Markdown for AI-facing output without changing their interactive rendering. Define `toMarkdown` on the component, then use the component as a standalone MDX tag.
+
+```tsx [src/components/ClientPrompt.tsx]
+const prompt = 'Add mppx to my app as a client.'
+
+export const ClientPrompt = Object.assign(
+  function ClientPrompt() {
+    return <pre>{prompt}</pre>
+  },
+  {
+    toMarkdown: () => ({
+      type: 'code',
+      lang: 'text',
+      value: prompt,
+    }),
+  },
+)
+```
+
+```mdx [src/pages/quickstart.mdx]
+import { ClientPrompt } from '../components/ClientPrompt'
+
+<ClientPrompt />
+```
+
+Vocs invokes the hook only while generating `.md`, `llms.txt`, and `llms-full.txt`. The hook must return a Markdown AST node or an array of nodes; components without a hook remain unchanged.
+
 ## Best Practices
 
 ### Optimize for LLMs

--- a/src/internal/llms.test.ts
+++ b/src/internal/llms.test.ts
@@ -328,6 +328,52 @@ import { Prompt } from './components'
     }
   })
 
+  test('only expands imported standalone PascalCase components', async () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-llms-components-'))
+    const componentPath = path.join(rootDir, 'Prompt.ts')
+    const pagePath = path.join(rootDir, 'quickstart.mdx')
+
+    try {
+      fs.writeFileSync(
+        componentPath,
+        `export const Prompt = {
+  toMarkdown: () => ({ type: 'paragraph', children: [{ type: 'text', value: 'Use mppx.' }] }),
+}`,
+      )
+      const source = `import { Prompt } from './Prompt'
+
+<Prompt>custom content</Prompt>
+
+<prompt />
+
+<Unimported />
+
+<Prompt />
+
+<Prompt />`
+      fs.writeFileSync(pagePath, source)
+
+      const markdown = await inlineMarkdownComponents(source, pagePath)
+
+      expect(markdown).toContain('<Prompt>custom content</Prompt>')
+      expect(markdown).toContain('<prompt />')
+      expect(markdown).toContain('<Unimported />')
+      expect(markdown.match(/Use mppx\./g)).toHaveLength(2)
+    } finally {
+      fs.rmSync(rootDir, { force: true, recursive: true })
+    }
+  })
+
+  test('preserves malformed MDX and unavailable component modules', async () => {
+    const filePath = path.join(os.tmpdir(), 'vocs-llms-components-missing.mdx')
+    const unavailable = `import { Prompt } from './missing'
+
+<Prompt />`
+
+    await expect(inlineMarkdownComponents('<Prompt', filePath)).resolves.toBe('<Prompt')
+    await expect(inlineMarkdownComponents(unavailable, filePath)).resolves.toBe(unavailable)
+  })
+
   test('resolves hooks in imported Markdown files from their own directory', async () => {
     const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-llms-components-'))
     const snippetsDir = path.join(rootDir, 'snippets')
@@ -380,7 +426,10 @@ import Example from './snippets/example.mdx'
       fs.writeFileSync(
         componentPath,
         `export function Invalid() { return null }
-Invalid.toMarkdown = () => 'not a Markdown node'`,
+Invalid.toMarkdown = () => [
+  { type: 'paragraph', children: [{ type: 'text', value: 'Valid.' }] },
+  'not a Markdown node',
+]`,
       )
       fs.writeFileSync(
         pagePath,

--- a/src/internal/llms.test.ts
+++ b/src/internal/llms.test.ts
@@ -6,6 +6,7 @@ import type { Pluggable } from 'unified'
 import { describe, expect, test } from 'vitest'
 import type * as Changelog from './changelog.js'
 import { buildLlmsContent, getMarkdownPagePrelude } from './llms.js'
+import { inlineMarkdownComponents } from './markdown-components.js'
 import {
   remarkChangelogMarkdown,
   remarkDefaultFrontmatter,
@@ -142,6 +143,156 @@ This is the home page.`,
       Content here.
       "
     `)
+  })
+
+  test('expands named and default MDX component imports with a toMarkdown hook', async () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-llms-components-'))
+    const componentPath = path.join(rootDir, 'prompts.ts')
+    const pagePath = path.join(rootDir, 'quickstart.mdx')
+
+    try {
+      fs.writeFileSync(
+        componentPath,
+        `export function ServerPrompt() { return null }
+ServerPrompt.toMarkdown = async () => [
+  { type: 'heading', depth: 2, children: [{ type: 'text', value: 'Server' }] },
+  { type: 'code', lang: 'text', value: 'Use mppx on the server.' },
+]
+
+function ClientPrompt() { return null }
+ClientPrompt.toMarkdown = () => ({ type: 'code', lang: 'text', value: 'Use mppx in the client.' })
+export default ClientPrompt`,
+      )
+      fs.writeFileSync(
+        pagePath,
+        `---
+title: Quickstart
+---
+
+import ClientPrompt, { ServerPrompt as Prompt } from './prompts'
+
+<ClientPrompt />
+
+<Prompt />`,
+      )
+
+      await expect(
+        inlineMarkdownComponents(fs.readFileSync(pagePath, 'utf-8'), pagePath),
+      ).resolves.toContain('```text\nUse mppx in the client.\n```')
+
+      const result = await buildLlmsContent({
+        pages: [{ path: '/quickstart', content: { path: pagePath } }],
+        title: 'My Docs',
+        ...plugins,
+      })
+
+      expect(result.full).toContain('```text\nUse mppx in the client.\n```')
+      expect(result.full).toContain('## Server\n\n```text\nUse mppx on the server.\n```')
+      expect(result.full).not.toContain('<ClientPrompt />')
+      expect(result.full).not.toContain('<Prompt />')
+      expect(result.results[0]?.content).toContain('Use mppx on the server.')
+    } finally {
+      fs.rmSync(rootDir, { force: true, recursive: true })
+    }
+  })
+
+  test('preserves imported components without a toMarkdown hook', async () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-llms-components-'))
+    const componentPath = path.join(rootDir, 'InteractiveWidget.ts')
+    const pagePath = path.join(rootDir, 'interactive.mdx')
+
+    try {
+      fs.writeFileSync(componentPath, 'export function InteractiveWidget() { return null }')
+      fs.writeFileSync(
+        pagePath,
+        `---
+title: Interactive
+---
+
+import { InteractiveWidget } from './InteractiveWidget'
+
+<InteractiveWidget />`,
+      )
+
+      const result = await buildLlmsContent({
+        pages: [{ path: '/interactive', content: { path: pagePath } }],
+        title: 'My Docs',
+        ...plugins,
+      })
+
+      expect(result.full).toContain('<InteractiveWidget />')
+    } finally {
+      fs.rmSync(rootDir, { force: true, recursive: true })
+    }
+  })
+
+  test('preserves components with attributes', async () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-llms-components-'))
+    const componentPath = path.join(rootDir, 'ClientPrompt.ts')
+    const pagePath = path.join(rootDir, 'quickstart.mdx')
+
+    try {
+      fs.writeFileSync(
+        componentPath,
+        `export function ClientPrompt() { return null }
+ClientPrompt.toMarkdown = () => ({ type: 'code', lang: 'text', value: 'Use mppx.' })`,
+      )
+      fs.writeFileSync(
+        pagePath,
+        `---
+title: Quickstart
+---
+
+import { ClientPrompt } from './ClientPrompt'
+
+<ClientPrompt mode="client" />`,
+      )
+
+      const result = await buildLlmsContent({
+        pages: [{ path: '/quickstart', content: { path: pagePath } }],
+        title: 'My Docs',
+        ...plugins,
+      })
+
+      expect(result.full).toContain('<ClientPrompt mode="client" />')
+      expect(result.full).not.toContain('Use mppx.')
+    } finally {
+      fs.rmSync(rootDir, { force: true, recursive: true })
+    }
+  })
+
+  test('rejects invalid toMarkdown hook values', async () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-llms-components-'))
+    const componentPath = path.join(rootDir, 'Invalid.ts')
+    const pagePath = path.join(rootDir, 'invalid.mdx')
+
+    try {
+      fs.writeFileSync(
+        componentPath,
+        `export function Invalid() { return null }
+Invalid.toMarkdown = () => 'not a Markdown node'`,
+      )
+      fs.writeFileSync(
+        pagePath,
+        `---
+title: Invalid
+---
+
+import { Invalid } from './Invalid'
+
+<Invalid />`,
+      )
+
+      await expect(
+        buildLlmsContent({
+          pages: [{ path: '/invalid', content: { path: pagePath } }],
+          title: 'My Docs',
+          ...plugins,
+        }),
+      ).rejects.toThrow('Invalid.toMarkdown must return a Markdown node or array of nodes.')
+    } finally {
+      fs.rmSync(rootDir, { force: true, recursive: true })
+    }
   })
 
   test('pages are sorted by depth then alphabetically', async () => {

--- a/src/internal/llms.test.ts
+++ b/src/internal/llms.test.ts
@@ -159,8 +159,9 @@ ServerPrompt.toMarkdown = async () => [
   { type: 'code', lang: 'text', value: 'Use mppx on the server.' },
 ]
 
-function ClientPrompt() { return null }
-ClientPrompt.toMarkdown = () => ({ type: 'code', lang: 'text', value: 'Use mppx in the client.' })
+const ClientPrompt = {
+  toMarkdown: () => ({ type: 'code', lang: 'text', value: 'Use mppx in the client.' }),
+}
 export default ClientPrompt`,
       )
       fs.writeFileSync(
@@ -169,7 +170,7 @@ export default ClientPrompt`,
 title: Quickstart
 ---
 
-import ClientPrompt, { ServerPrompt as Prompt } from './prompts'
+import ClientPrompt, { ServerPrompt as Prompt } from './prompts.js'
 
 <ClientPrompt />
 
@@ -256,6 +257,115 @@ import { ClientPrompt } from './ClientPrompt'
 
       expect(result.full).toContain('<ClientPrompt mode="client" />')
       expect(result.full).not.toContain('Use mppx.')
+    } finally {
+      fs.rmSync(rootDir, { force: true, recursive: true })
+    }
+  })
+
+  test('expands hooks imported through a barrel file', async () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-llms-components-'))
+    const componentsDir = path.join(rootDir, 'components')
+    const pagePath = path.join(rootDir, 'quickstart.mdx')
+
+    try {
+      fs.mkdirSync(componentsDir)
+      fs.writeFileSync(
+        path.join(componentsDir, 'index.ts'),
+        `export const Prompt = {
+  toMarkdown: () => ({ type: 'paragraph', children: [{ type: 'text', value: 'Use mppx.' }] }),
+}`,
+      )
+      fs.writeFileSync(
+        pagePath,
+        `---
+title: Quickstart
+---
+
+import { Prompt } from './components'
+
+<Prompt />`,
+      )
+
+      const result = await buildLlmsContent({
+        pages: [{ path: '/quickstart', content: { path: pagePath } }],
+        title: 'My Docs',
+        ...plugins,
+      })
+
+      expect(result.full).toContain('Use mppx.')
+      expect(result.full).not.toContain('<Prompt />')
+    } finally {
+      fs.rmSync(rootDir, { force: true, recursive: true })
+    }
+  })
+
+  test('uses Vite-resolved component imports', async () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-llms-components-'))
+    const componentPath = path.join(rootDir, 'Prompt.ts')
+    const pagePath = path.join(rootDir, 'quickstart.mdx')
+
+    try {
+      fs.writeFileSync(
+        componentPath,
+        `export const Prompt = {
+  toMarkdown: () => ({ type: 'paragraph', children: [{ type: 'text', value: 'Use mppx.' }] }),
+}`,
+      )
+      fs.writeFileSync(
+        pagePath,
+        `import { Prompt } from 'components'
+
+<Prompt />`,
+      )
+
+      await expect(
+        inlineMarkdownComponents(fs.readFileSync(pagePath, 'utf-8'), pagePath, {
+          resolve: async (source) => (source === 'components' ? componentPath : undefined),
+        }),
+      ).resolves.toContain('Use mppx.')
+    } finally {
+      fs.rmSync(rootDir, { force: true, recursive: true })
+    }
+  })
+
+  test('resolves hooks in imported Markdown files from their own directory', async () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-llms-components-'))
+    const snippetsDir = path.join(rootDir, 'snippets')
+    const pagePath = path.join(rootDir, 'quickstart.mdx')
+
+    try {
+      fs.mkdirSync(snippetsDir)
+      fs.writeFileSync(
+        path.join(snippetsDir, 'Prompt.ts'),
+        `export const Prompt = {
+  toMarkdown: () => ({ type: 'paragraph', children: [{ type: 'text', value: 'Use mppx.' }] }),
+}`,
+      )
+      fs.writeFileSync(
+        path.join(snippetsDir, 'example.mdx'),
+        `import { Prompt } from './Prompt'
+
+<Prompt />`,
+      )
+      fs.writeFileSync(
+        pagePath,
+        `---
+title: Quickstart
+---
+
+import Example from './snippets/example.mdx'
+
+<Example />`,
+      )
+
+      const result = await buildLlmsContent({
+        pages: [{ path: '/quickstart', content: { path: pagePath } }],
+        title: 'My Docs',
+        ...plugins,
+      })
+
+      expect(result.full).toContain('Use mppx.')
+      expect(result.full).not.toContain('<Prompt />')
     } finally {
       fs.rmSync(rootDir, { force: true, recursive: true })
     }

--- a/src/internal/llms.ts
+++ b/src/internal/llms.ts
@@ -11,7 +11,15 @@ import * as OpenApiMarkdown from './openapi/markdown.js'
 import type * as Sidebar from './sidebar.js'
 
 export async function buildLlmsContent(options: buildLlmsContent.Options) {
-  const { title, description, pagePrelude, rehypePlugins, remarkPlugins, sidebar } = options
+  const {
+    componentOptions,
+    title,
+    description,
+    pagePrelude,
+    rehypePlugins,
+    remarkPlugins,
+    sidebar,
+  } = options
 
   // Dedupe by path (first occurrence wins), so consumer-authored source pages
   // take precedence over generated pages (e.g. OpenAPI) mounted at the same path.
@@ -46,14 +54,15 @@ export async function buildLlmsContent(options: buildLlmsContent.Options) {
         typeof page.content === 'string'
           ? page.content
           : await fs.readFile(page.content.path, 'utf-8')
-      const markdown =
-        typeof page.content === 'string'
-          ? rawContent
-          : MarkdownImports.inlineMarkdownImports(rawContent, page.content.path)
       const content =
         typeof page.content === 'string'
-          ? markdown
-          : await MarkdownComponents.inlineMarkdownComponents(markdown, page.content.path)
+          ? rawContent
+          : await MarkdownImports.inlineMarkdownImportsAsync(
+              rawContent,
+              page.content.path,
+              (source, filePath) =>
+                MarkdownComponents.inlineMarkdownComponents(source, filePath, componentOptions),
+            )
       const file = await unified()
         .use(remarkParse)
         .use(remarkMdx)
@@ -101,6 +110,7 @@ export async function buildLlmsContent(options: buildLlmsContent.Options) {
 
 export declare namespace buildLlmsContent {
   type Options = {
+    componentOptions?: MarkdownComponents.inlineMarkdownComponents.Options | undefined
     pages: Page[]
     title: string
     description?: string | undefined

--- a/src/internal/llms.ts
+++ b/src/internal/llms.ts
@@ -5,6 +5,7 @@ import remarkStringify from 'remark-stringify'
 import type { PluggableList } from 'unified'
 import { unified } from 'unified'
 import type * as Config from './config.js'
+import * as MarkdownComponents from './markdown-components.js'
 import * as MarkdownImports from './markdown-imports.js'
 import * as OpenApiMarkdown from './openapi/markdown.js'
 import type * as Sidebar from './sidebar.js'
@@ -45,10 +46,14 @@ export async function buildLlmsContent(options: buildLlmsContent.Options) {
         typeof page.content === 'string'
           ? page.content
           : await fs.readFile(page.content.path, 'utf-8')
-      const content =
+      const markdown =
         typeof page.content === 'string'
           ? rawContent
           : MarkdownImports.inlineMarkdownImports(rawContent, page.content.path)
+      const content =
+        typeof page.content === 'string'
+          ? markdown
+          : await MarkdownComponents.inlineMarkdownComponents(markdown, page.content.path)
       const file = await unified()
         .use(remarkParse)
         .use(remarkMdx)

--- a/src/internal/markdown-components.ts
+++ b/src/internal/markdown-components.ts
@@ -41,7 +41,11 @@ type MarkdownComponent = {
 }
 
 /** Replaces standalone MDX components with their Markdown representations. */
-export async function inlineMarkdownComponents(source: string, filePath: string) {
+export async function inlineMarkdownComponents(
+  source: string,
+  filePath: string,
+  options: inlineMarkdownComponents.Options = {},
+) {
   let tree: MdAst.Root
   try {
     tree = unified().use(remarkParse).use(remarkMdx).parse(source)
@@ -63,7 +67,7 @@ export async function inlineMarkdownComponents(source: string, filePath: string)
     const componentImport = imports.get(node.name)
     if (!componentImport) continue
 
-    const component = await loadComponent(componentImport, filePath)
+    const component = await loadComponent(componentImport, filePath, options)
     if (!component?.toMarkdown) continue
 
     const markdown = await component.toMarkdown()
@@ -76,6 +80,12 @@ export async function inlineMarkdownComponents(source: string, filePath: string)
   }
 
   return applyReplacements(source, replacements)
+}
+
+export declare namespace inlineMarkdownComponents {
+  type Options = {
+    resolve?: (source: string, importer: string) => Promise<string | undefined>
+  }
 }
 
 function getComponentImports(tree: MdAst.Root) {
@@ -113,14 +123,28 @@ function isStaticMdxComponent(node: MdAst.RootContent): node is MdxJsxElement {
   return node.attributes.length === 0 && node.children.length === 0
 }
 
-async function loadComponent(componentImport: ComponentImport, filePath: string) {
+async function loadComponent(
+  componentImport: ComponentImport,
+  filePath: string,
+  options: inlineMarkdownComponents.Options,
+) {
   try {
-    const module = await tsImport(resolveComponentImport(componentImport.source, filePath), {
+    const source =
+      (await options.resolve?.(componentImport.source, filePath)) ??
+      resolveComponentImport(componentImport.source, filePath)
+    const module = await tsImport(source, {
       parentURL: pathToFileURL(filePath).href,
     })
     const exports =
-      'default' in module && typeof module.default === 'object' ? module.default : module
-    return exports[componentImport.exportName] as MarkdownComponent | undefined
+      'default' in module &&
+      typeof module.default === 'object' &&
+      module.default !== null &&
+      componentImport.exportName in module.default
+        ? module.default
+        : module
+    return exports[componentImport.exportName as keyof typeof exports] as
+      | MarkdownComponent
+      | undefined
   } catch {
     return undefined
   }
@@ -130,11 +154,19 @@ function resolveComponentImport(source: string, filePath: string) {
   if (!source.startsWith('.') && !path.isAbsolute(source)) return source
 
   const resolved = path.isAbsolute(source) ? source : path.resolve(path.dirname(filePath), source)
+  const extension = path.extname(resolved)
+  const sourceExtensions = ['.cts', '.mts', '.ts', '.tsx']
+  const sourcePath = ['.cjs', '.js', '.jsx', '.mjs'].includes(extension)
+    ? resolved.slice(0, -extension.length)
+    : undefined
   const candidates = [
     resolved,
-    ...['.cjs', '.cts', '.js', '.jsx', '.mjs', '.mts', '.ts', '.tsx'].map(
-      (extension) => `${resolved}${extension}`,
-    ),
+    ...(sourcePath ? sourceExtensions.map((extension) => `${sourcePath}${extension}`) : []),
+    ...(!extension
+      ? ['.cjs', '.cts', '.js', '.jsx', '.mjs', '.mts', '.ts', '.tsx'].map(
+          (extension) => `${resolved}${extension}`,
+        )
+      : []),
     ...[
       'index.cjs',
       'index.cts',
@@ -147,7 +179,9 @@ function resolveComponentImport(source: string, filePath: string) {
     ].map((file) => path.join(resolved, file)),
   ]
 
-  const resolvedPath = candidates.find((candidate) => fs.existsSync(candidate))
+  const resolvedPath = candidates.find(
+    (candidate) => fs.existsSync(candidate) && fs.statSync(candidate).isFile(),
+  )
   return resolvedPath ?? source
 }
 

--- a/src/internal/markdown-components.ts
+++ b/src/internal/markdown-components.ts
@@ -1,0 +1,166 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import type * as Estree from 'estree'
+import type * as MdAst from 'mdast'
+import { toMarkdown } from 'mdast-util-to-markdown'
+import remarkMdx from 'remark-mdx'
+import remarkParse from 'remark-parse'
+import { tsImport } from 'tsx/esm/api'
+import { unified } from 'unified'
+import { visit } from 'unist-util-visit'
+
+type MdxEsm = MdAst.RootContent & {
+  data?: { estree?: Estree.Program }
+  type: 'mdxjsEsm'
+}
+
+type MdxJsxElement = MdAst.RootContent & {
+  attributes?: unknown[]
+  children?: MdAst.RootContent[]
+  name?: string | null
+  type: 'mdxJsxFlowElement'
+}
+
+type ComponentImport = {
+  exportName: string
+  source: string
+}
+
+type Replacement = {
+  end: number
+  start: number
+  value: string
+}
+
+type MarkdownComponent = {
+  toMarkdown?: () =>
+    | MdAst.RootContent
+    | MdAst.RootContent[]
+    | Promise<MdAst.RootContent | MdAst.RootContent[]>
+}
+
+/** Replaces standalone MDX components with their Markdown representations. */
+export async function inlineMarkdownComponents(source: string, filePath: string) {
+  let tree: MdAst.Root
+  try {
+    tree = unified().use(remarkParse).use(remarkMdx).parse(source)
+  } catch {
+    return source
+  }
+
+  const imports = getComponentImports(tree)
+  const replacements: Replacement[] = []
+
+  const components: MdxJsxElement[] = []
+  visit(tree, 'mdxJsxFlowElement', (node) => {
+    if (isStaticMdxComponent(node)) components.push(node)
+  })
+
+  for (const node of components) {
+    if (!node.name) continue
+
+    const componentImport = imports.get(node.name)
+    if (!componentImport) continue
+
+    const component = await loadComponent(componentImport, filePath)
+    if (!component?.toMarkdown) continue
+
+    const markdown = await component.toMarkdown()
+    const nodes = Array.isArray(markdown) ? markdown : [markdown]
+    if (!nodes.every((node) => node && typeof node.type === 'string'))
+      throw new TypeError(`${node.name}.toMarkdown must return a Markdown node or array of nodes.`)
+
+    const replacement = toReplacement(node, toMarkdown({ type: 'root', children: nodes }))
+    if (replacement) replacements.push(replacement)
+  }
+
+  return applyReplacements(source, replacements)
+}
+
+function getComponentImports(tree: MdAst.Root) {
+  const imports = new Map<string, ComponentImport>()
+
+  visit(tree, 'mdxjsEsm', (node) => {
+    const declarations = (node as MdxEsm).data?.estree?.body.filter(
+      (statement): statement is Estree.ImportDeclaration => statement.type === 'ImportDeclaration',
+    )
+    if (!declarations) return
+
+    for (const declaration of declarations) {
+      if (typeof declaration.source.value !== 'string') continue
+      for (const specifier of declaration.specifiers) {
+        if (specifier.type === 'ImportDefaultSpecifier')
+          imports.set(specifier.local.name, {
+            exportName: 'default',
+            source: declaration.source.value,
+          })
+        if (specifier.type === 'ImportSpecifier' && specifier.imported.type === 'Identifier')
+          imports.set(specifier.local.name, {
+            exportName: specifier.imported.name,
+            source: declaration.source.value,
+          })
+      }
+    }
+  })
+
+  return imports
+}
+
+function isStaticMdxComponent(node: MdAst.RootContent): node is MdxJsxElement {
+  if (node.type !== 'mdxJsxFlowElement') return false
+  if (!node.name || !/^[A-Z][A-Za-z0-9_$]*$/.test(node.name)) return false
+  return node.attributes.length === 0 && node.children.length === 0
+}
+
+async function loadComponent(componentImport: ComponentImport, filePath: string) {
+  try {
+    const module = await tsImport(resolveComponentImport(componentImport.source, filePath), {
+      parentURL: pathToFileURL(filePath).href,
+    })
+    const exports =
+      'default' in module && typeof module.default === 'object' ? module.default : module
+    return exports[componentImport.exportName] as MarkdownComponent | undefined
+  } catch {
+    return undefined
+  }
+}
+
+function resolveComponentImport(source: string, filePath: string) {
+  if (!source.startsWith('.') && !path.isAbsolute(source)) return source
+
+  const resolved = path.isAbsolute(source) ? source : path.resolve(path.dirname(filePath), source)
+  const candidates = [
+    resolved,
+    ...['.cjs', '.cts', '.js', '.jsx', '.mjs', '.mts', '.ts', '.tsx'].map(
+      (extension) => `${resolved}${extension}`,
+    ),
+    ...[
+      'index.cjs',
+      'index.cts',
+      'index.js',
+      'index.jsx',
+      'index.mjs',
+      'index.mts',
+      'index.ts',
+      'index.tsx',
+    ].map((file) => path.join(resolved, file)),
+  ]
+
+  const resolvedPath = candidates.find((candidate) => fs.existsSync(candidate))
+  return resolvedPath ?? source
+}
+
+function toReplacement(node: MdAst.RootContent, value: string): Replacement | undefined {
+  const start = node.position?.start.offset
+  const end = node.position?.end.offset
+  if (start === undefined || end === undefined) return undefined
+  return { end, start, value }
+}
+
+function applyReplacements(source: string, replacements: Replacement[]) {
+  let result = source
+  for (const replacement of replacements.sort((a, b) => b.start - a.start))
+    result = result.slice(0, replacement.start) + replacement.value + result.slice(replacement.end)
+  return result
+}

--- a/src/internal/markdown-imports.ts
+++ b/src/internal/markdown-imports.ts
@@ -34,6 +34,18 @@ export function inlineMarkdownImports(source: string, filePath: string): string 
   return inline(source, path.resolve(filePath), new Set())
 }
 
+export async function inlineMarkdownImportsAsync(
+  source: string,
+  filePath: string,
+  transform: inlineMarkdownImportsAsync.Transform,
+): Promise<string> {
+  return inlineAsync(source, path.resolve(filePath), new Set(), transform)
+}
+
+export declare namespace inlineMarkdownImportsAsync {
+  type Transform = (source: string, filePath: string) => Promise<string>
+}
+
 function inline(source: string, filePath: string, seen: Set<string>): string {
   if (seen.has(filePath)) return ''
   seen.add(filePath)
@@ -50,6 +62,34 @@ function inline(source: string, filePath: string, seen: Set<string>): string {
 
   collectImports(tree.children, imports, replacements)
   collectComponentReplacements(tree, imports, filePath, seen, replacements)
+
+  if (replacements.length === 0) return source
+  return applyReplacements(source, replacements)
+}
+
+async function inlineAsync(
+  source: string,
+  filePath: string,
+  seen: Set<string>,
+  transform: inlineMarkdownImportsAsync.Transform,
+): Promise<string> {
+  if (seen.has(filePath)) return ''
+  seen.add(filePath)
+
+  source = await transform(source, filePath)
+
+  let tree: MdAst.Root
+  try {
+    tree = unified().use(remarkParse).use(remarkMdx).parse(source)
+  } catch {
+    return source
+  }
+
+  const imports = new Map<string, MarkdownImport>()
+  const replacements: Replacement[] = []
+
+  collectImports(tree.children, imports, replacements)
+  await collectComponentReplacementsAsync(tree, imports, filePath, seen, replacements, transform)
 
   if (replacements.length === 0) return source
   return applyReplacements(source, replacements)
@@ -114,6 +154,40 @@ function collectComponentReplacements(
   if ('children' in node && Array.isArray(node.children))
     for (const child of node.children)
       collectComponentReplacements(child, imports, filePath, seen, replacements)
+}
+
+async function collectComponentReplacementsAsync(
+  node: MdAst.Root | MdAst.RootContent,
+  imports: Map<string, MarkdownImport>,
+  filePath: string,
+  seen: Set<string>,
+  replacements: Replacement[],
+  transform: inlineMarkdownImportsAsync.Transform,
+): Promise<void> {
+  if (isMdxJsxElement(node)) {
+    const name = node.name ?? undefined
+    const markdownImport = name ? imports.get(name) : undefined
+    if (markdownImport && isStaticMdxComponent(node)) {
+      const importedPath = resolveMarkdownImport(markdownImport.source, filePath)
+      if (importedPath) {
+        const importedSource = fs.readFileSync(importedPath, 'utf-8')
+        const value = await inlineAsync(importedSource, importedPath, new Set(seen), transform)
+        const replacement = toReplacement(node, value)
+        if (replacement) replacements.push(replacement)
+      }
+    }
+  }
+
+  if ('children' in node && Array.isArray(node.children))
+    for (const child of node.children)
+      await collectComponentReplacementsAsync(
+        child,
+        imports,
+        filePath,
+        seen,
+        replacements,
+        transform,
+      )
 }
 
 function isMdxJsxElement(node: MdAst.Root | MdAst.RootContent): node is MdxJsxElement {

--- a/src/internal/vite-plugins.ts
+++ b/src/internal/vite-plugins.ts
@@ -179,6 +179,7 @@ export function llms(config: Config.Config): PluginOption {
     const pagesDir = path.resolve(viteConfig.root, config.srcDir, config.pagesDir)
     const pages = await Llms.getPagesFromDir(pagesDir)
     const openapiPages = await Llms.getOpenApiPages(config)
+    const resolve = viteConfig.createResolver({ asSrc: true })
     // Generated OpenAPI pages first so they win over any consumer override at the
     // same generated route (`.md` serves the full reference); authored-only guide
     // pages under the section keep their own content.
@@ -190,6 +191,9 @@ export function llms(config: Config.Config): PluginOption {
       rehypePlugins,
       remarkPlugins,
       sidebar: config.sidebar,
+      componentOptions: {
+        resolve: (source, importer) => resolve(source, importer),
+      },
     })
   }
 


### PR DESCRIPTION
## Motivation

Custom MDX components are preserved as JSX in generated LLM Markdown, leaving agents without the component content.

## Summary

- Add automatic `toMarkdown` hooks for imported MDX components.
- Generate LLM Markdown after the SSR component graph is available.
- Document and test component-to-Markdown conversion.

## Key design considerations

- Hooks affect LLM artifacts only; interactive component rendering is unchanged.
- Components are discovered per MDX page, so no config registry is required.