### PR TITLE
feat: add markdown audit command

### DIFF
--- a/.changeset/fuzzy-cats-audit.md
+++ b/.changeset/fuzzy-cats-audit.md
@@ -1,0 +1,5 @@
+---
+"vocs": minor
+---
+
+Add a CLI audit for MDX components left in generated Markdown.

--- a/site/src/pages/features/agent-support.mdx
+++ b/site/src/pages/features/agent-support.mdx
@@ -91,6 +91,43 @@ import { ClientPrompt } from '../components/ClientPrompt'
 
 Vocs invokes the hook only while generating `.md`, `llms.txt`, and `llms-full.txt`. The hook must return a Markdown AST node or an array of nodes; components without a hook remain unchanged.
 
+### Audit Markdown Components
+
+Dry render every page locally to find components that remain as MDX in AI-facing Markdown:
+
+```sh
+vocs markdown-audit
+```
+
+The report groups results by component, then lists each affected page and a suggested fix. It exits with status `1` when a component remains unrendered, so it can be used in CI. Add `--json` for machine-readable output.
+
+#### Example Output
+
+```txt
+[vocs] Markdown audit found 1 component left after dry rendering 1 page (2 occurrences).
+
+Components:
+  InteractiveWidget (2 occurrences)
+    Fix: add `InteractiveWidget.toMarkdown` to return a Markdown AST node.
+    /guides/setup (2 occurrences)
+```
+
+#### JSON Output
+
+```json
+{
+  "components": [
+    {
+      "name": "InteractiveWidget",
+      "unsupportedUsages": 0,
+      "count": 2,
+      "pages": [{ "path": "/guides/setup", "count": 2 }]
+    }
+  ],
+  "errors": []
+}
+```
+
 ## Best Practices
 
 ### Optimize for LLMs

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,9 @@ import react from '@vitejs/plugin-react'
 import { cac } from 'cac'
 import * as vite from 'vite'
 import * as Config from './internal/config.js'
+import * as Llms from './internal/llms.js'
+import * as MarkdownAudit from './internal/markdown-audit.js'
+import * as Mdx from './internal/mdx.js'
 import { vocs } from './waku/vite.js'
 
 const pkg = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8'))
@@ -49,6 +52,28 @@ cli
       },
     })
     await builder.buildApp()
+  })
+
+cli
+  .command('markdown-audit [root]', 'Find MDX components that remain in generated Markdown')
+  .option('--json', 'Write the audit report as JSON')
+  .action(async (root: string | undefined, options: { json?: boolean }) => {
+    const rootDir = path.resolve(root ?? process.cwd())
+    const config = await Config.resolve({ rootDir })
+    const pagesDir = path.resolve(config.rootDir, config.srcDir, config.pagesDir)
+    const pages = await Llms.getPagesFromDir(pagesDir)
+    const { rehypePlugins, remarkPlugins } = Mdx.getCompileOptions('txt', config)
+    const viteConfig = await vite.resolveConfig({ root: rootDir }, 'build', 'production')
+    const resolve = viteConfig.createResolver({ asSrc: true })
+    const report = await MarkdownAudit.audit({
+      componentOptions: { resolve: (source, importer) => resolve(source, importer) },
+      pages,
+      rehypePlugins,
+      remarkPlugins,
+    })
+
+    console.log(options.json ? JSON.stringify(report, null, 2) : MarkdownAudit.format(report))
+    if (report.components.length > 0 || report.errors.length > 0) process.exitCode = 1
   })
 
 cli

