### PR TITLE
fix(openapi): pretty-print nested schema examples

### DIFF
--- a/.changeset/tidy-examples-flow.md
+++ b/.changeset/tidy-examples-flow.md
@@ -2,4 +2,4 @@
 "vocs": patch
 ---
 
-Pretty-print nested objects and arrays from authored OpenAPI schema values.
+Pretty-printed nested objects and arrays from authored OpenAPI schema values.

--- a/.changeset/tidy-examples-flow.md
+++ b/.changeset/tidy-examples-flow.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Pretty-print nested objects and arrays from authored OpenAPI schema values.

--- a/src/internal/openapi/sample.test.ts
+++ b/src/internal/openapi/sample.test.ts
@@ -218,6 +218,46 @@ describe('responseSamples', () => {
     expect(JSON.parse(samples[0]?.code ?? '{}')).toEqual({ id: 'abc' })
   })
 
+  test.each([
+    ['example', { example: { method: 'tempo' } }],
+    ['examples', { examples: [{ method: 'tempo' }] }],
+    ['default', { default: { method: 'tempo' } }],
+    ['enum', { enum: [{ method: 'tempo' }] }],
+  ])('pretty-prints nested objects from schema %s values', (_, authoredValue) => {
+    const samples = responseSamples({
+      ...operation,
+      responses: [
+        {
+          status: '200',
+          description: 'ok',
+          content: [
+            {
+              mediaType: 'application/json',
+              schema: {
+                type: 'object',
+                properties: {
+                  receipt: {
+                    type: 'object',
+                    ...authoredValue,
+                  },
+                },
+              },
+            },
+          ],
+          headers: [],
+        },
+      ],
+    })
+
+    expect(samples[0]?.code).toBe(`{
+  "receipt": {
+    "method": "tempo"
+  }
+}`)
+    expect(samples[0]?.placeholders).toEqual([])
+    expect(samples[0]?.linePaths[2]).toEqual(['receipt', 'method'])
+  })
+
   test('exposes a status-scoped id base for anchor resolution', () => {
     const samples = responseSamples(operation)
     expect(samples[0]?.idBase).toBe('createpet-response-200')

--- a/src/internal/openapi/sample.ts
+++ b/src/internal/openapi/sample.ts
@@ -412,16 +412,12 @@ function sampleTree(
 ): SampleNode | undefined {
   if (!schema || depth > 6) return undefined
 
-  if (schema['example'] !== undefined)
-    return { kind: 'leaf', value: schema['example'], placeholder: false }
+  if (schema['example'] !== undefined) return sampleTreeFromValue(schema['example'])
   const examples = schema['examples']
-  if (Array.isArray(examples) && examples.length > 0)
-    return { kind: 'leaf', value: examples[0], placeholder: false }
-  if (schema['default'] !== undefined)
-    return { kind: 'leaf', value: schema['default'], placeholder: false }
+  if (Array.isArray(examples) && examples.length > 0) return sampleTreeFromValue(examples[0])
+  if (schema['default'] !== undefined) return sampleTreeFromValue(schema['default'])
   const enumValues = schema['enum']
-  if (Array.isArray(enumValues) && enumValues.length > 0)
-    return { kind: 'leaf', value: enumValues[0], placeholder: false }
+  if (Array.isArray(enumValues) && enumValues.length > 0) return sampleTreeFromValue(enumValues[0])
 
   // oneOf/anyOf variant picker (matching the docs renderer): sample the first
   // variant and tag the resulting node with the variant's path segment, so its


### PR DESCRIPTION
## What changed

- Build response sample trees recursively for composite authored schema values.
- Add regression coverage for `example`, `examples`, `default`, and `enum` values.
- Add a patch changeset.

## Why

Authored schema objects and arrays were treated as scalar leaves. The response serializer therefore emitted nested examples on one long line instead of formatting them as indented JSON.

## Impact

Nested authored response values now render as multi-line JSON. Scalar examples and placeholder behavior are unchanged.

## Validation

- `pnpm exec vitest run ./src`
- `pnpm check:types`
- `pnpm exec biome check src/internal/openapi/sample.ts src/internal/openapi/sample.test.ts .changeset/tidy-examples-flow.md`
