### PR TITLE
feat(markdown): add output-only remark plugins

### DIFF
--- a/.changeset/plain-tools-smile.md
+++ b/.changeset/plain-tools-smile.md
@@ -1,0 +1,5 @@
+---
+"vocs": minor
+---
+
+Added output-only remark plugins for generated Markdown.

--- a/site/src/pages/features/rehype-and-remark.mdx
+++ b/site/src/pages/features/rehype-and-remark.mdx
@@ -83,6 +83,37 @@ export default defineConfig({
 })
 ```
 
+### Change Generated Markdown Only
+
+Use `outputRemarkPlugins` when an authored page needs a simpler Markdown form than its interactive form. These plugins run for authored page bodies used in per-page `.md` files and `llms-full.txt`, but do not change the rendered site.
+
+This is useful for replacing custom MDX components with plain headings, links, prose, or code. It uses the normal remark plugin format, so a plugin can read component names, props, and children without a separate Vocs component registry.
+
+```js [remark-plain-components.mjs]
+export default function unwrapPageGrid() {
+  return (tree) => {
+    for (let index = tree.children.length - 1; index >= 0; index--) {
+      const node = tree.children[index]
+      if (node.type !== 'mdxJsxFlowElement' || node.name !== 'PageGrid') continue
+      tree.children.splice(index, 1, ...node.children)
+    }
+  }
+}
+```
+
+```ts [vocs.config.ts]
+import { defineConfig } from 'vocs/config'
+import unwrapPageGrid from './remark-plain-components.mjs'
+
+export default defineConfig({
+  markdown: {
+    outputRemarkPlugins: [unwrapPageGrid] // [!code focus]
+  }
+})
+```
+
+Components that the plugin does not replace stay as MDX in the generated Markdown.
+
 ### Add Rehype Plugins
 
 Use `rehypePlugins` for transforms that work on HTML, such as adding attributes to links, rewriting elements, or integrating HTML-focused plugins.
@@ -123,7 +154,7 @@ export default defineConfig({
 
 ## Plugin Order
 
-Vocs runs its built-in Markdown plugins first, then runs plugins from your `markdown` config. Custom rehype plugins run after syntax highlighting and heading anchors, then Vocs finishes link and image processing.
+Vocs runs its built-in Markdown plugins first, followed by `remarkPlugins`. When Vocs generates Markdown, `outputRemarkPlugins` run last. Custom rehype plugins run after syntax highlighting and heading anchors, then Vocs finishes link and image processing.
 
 ## Reference
 

--- a/site/src/pages/reference/site-config.mdx
+++ b/site/src/pages/reference/site-config.mdx
@@ -584,7 +584,7 @@ export default defineConfig({
 
 ### `markdown`
 
-- **Type:** `@mdx-js/rollup` options
+- **Type:** `@mdx-js/rollup` options with `outputRemarkPlugins`
 
 Extends the underlying MDX compilation pipeline. Use this when you need to add custom remark, rehype, or recma plugins.
 
@@ -597,6 +597,8 @@ export default defineConfig({
   }
 })
 ```
+
+Use `outputRemarkPlugins` for remark transforms that should apply only to authored page bodies used in per-page `.md` output and `llms-full.txt`, not the rendered site. They run after `remarkPlugins`.
 
 Vocs already includes its own MDX plugins for features such as callouts, code groups, frontmatter handling, and syntax highlighting, so `markdown` is usually only needed for custom behavior.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ export * as Changelog from './internal/changelog.js'
 export {
   type Config,
   define as defineConfig,
+  type MarkdownOptions,
   resolve as resolveConfig,
 } from './internal/config.js'
 export * as Embedding from './internal/embedding.js'

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -6,6 +6,7 @@ import type {
   SearchOptions as MiniSearchSearchOptions,
 } from 'minisearch'
 import type { Link, MetaFlat, Script, StringInnerContent, Style } from 'unhead/types'
+import type { PluggableList } from 'unified'
 import type * as Changelog from './changelog.js'
 import type * as Feedback from './feedback.js'
 import * as Langs from './langs.js'
@@ -89,6 +90,16 @@ export type SitemapOptions = {
         },
       ) => boolean | string | undefined)
     | undefined
