### PR TITLE
feat: add JSON-LD structured data

### DIFF
--- a/.changeset/bright-eggs-attend.md
+++ b/.changeset/bright-eggs-attend.md
@@ -1,0 +1,5 @@
+---
+"vocs": minor
+---
+
+Add enabled-by-default JSON-LD structured data with a `jsonLd` opt-out.

--- a/site/src/pages/reference/site-config.mdx
+++ b/site/src/pages/reference/site-config.mdx
@@ -147,6 +147,19 @@ export default defineConfig({
 })
 ```
 
+### `jsonLd`
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Adds [`TechArticle` JSON-LD](https://schema.org/TechArticle) to each page. Vocs includes the title, description, canonical URL, site identity, author, publication date, and modification date when available. Set `baseUrl` to include canonical page URLs.
+
+```ts
+export default defineConfig({
+  jsonLd: false
+})
+```
+
 ## URLs And Deployment
 
 ### `basePath`

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -545,6 +545,12 @@ export type Config<partial extends boolean = false> = MaybePartial<
      */
     head?: HeadOptions | undefined
     /**
+     * Whether Vocs includes JSON-LD structured data on pages.
+     *
+     * @default true
+     */
+    jsonLd: boolean
+    /**
      * Markdown configuration.
      */
     markdown?: MarkdownOptions | undefined
@@ -852,6 +858,7 @@ export function define(config: define.Options = {}): Config {
     description,
     head,
     iconUrl,
+    jsonLd = true,
     logoUrl,
     markdown,
     mcp,
@@ -948,6 +955,7 @@ export function define(config: define.Options = {}): Config {
     groupIcons: config.groupIcons,
     head,
     iconUrl,
+    jsonLd,
     logoUrl,
     markdown,
     mcp,

--- a/src/react/Head.test.tsx
+++ b/src/react/Head.test.tsx
@@ -106,11 +106,14 @@ describe('Head', () => {
     expect(html).toContain('"dateModified":"2026-07-25T00:00:00.000Z"')
   })
 
-  test('omits JSON-LD when disabled and escapes inline JSON', () => {
+  test('omits JSON-LD when disabled or excluded and escapes inline JSON', () => {
     mocks.config = createConfig({ jsonLd: false })
     expect(renderHead({ title: 'Post' })).not.toContain('application/ld+json')
 
     mocks.config = createConfig()
+    expect(renderHead({ title: 'Post' }, { includeJsonLd: false })).not.toContain(
+      'application/ld+json',
+    )
     expect(
       renderHead({ description: '</script><script>alert(1)</script>', title: 'Post' }),
     ).toContain('\\u003c/script\\u003e\\u003cscript\\u003ealert(1)\\u003c/script\\u003e')
@@ -266,10 +269,10 @@ describe('Head', () => {
   })
 })
 
-function renderHead(frontmatter: Config.Frontmatter | undefined) {
+function renderHead(frontmatter: Config.Frontmatter | undefined, props: Head.Props = {}) {
   return renderToStaticMarkup(
     <MdxPageContext.Provider frontmatter={frontmatter}>
-      <Head />
+      <Head {...props} />
     </MdxPageContext.Provider>,
   )
 }

--- a/src/react/Head.test.tsx
+++ b/src/react/Head.test.tsx
@@ -87,6 +87,35 @@ describe('Head', () => {
     expect(html).toContain('name="twitter:image"')
   })
 
+  test('renders enabled-by-default JSON-LD metadata', () => {
+    mocks.path = '/docs/intro'
+
+    const html = renderHead({
+      author: '[Ada Lovelace](https://example.com/ada)',
+      date: '2026-07-24',
+      description: 'Use Vocs to build documentation.',
+      lastModified: '2026-07-25T00:00:00.000Z',
+      title: 'Introduction',
+    })
+
+    expect(html).toContain('<script type="application/ld+json">')
+    expect(html).toContain('"@type":"TechArticle"')
+    expect(html).toContain('"url":"https://example.com/docs/intro"')
+    expect(html).toContain('"name":"Ada Lovelace"')
+    expect(html).toContain('"datePublished":"2026-07-24"')
+    expect(html).toContain('"dateModified":"2026-07-25T00:00:00.000Z"')
+  })
+
+  test('omits JSON-LD when disabled and escapes inline JSON', () => {
+    mocks.config = createConfig({ jsonLd: false })
+    expect(renderHead({ title: 'Post' })).not.toContain('application/ld+json')
+
+    mocks.config = createConfig()
+    expect(
+      renderHead({ description: '</script><script>alert(1)</script>', title: 'Post' }),
+    ).toContain('\\u003c/script\\u003e\\u003cscript\\u003ealert(1)\\u003c/script\\u003e')
+  })
+
   test('renders arbitrary meta tags from unhead vocabulary', () => {
     mocks.config = createConfig({
       head: {
@@ -231,6 +260,7 @@ describe('Head', () => {
     expect(html).not.toContain('rel="icon"')
     expect(html).not.toContain('og:')
     expect(html).not.toContain('twitter:')
+    expect(html).not.toContain('application/ld+json')
     // Functional tags are unaffected.
     expect(html).toContain('name="color-scheme"')
   })
@@ -259,6 +289,7 @@ function createConfig(config: Partial<Config.Config> = {}): Config.Config {
     colorScheme: 'light dark',
     description: 'Acme docs',
     feedback: false,
+    jsonLd: true,
     outDir: 'dist',
     pagesDir: 'pages',
     renderStrategy: 'dynamic',

--- a/src/react/Head.tsx
+++ b/src/react/Head.tsx
@@ -4,6 +4,7 @@ import type { Meta, MetaFlat } from 'unhead/types'
 import { unpackMeta } from 'unhead/utils'
 import { useRouter } from 'waku'
 import type * as Config from '../internal/config.js'
+import * as JsonLd from './json-ld.js'
 import * as MdxPageContext from './MdxPageContext.js'
 import { useConfig } from './useConfig.js'
 
@@ -68,6 +69,19 @@ export function Head() {
   const base = tag(head.base, baseUrl)
   const canonical = tag(head.canonical, canonicalDefault)
   const icons = head.icons !== false
+  const jsonLd =
+    !disabled && config.jsonLd
+      ? JsonLd.serialize(
+          JsonLd.from({
+            canonical,
+            description: descriptionSource,
+            frontmatter,
+            siteName: config.title,
+            siteUrl: baseUrl,
+            title: titleSource ?? config.title,
+          }),
+        )
+      : undefined
 
   const metaTags = unpackMeta(
     compactMeta({
@@ -153,6 +167,15 @@ export function Head() {
               />
             )
           })}
+
+          {/* Structured data */}
+          {jsonLd && (
+            <script
+              type="application/ld+json"
+              // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD is serialized and escaped above
+              dangerouslySetInnerHTML={{ __html: jsonLd }}
+            />
+          )}
 
           {/* Links */}
           {head.link?.map((tag, index) => (

--- a/src/react/Head.tsx
+++ b/src/react/Head.tsx
@@ -8,7 +8,8 @@ import * as JsonLd from './json-ld.js'
 import * as MdxPageContext from './MdxPageContext.js'
 import { useConfig } from './useConfig.js'
 
-export function Head() {
+export function Head(props: Head.Props) {
+  const { includeJsonLd = true } = props
   const config = useConfig()
   const { path: pathname } = useRouter()
   const { frontmatter } = MdxPageContext.use()
@@ -70,7 +71,7 @@ export function Head() {
   const canonical = tag(head.canonical, canonicalDefault)
   const icons = head.icons !== false
   const jsonLd =
-    !disabled && config.jsonLd
+    !disabled && includeJsonLd && config.jsonLd
       ? JsonLd.serialize(
           JsonLd.from({
             canonical,
@@ -219,6 +220,12 @@ export function Head() {
       )}
     </>
   )
+}
+
+export declare namespace Head {
+  export type Props = {
+    includeJsonLd?: boolean | undefined
+  }
 }
 
 /** unhead types use HTML attribute casing; React needs camelCase for these. */

--- a/src/react/Layout.tsx
+++ b/src/react/Layout.tsx
@@ -2,10 +2,10 @@ import { Head } from './Head.js'
 import * as Layout_client from './Layout.client.js'
 
 export function Layout(props: Layout.Props) {
-  const { children } = props
+  const { children, includeJsonLd } = props
   return (
     <>
-      <Head />
+      <Head includeJsonLd={includeJsonLd} />
       <Layout_client.Main>{children}</Layout_client.Main>
     </>
   )
@@ -14,5 +14,6 @@ export function Layout(props: Layout.Props) {
 export namespace Layout {
   export type Props = {
     children: React.ReactNode
+    includeJsonLd?: boolean | undefined
   }
 }

--- a/src/react/Root.tsx
+++ b/src/react/Root.tsx
@@ -22,7 +22,7 @@ export async function Root({ children }: { children: React.ReactNode }) {
         <link rel="stylesheet" href={stylesUrl} />
         {userStylesUrl && <link rel="stylesheet" href={userStylesUrl} />}
         {groupIconsStylesUrl && <link rel="stylesheet" href={groupIconsStylesUrl} />}
-        <Head />
+        <Head includeJsonLd={false} />
       </head>
       <body data-version="1.0">
         <Root_client>{children}</Root_client>

--- a/src/react/internal/openapi/OpenApiPage.tsx
+++ b/src/react/internal/openapi/OpenApiPage.tsx
@@ -25,7 +25,7 @@ function OpenApiLayout(props: {
     <MdxPageContext.Provider
       frontmatter={{ outline: props.outline ?? true, content: { width: props.width ?? 'full' } }}
     >
-      <Layout>{props.children}</Layout>
+      <Layout includeJsonLd={false}>{props.children}</Layout>
     </MdxPageContext.Provider>
   )
 }

--- a/src/react/json-ld.ts
+++ b/src/react/json-ld.ts
@@ -5,7 +5,8 @@ type JsonLd = Record<string, unknown>
 export function from(options: from.Options): JsonLd {
   const { canonical, description, frontmatter, siteName, siteUrl, title } = options
   const author = toAuthor(frontmatter?.author)
-  const datePublished = typeof frontmatter?.date === 'string' ? frontmatter.date : undefined
+  const date = frontmatter?.['date']
+  const datePublished = typeof date === 'string' ? date : undefined
 
   return {
     '@context': 'https://schema.org',
@@ -52,7 +53,7 @@ export function serialize(value: JsonLd): string {
       '\u2028': '\\u2028',
       '\u2029': '\\u2029',
     }
-    return replacements[character]
+    return replacements[character] ?? character
   })
 }
 

--- a/src/react/json-ld.ts
+++ b/src/react/json-ld.ts
@@ -1,0 +1,65 @@
+import type * as Config from '../internal/config.js'
+
+type JsonLd = Record<string, unknown>
+
+export function from(options: from.Options): JsonLd {
+  const { canonical, description, frontmatter, siteName, siteUrl, title } = options
+  const author = toAuthor(frontmatter?.author)
+  const datePublished = typeof frontmatter?.date === 'string' ? frontmatter.date : undefined
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'TechArticle',
+    headline: title,
+    ...(description && description !== 'undefined' ? { description } : {}),
+    ...(canonical
+      ? {
+          mainEntityOfPage: {
+            '@id': canonical,
+            '@type': 'WebPage',
+          },
+          url: canonical,
+        }
+      : {}),
+    ...(author ? { author } : {}),
+    ...(datePublished ? { datePublished } : {}),
+    ...(frontmatter?.lastModified ? { dateModified: frontmatter.lastModified } : {}),
+    isPartOf: {
+      '@type': 'WebSite',
+      name: siteName,
+      ...(siteUrl ? { url: siteUrl } : {}),
+    },
+  }
+}
+
+export declare namespace from {
+  export type Options = {
+    canonical?: string | undefined
+    description?: string | undefined
+    frontmatter?: Config.Frontmatter | undefined
+    siteName: string
+    siteUrl?: string | undefined
+    title: string
+  }
+}
+
+export function serialize(value: JsonLd): string {
+  return JSON.stringify(value).replace(/[<>&\u2028\u2029]/g, (character) => {
+    const replacements: Record<string, string> = {
+      '<': '\\u003c',
+      '>': '\\u003e',
+      '&': '\\u0026',
+      '\u2028': '\\u2028',
+      '\u2029': '\\u2029',
+    }
+    return replacements[character]
+  })
+}
+
+function toAuthor(author: string | undefined): JsonLd | undefined {
+  if (!author) return undefined
+
+  const match = author.match(/^\[([^\]]+)]\(([^)]+)\)$/)
+  if (match) return { '@type': 'Person', name: match[1], url: match[2] }
+  return { '@type': 'Person', name: author }
+}


### PR DESCRIPTION
## Motivation

Expose structured, machine-readable documentation metadata by default.

## Summary

- Add per-page TechArticle JSON-LD metadata
- Add a default-enabled `jsonLd` configuration toggle
- Document and test JSON-LD generation

## Key design considerations

- Canonical URLs are emitted only when `baseUrl` is valid
- Inline JSON is escaped to prevent script injection
- Authors, dates, and paths are included when available