--- a/src/internal/markdown-audit.test.ts
+++ b/src/internal/markdown-audit.test.ts
@@ -1,0 +1,98 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { describe, expect, test } from 'vitest'
+import { audit, format } from './markdown-audit.js'
+
+describe('audit', () => {
+  test('reports unrendered components by component, then page', async () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocs-markdown-audit-'))
+    const componentPath = path.join(rootDir, 'components.ts')
+    const servicesPath = path.join(rootDir, 'services.mdx')
+    const setupPath = path.join(rootDir, 'setup.mdx')
+
+    try {
+      fs.writeFileSync(
+        componentPath,
+        `export const Rendered = {
+  toMarkdown: () => ({ type: 'paragraph', children: [{ type: 'text', value: 'Rendered.' }] }),
+}
+
+export function Image() { return null }
+
+export const Button = {
+  toMarkdown: () => ({ type: 'paragraph', children: [{ type: 'text', value: 'Button.' }] }),
+}`,
+      )
+      fs.writeFileSync(
+        servicesPath,
+        `import { Button, Image, Rendered } from './components'
+
+<Rendered />
+
+<Image />
+
+<Image />
+
+<Button href="/docs" />`,
+      )
+      fs.writeFileSync(
+        setupPath,
+        `import { Image } from './components'
+
+<Image />`,
+      )
+
+      const result = await audit({
+        pages: [
+          { content: { path: servicesPath }, path: '/services' },
+          { content: { path: setupPath }, path: '/setup' },
+        ],
+      })
+
+      expect(result).toEqual({
+        components: [
+          {
+            count: 3,
+            name: 'Image',
+            pages: [
+              { count: 2, path: '/services' },
+              { count: 1, path: '/setup' },
+            ],
+            unsupportedUsages: 0,
+          },
+          {
+            count: 1,
+            name: 'Button',
+            pages: [{ count: 1, path: '/services' }],
+            unsupportedUsages: 1,
+          },
+        ],
+        errors: [],
+      })
+      expect(format(result)).toMatchInlineSnapshot(`
+        "[vocs] Markdown audit found 2 components left after dry rendering 2 pages (4 occurrences).
+
+        Components:
+          Image (3 occurrences)
+            Fix: add \`Image.toMarkdown\` to return a Markdown AST node.
+            /services (2 occurrences)
+            /setup (1 occurrence)
+          Button (1 occurrence)
+            Fix: replace this prop or child usage with Markdown; \`toMarkdown\` only supports standalone components.
+            /services (1 occurrence)"
+      `)
+    } finally {
+      fs.rmSync(rootDir, { force: true, recursive: true })
+    }
+  })
+
+  test('passes when generated Markdown contains no MDX components', async () => {
+    const result = await audit({
+      pages: [{ content: '# Hello\n\nMarkdown only.', path: '/' }],
+    })
+
+    expect(result).toEqual({ components: [], errors: [] })
+    expect(format(result)).toBe('[vocs] Markdown audit passed. No unrendered MDX components found.')
+  })
+})