+}
+
+export type MarkdownOptions = MdxRollup.Options & {
+  /**
+   * Remark plugins applied only when Vocs generates Markdown for authored pages.
+   *
+   * Applies to per-page `.md` output and `llms-full.txt`. Runs after Vocs' built-in text
+   * transforms and `remarkPlugins`.
+   */
+  outputRemarkPlugins?: PluggableList | undefined
 }
 
 type SearchDocument = {
@@ -536,7 +547,7 @@ export type Config<partial extends boolean = false> = MaybePartial<
     /**
      * Markdown configuration.
      */
-    markdown?: MdxRollup.Options | undefined
+    markdown?: MarkdownOptions | undefined
     /**
      * MCP (Model Context Protocol) server configuration.
      * Enables LLMs to navigate documentation and source code.

--- a/src/internal/llms.test.ts
+++ b/src/internal/llms.test.ts
@@ -1,13 +1,16 @@
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
+import type * as MdAst from 'mdast'
 import remarkDirective from 'remark-directive'
 import type { Pluggable } from 'unified'
 import { describe, expect, test } from 'vitest'
 import type * as Changelog from './changelog.js'
+import * as Config from './config.js'
 import { buildLlmsContent, getMarkdownPagePrelude } from './llms.js'
 import { inlineMarkdownComponents } from './markdown-components.js'
 import {
+  getCompileOptions,
   remarkChangelogMarkdown,
   remarkDefaultFrontmatter,
   remarkExtractFrontmatter,
@@ -740,6 +743,98 @@ title: Component
       <Component />
       "
     `)
+  })
+
+  test('renders components with output-only remark plugins', async () => {
+    type ComponentAttribute = {
+      name?: string
+      type: string
+      value?: unknown
+    }
+    type ComponentNode = {
+      attributes: ComponentAttribute[]
+      children: MdAst.RootContent[]
+      name: string | null
+      type: 'mdxJsxFlowElement'
+    }
+
+    function renamePanel() {
+      return (tree: MdAst.Root) => {
+        for (const child of tree.children) {
+          if (child.type !== 'mdxJsxFlowElement') continue
+          const node = child as ComponentNode
+          if (node.name !== 'Panel') continue
+          const title = node.attributes.find(
+            (attribute) => attribute.type === 'mdxJsxAttribute' && attribute.name === 'title',
+          )
+          if (typeof title?.value === 'string') title.value = 'Readable title'
+        }
+      }
+    }
+
+    function renderPanel() {
+      return (tree: MdAst.Root) => {
+        for (const [index, child] of tree.children.entries()) {
+          if (child.type !== 'mdxJsxFlowElement') continue
+          const node = child as ComponentNode
+          if (node.name !== 'Panel') continue
+          const title = node.attributes.find(
+            (attribute) => attribute.type === 'mdxJsxAttribute' && attribute.name === 'title',
+          )?.value
+          if (typeof title !== 'string') continue
+          tree.children.splice(
+            index,
+            1,
+            {
+              type: 'heading',
+              depth: 2,
+              children: [{ type: 'text', value: title }],
+            },
+            ...node.children,
+          )
+        }
+      }
+    }
+
+    const config = Config.define({
+      markdown: {
+        remarkPlugins: [renamePanel],
+        outputRemarkPlugins: [renderPanel],
+      },
+      rootDir: process.cwd(),
+    })
+    const { rehypePlugins, remarkPlugins } = getCompileOptions('txt', config)
+    const result = await buildLlmsContent({
+      pages: [
+        {
+          path: '/component',
+          content: `---
+title: Component
+---
+
+<Panel title="Interactive title">
+Child prose.
+</Panel>
+
+<Unknown />`,
+        },
+      ],
+      title: 'My Docs',
+      rehypePlugins,
+      remarkPlugins,
+    })
+
+    expect(result.results[0]?.content).toMatchInlineSnapshot(`
+      "## Readable title
+
+      Child prose.
+
+      <Unknown />
+      "
+    `)
+    expect(result.full).toContain(result.results[0]?.content)
+    expect(result.full).not.toContain('<Panel')
+    expect(result.short).toContain('- [Component](/component)')
   })
 
   test('strips inline twoslash cache comments from code blocks', async () => {

--- a/src/internal/mdx.test.ts
+++ b/src/internal/mdx.test.ts
@@ -387,15 +387,27 @@ describe('getCompileOptions', () => {
     expect(codeNode.meta).toBe('[example.ts]')
   })
 
-  it('threads user-configured remark plugins into the txt profile', () => {
+  it('applies output remark plugins only to the txt profile', () => {
     function userRemarkPlugin() {}
+    function outputRemarkPlugin() {}
     const config = Config.define({
-      markdown: { remarkPlugins: [userRemarkPlugin] },
+      markdown: {
+        remarkPlugins: [userRemarkPlugin],
+        outputRemarkPlugins: [outputRemarkPlugin],
+      },
       rootDir: process.cwd(),
     })
 
-    expect(getCompileOptions('txt', config).remarkPlugins).toContain(userRemarkPlugin)
-    expect(getCompileOptions('react', config).remarkPlugins).toContain(userRemarkPlugin)
+    const txtOptions = getCompileOptions('txt', config)
+    const reactOptions = getCompileOptions('react', config)
+
+    expect(txtOptions.remarkPlugins.indexOf(userRemarkPlugin)).toBeLessThan(
+      txtOptions.remarkPlugins.indexOf(outputRemarkPlugin),
+    )
+    expect(reactOptions.remarkPlugins).toContain(userRemarkPlugin)
+    expect(reactOptions.remarkPlugins).not.toContain(outputRemarkPlugin)
+    expect(txtOptions).not.toHaveProperty('outputRemarkPlugins')
+    expect(reactOptions).not.toHaveProperty('outputRemarkPlugins')
   })
 })
 

--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -283,7 +283,7 @@ export function getCompileOptions(
   recmaPlugins: PluggableList
 } {
   const { cacheDir, codeHighlight, markdown, rootDir, srcDir, twoslash } = config
-  const { jsxImportSource = 'react' } = markdown ?? {}
+  const { jsxImportSource = 'react', outputRemarkPlugins, ...markdownOptions } = markdown ?? {}
 
   // Extract language names from twoslash transformers (e.g., rust, toml from experimental_rust)
   const twoslashTransformerLangs =
@@ -323,6 +323,9 @@ export function getCompileOptions(
           // User plugins extend the parser (e.g. `remark-math`) so syntax
           // recognized in the React build also parses for llms/search.
           ...(markdown?.remarkPlugins ?? []),
+          // Output-only plugins can replace interactive MDX with a plain
+          // Markdown representation without changing the rendered site.
+          ...(outputRemarkPlugins ?? []),
         ],
       }
     if (type === 'react')
@@ -420,7 +423,7 @@ export function getCompileOptions(
   })()
 
   return {
-    ...markdown,
+    ...markdownOptions,
     jsxImportSource,
     providerImportSource: 'vocs/mdx',
     recmaPlugins,


### PR DESCRIPTION
## Motivation

Vocs now supports component-owned `toMarkdown` hooks (#593) and can audit generated Markdown for unresolved MDX (#595). A site still needs a generic way to rewrite output when the Markdown form depends on attributes, children, third-party components, or other custom syntax.

This adds an output-only remark hook at Vocs's existing React/Markdown boundary. Sites can keep one source page while customizing AI-facing Markdown without changing browser rendering or loading component modules.

## Changes

- Add `markdown.outputRemarkPlugins` and export its `MarkdownOptions` type.
- Run output plugins after the shared `remarkPlugins`.
- Apply them to authored pages used for per-page `.md` output and `llms-full.txt`.
- Keep them out of React compilation and `@mdx-js/rollup`.
- Document plugin order with a self-contained example.
- Test isolation, order, attributes, children, output parity, and fallback behavior.

## How it fits with #593 and #595

- #593 is the default path for imported components that own their Markdown representation.
- This PR provides a site-owned path for transformations that belong in the output pipeline, including third-party components and syntax that spans attributes or children.
- #595 runs the configured Markdown pipeline and reports anything that remains unresolved.

The approaches are complementary and can be adopted one component at a time.

## Scope

This PR only establishes the generic output hook. It does not guess how arbitrary components should render, change search indexing or MCP raw-page reads, or reprocess generated OpenAPI Markdown that is already final.

## Compatibility

Existing `remarkPlugins` behavior is unchanged. Without `outputRemarkPlugins`, generated output is unchanged. React output never receives the new plugins.

## Test plan

- [x] `pnpm check`
- [x] `pnpm check:types`
- [x] `pnpm test --run` (681 passed, 3 skipped)
- [x] `pnpm docs:twoslash` (33 passed)
- [x] `pnpm docs:build`
