### PR TITLE
fix(markdown): preserve content after nested expressions

### DIFF
--- a/.changeset/calm-pages-stay.md
+++ b/.changeset/calm-pages-stay.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Preserve content after nested MDX expressions in generated Markdown.

--- a/src/internal/llms.test.ts
+++ b/src/internal/llms.test.ts
@@ -864,6 +864,36 @@ const a = 1
     `)
   })
 
+  test('strips nested expressions without removing later content', async () => {
+    const result = await buildLlmsContent({
+      pages: [
+        {
+          path: '/agents',
+          content: `---
+title: Agents
+---
+
+<style>{\`
+  .tabs { display: flex }
+\`}</style>
+
+## Agent resources
+
+| URL | Contents |
+| --- | --- |
+| /llms.txt | Documentation index |`,
+        },
+      ],
+      title: 'My Docs',
+      ...plugins,
+    })
+
+    expect(result.results[0]?.content).not.toContain('.tabs')
+    expect(result.results[0]?.content).toContain('## Agent resources')
+    expect(result.results[0]?.content).toContain('/llms.txt')
+    expect(result.results[0]?.content).toContain('Documentation index')
+  })
+
   describe('::changelog directive', () => {
     const releases: Changelog.Release[] = [
       {

--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -1172,11 +1172,11 @@ export function remarkTerminal() {
  */
 export function remarkStripJs() {
   return (tree: MdAst.Root) => {
-    UnistUtil.visit(tree, 'mdxjsEsm', (node) => {
-      tree.children.splice(tree.children.indexOf(node), 1)
-    })
-    UnistUtil.visit(tree, 'mdxFlowExpression', (node) => {
-      tree.children.splice(tree.children.indexOf(node), 1)
+    UnistUtil.visit(tree, (node, index, parent) => {
+      if (node.type !== 'mdxjsEsm' && node.type !== 'mdxFlowExpression') return
+      if (index === undefined || !parent) return
+      parent.children.splice(index, 1)
+      return [UnistUtil.SKIP, index]
     })
   }
 }


### PR DESCRIPTION
## What changed

Generated Markdown now removes MDX imports, exports, and flow expressions from their actual parent node.

## Why

The previous transform always removed matches from the document root. For an expression nested inside an element such as `<style>`, its root index was `-1`, so the transform removed the document's final root node instead. This could silently drop valid content after the nested expression.

The regression test places a table after a nested style expression and verifies that the expression is removed while the table remains.

## Validation

- `./node_modules/.bin/vitest run ./src`
- `./node_modules/.bin/biome check .`
- `./node_modules/.bin/tsc --noEmit`
- `pnpm build`