--- a/src/internal/markdown-audit.ts
+++ b/src/internal/markdown-audit.ts
@@ -1,0 +1,217 @@
+import * as fs from 'node:fs/promises'
+import type * as MdAst from 'mdast'
+import remarkMdx from 'remark-mdx'
+import remarkParse from 'remark-parse'
+import remarkStringify from 'remark-stringify'
+import type { PluggableList } from 'unified'
+import { unified } from 'unified'
+import { visit } from 'unist-util-visit'
+import * as MarkdownComponents from './markdown-components.js'
+import * as MarkdownImports from './markdown-imports.js'
+
+/**
+ * The Markdown audit deliberately follows the same local transformation path as Vocs' Markdown
+ * twins. It reads every page, expands imported Markdown, runs `toMarkdown` hooks, and then runs
+ * the configured Markdown processor. The final pass only reports PascalCase MDX tags that survive
+ * that dry render, so a component with a working Markdown representation is never flagged.
+ *
+ * This module does not fetch a built site or make network requests. The CLI supplies the site's
+ * configured remark/rehype plugins and import resolver, allowing aliases and local components to
+ * behave as they do during a normal Vocs build.
+ */
+type MdxJsxElement = MdAst.RootContent & {
+  attributes?: unknown[]
+  children?: MdAst.RootContent[]
+  name?: string | null
+  type: 'mdxJsxFlowElement' | 'mdxJsxTextElement'
+}
+
+/** Finds MDX components that remain in the Markdown generated for a set of pages. */
+export async function audit(options: audit.Options): Promise<audit.Result> {
+  const components = new Map<string, audit.Component>()
+  const errors: audit.PageError[] = []
+
+  for (const page of options.pages) {
+    // Read source from disk when auditing a site. String pages keep the helper convenient for
+    // callers that already have page content, but cannot resolve component imports on their own.
+    const source =
+      typeof page.content === 'string' ? page.content : await fs.readFile(page.content.path, 'utf8')
+    const filePath = typeof page.content === 'string' ? undefined : page.content.path
+
+    let markdown = source
+    try {
+      // First reproduce the part of Markdown generation that is specific to MDX components:
+      // imported Markdown is inlined recursively and standalone components get a chance to
+      // replace themselves through `toMarkdown`.
+      if (filePath)
+        markdown = await MarkdownImports.inlineMarkdownImportsAsync(
+          source,
+          filePath,
+          (content, path) =>
+            MarkdownComponents.inlineMarkdownComponents(content, path, options.componentOptions),
+        )
+
+      // Then perform the site's real Markdown processing. This lets configured remark/rehype
+      // plugins remove, rewrite, or add content before the audit decides what still remains.
+      markdown = String(
+        await unified()
+          .use(remarkParse)
+          .use(remarkMdx)
+          .use(remarkStringify)
+          .use(options.remarkPlugins ?? [])
+          .use(options.rehypePlugins ?? [])
+          .process(markdown),
+      )
+    } catch (error) {
+      // A failed component hook should not hide findings from unrelated pages. Keep the original
+      // Markdown for inspection and put the render failure in the report alongside the findings.
+      errors.push({
+        error: error instanceof Error ? error.message : String(error),
+        path: page.path,
+      })
+    }
+
+    let tree: MdAst.Root
+    try {
+      // Parse the fully rendered Markdown, rather than the source MDX. A remaining MDX JSX node
+      // here is precisely what an AI-facing Markdown consumer would receive.
+      tree = unified().use(remarkParse).use(remarkMdx).parse(markdown)
+    } catch (error) {
+      errors.push({
+        error: error instanceof Error ? error.message : String(error),
+        path: page.path,
+      })
+      continue
+    }
+
+    visit(tree, ['mdxJsxFlowElement', 'mdxJsxTextElement'], (node) => {
+      const component = node as MdxJsxElement
+      if (!isMdxComponent(component)) return
+
+      // Aggregate by component first, then route. This gives maintainers one fix per component
+      // while still showing the complete set of pages affected by that missing representation.
+      const finding = components.get(component.name) ?? {
+        name: component.name,
+        pages: new Map(),
+        unsupportedUsages: 0,
+      }
+      const pageFinding = finding.pages.get(page.path) ?? { count: 0, path: page.path }
+      pageFinding.count += 1
+      finding.pages.set(page.path, pageFinding)
+      if (!isStandalone(component)) finding.unsupportedUsages += 1
+      components.set(component.name, finding)
+    })
+  }
+
+  return {
+    components: [...components.values()]
+      .map((component) => {
+        const pages = [...component.pages.values()].sort((a, b) => a.path.localeCompare(b.path))
+        return { ...component, count: pages.reduce((count, page) => count + page.count, 0), pages }
+      })
+      .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name)),
+    errors: errors.sort((a, b) => a.path.localeCompare(b.path) || a.error.localeCompare(b.error)),
+  }
+}
+
+export declare namespace audit {
+  type Options = {
+    componentOptions?: MarkdownComponents.inlineMarkdownComponents.Options | undefined
+    pages: Page[]
+    rehypePlugins?: PluggableList | undefined
+    remarkPlugins?: PluggableList | undefined
+  }
+
+  type Page = {
+    content: string | { path: string }
+    path: string
+  }
+
+  type Component = {
+    name: string
+    pages: Map<string, PageFinding>
+    unsupportedUsages: number
+  }
+
+  type PageFinding = {
+    count: number
+    path: string
+  }
+
+  type PageError = {
+    error: string
+    path: string
+  }
+
+  type Result = {
+    components: Array<Omit<Component, 'pages'> & { count: number; pages: PageFinding[] }>
+    errors: PageError[]
+  }
+}
+
+/** Formats a Markdown audit for terminal output. */
+export function format(result: audit.Result): string {
+  const pageCount = new Set(
+    result.components.flatMap((component) => component.pages.map((page) => page.path)),
+  ).size
+  const occurrenceCount = result.components.reduce((count, component) => count + component.count, 0)
+
+  if (result.components.length === 0 && result.errors.length === 0)
+    return '[vocs] Markdown audit passed. No unrendered MDX components found.'
+
+  // Keep the human report component-first: a single hook or content change commonly fixes many
+  // routes, and the nested page counts make the highest-impact fixes immediately visible.
+  const lines = [
+    `[vocs] Markdown audit found ${result.components.length} ${pluralize('component', result.components.length)} left after dry rendering ${pageCount} ${pluralize('page', pageCount)} (${occurrenceCount} ${pluralize('occurrence', occurrenceCount)}).`,
+  ]
+
+  if (result.components.length > 0) {
+    lines.push('', 'Components:')
+    for (const component of result.components) {
+      lines.push(
+        `  ${component.name} (${component.count} ${pluralize('occurrence', component.count)})`,
+      )
+      lines.push(`    ${suggestion(component)}`)
+      for (const page of component.pages)
+        lines.push(`    ${page.path || '/'} (${page.count} ${pluralize('occurrence', page.count)})`)
+    }
+  }
+
+  if (result.errors.length > 0) {
+    lines.push('', 'Pages that could not be fully audited:')
+    for (const error of result.errors) lines.push(`  ${error.path || '/'}: ${error.error}`)
+  }
+
+  return lines.join('\n')
+}
+
+function isMdxComponent(node: MdxJsxElement): node is MdxJsxElement & { name: string } {
+  // Lowercase tags are HTML. Only PascalCase names (including namespaced MDX components such as
+  // `HomePage.Button`) require a JavaScript component implementation and cannot be plain Markdown.
+  return !!node.name && /^[A-Z][A-Za-z0-9_$]*(?:\.[A-Za-z0-9_$]+)*$/.test(node.name)
+}
+
+function isStandalone(node: MdxJsxElement) {
+  // Vocs currently invokes `toMarkdown` only for imported, self-closing flow components. Record
+  // prop, child, inline, and namespaced usages separately so the report can recommend Markdown
+  // replacement rather than suggesting a hook that cannot run for that invocation.
+  return (
+    node.type === 'mdxJsxFlowElement' &&
+    node.attributes?.length === 0 &&
+    node.children?.length === 0
+  )
+}
+
+function pluralize(word: string, count: number) {
+  return `${word}${count === 1 ? '' : 's'}`
+}
+
+function suggestion(component: audit.Result['components'][number]) {
+  // Suggestions reflect the actual hook contract above instead of treating every MDX component as
+  // hook-compatible. A component can have both standalone and unsupported usages across pages.
+  if (component.unsupportedUsages === 0)
+    return `Fix: add \`${component.name}.toMarkdown\` to return a Markdown AST node.`
+  if (component.unsupportedUsages === component.count)
+    return 'Fix: replace this prop or child usage with Markdown; `toMarkdown` only supports standalone components.'
+  return `Fix: add \`${component.name}.toMarkdown\` for standalone usages; replace prop or child usages with Markdown.`
+}


### PR DESCRIPTION
## Motivation

Documentation sites can expose interactive MDX components as unresolved tags in AI-facing Markdown. Maintainers need an offline way to identify every affected component and page before publishing.

## Summary

- Add `vocs markdown-audit` to dry-render each page through the Markdown pipeline.
- Group remaining MDX components by name, affected route, occurrence count, and suggested fix.
- Add terminal and JSON output examples to the Agent Support docs.

## Key design considerations

- Reuse the Markdown import, component-hook, and configured remark/rehype processing paths for faithful local results.
- Return a non-zero exit status when findings or render errors exist so the audit works in CI.
- Provide a machine-readable `--json` report alongside the component-first terminal report.