### PR TITLE
fix(openapi): preserve page metadata

### DIFF
--- a/.changeset/fresh-ravens-share.md
+++ b/.changeset/fresh-ravens-share.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Preserved authored frontmatter metadata in OpenAPI page head tags.

--- a/src/internal/test/virtual-openapi.stub.ts
+++ b/src/internal/test/virtual-openapi.stub.ts
@@ -1,0 +1,3 @@
+import type { Ir } from '../openapi/parser.js'
+
+export const specs: Record<string, Ir> = {}

--- a/src/react/internal/openapi/OpenApiPage.test.tsx
+++ b/src/react/internal/openapi/OpenApiPage.test.tsx
@@ -1,0 +1,171 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import type * as Config from '../../../internal/config.js'
+import type { Ir } from '../../../internal/openapi/parser.js'
+import { OpenApiGuide, OpenApiPage } from './OpenApiPage.js'
+
+const mocks = vi.hoisted(() => ({
+  config: {} as Config.Config,
+  path: '/api',
+  specs: {} as Record<string, Ir>,
+}))
+
+vi.mock('waku', () => ({
+  useRouter: () => ({ path: mocks.path }),
+}))
+
+vi.mock('virtual:vocs/config', () => ({
+  get config() {
+    return mocks.config
+  },
+}))
+
+vi.mock('virtual:vocs/openapi', () => ({
+  get specs() {
+    return mocks.specs
+  },
+}))
+
+vi.mock('../../Layout.client.js', () => ({
+  Main: (props: { children: React.ReactNode }) => props.children,
+}))
+
+vi.mock('./Endpoints.js', () => ({
+  Endpoints: () => null,
+}))
+
+vi.mock('./HeadingAnchor.js', () => ({
+  HeadingAnchor: () => null,
+}))
+
+vi.mock('./Playground.client.js', () => ({
+  PlaygroundProvider: (props: { children: React.ReactNode }) => props.children,
+}))
+
+vi.mock('./Reference.js', () => ({
+  Prose: () => null,
+  ReferenceGroup: () => null,
+  ReferenceOverview: () => null,
+}))
+
+beforeEach(() => {
+  mocks.config = createConfig()
+  mocks.path = '/api'
+  mocks.specs = {
+    '/api': {
+      client: { url: 'https://example.com/openapi.json' },
+      groups: [{ id: 'payments', name: 'Payments', operations: [] }],
+      info: { title: 'Tempo API' },
+      path: '/api',
+      securitySchemes: {},
+      servers: [],
+      traits: [],
+    },
+  }
+})
+
+describe('OpenAPI page metadata', () => {
+  test('preserves custom landing page frontmatter in generated head tags', () => {
+    const html = renderToStaticMarkup(
+      <OpenApiPage
+        frontmatter={{
+          author: 'Tempo',
+          description: 'Explore the Tempo API.',
+          robots: 'noindex',
+          socialImage: 'https://example.com/api.png',
+          title: 'Tempo API Reference',
+        }}
+        intro={<p>Custom introduction</p>}
+        mount="/api"
+      />,
+    )
+
+    expect(html).toContain('name="description" content="Explore the Tempo API."')
+    expect(html).toContain('name="author" content="Tempo"')
+    expect(html).toContain('name="robots" content="noindex"')
+    expect(html).toContain('property="og:title" content="Tempo API Reference"')
+    expect(html).toContain('property="og:description" content="Explore the Tempo API."')
+    expect(html).toContain('property="og:image" content="https://example.com/api.png"')
+    expect(html).toContain('name="twitter:title" content="Tempo API Reference"')
+    expect(html).toContain('name="twitter:description" content="Explore the Tempo API."')
+  })
+
+  test('preserves authored child page frontmatter in generated head tags', () => {
+    mocks.path = '/api/authentication'
+
+    const html = renderToStaticMarkup(
+      <OpenApiGuide
+        frontmatter={{
+          description: 'Authenticate Tempo API requests.',
+          lastModified: '2026-07-28T00:00:00.000Z',
+          title: 'Authentication',
+        }}
+      >
+        <h1>Authentication</h1>
+      </OpenApiGuide>,
+    )
+
+    expect(html).toContain('name="description" content="Authenticate Tempo API requests."')
+    expect(html).toContain('property="article:modified_time"')
+    expect(html).toContain('property="og:title" content="Authentication"')
+    expect(html).toContain('property="og:description" content="Authenticate Tempo API requests."')
+    expect(html).toContain('name="twitter:title" content="Authentication"')
+    expect(html).toContain('name="twitter:description" content="Authenticate Tempo API requests."')
+  })
+
+  test('uses the generated group title for head metadata', () => {
+    mocks.path = '/api/payments'
+
+    const html = renderToStaticMarkup(<OpenApiPage group="payments" mount="/api" />)
+
+    expect(html).toContain('<title>Payments · Tempo API</title>')
+    expect(html).toContain('property="og:title" content="Payments · Tempo API"')
+    expect(html).toContain('name="twitter:title" content="Payments · Tempo API"')
+  })
+})
+
+function createConfig(): Config.Config {
+  return {
+    accentColor: 'light-dark(black, white)',
+    basePath: '/',
+    baseUrl: 'https://example.com',
+    cacheDir: '/tmp/vocs-cache',
+    checkDeadlinks: true,
+    codeHighlight: {
+      langAlias: {},
+      langs: [],
+      themes: { dark: 'github-dark-dimmed', light: 'github-light' },
+    },
+    colorScheme: 'light dark',
+    description: 'Tempo developer documentation.',
+    feedback: false,
+    head: (_path, { frontmatter }) => ({
+      meta: {
+        ogImage:
+          typeof frontmatter?.['socialImage'] === 'string' ? frontmatter['socialImage'] : undefined,
+      },
+    }),
+    jsonLd: true,
+    outDir: 'dist',
+    pagesDir: 'pages',
+    renderStrategy: 'dynamic',
+    rootDir: '/site',
+    search: {
+      boost: {},
+      boostDocument: () => 1,
+      combineWith: 'AND',
+      fuzzy: 0.2,
+      prefix: true,
+      query: {
+        boost: {},
+        combineWith: 'AND',
+        fuzzy: 0.2,
+        prefix: true,
+      },
+    },
+    srcDir: 'src',
+    title: 'Tempo',
+    titleTemplate: '%s – Tempo',
+    trailingSlashRedirect: true,
+  }
+}

--- a/src/react/internal/openapi/OpenApiPage.tsx
+++ b/src/react/internal/openapi/OpenApiPage.tsx
@@ -1,5 +1,6 @@
 import { specs } from 'virtual:vocs/openapi'
 import type { ReactNode } from 'react'
+import type { Frontmatter } from '../../../internal/config.js'
 import { Layout } from '../../Layout.js'
 import * as MdxPageContext from '../../MdxPageContext.js'
 import { Endpoints } from './Endpoints.js'
@@ -18,12 +19,17 @@ import { Prose, ReferenceGroup, ReferenceOverview } from './Reference.js'
  */
 function OpenApiLayout(props: {
   children: React.ReactNode
+  frontmatter?: Frontmatter | undefined
   outline?: boolean | undefined
   width?: 'default' | 'full'
 }) {
   return (
     <MdxPageContext.Provider
-      frontmatter={{ outline: props.outline ?? true, content: { width: props.width ?? 'full' } }}
+      frontmatter={{
+        ...props.frontmatter,
+        content: { ...props.frontmatter?.content, width: props.width ?? 'full' },
+        outline: props.outline ?? true,
+      }}
     >
       <Layout includeJsonLd={false}>{props.children}</Layout>
     </MdxPageContext.Provider>
@@ -49,17 +55,20 @@ function OpenApiLayout(props: {
  * since their title/subtitle come from the spec tag and the body has no heading.
  */
 export function OpenApiGuide(props: OpenApiGuide.Props) {
+  const title = props.title ?? props.frontmatter?.title
+  const description = props.description ?? props.frontmatter?.description
+
   return (
-    <OpenApiLayout width="full">
-      {props.title ? <title>{props.title}</title> : null}
+    <OpenApiLayout frontmatter={{ ...props.frontmatter, description, title }} width="full">
+      {title ? <title>{title}</title> : null}
       <div data-v-openapi-guide>
-        {props.header && props.title ? (
+        {props.header && title ? (
           <header data-v-openapi-header>
             <h1 data-v data-v-openapi-h1 id={props.id}>
-              {props.title}
+              {title}
               {props.id ? <HeadingAnchor id={props.id} /> : null}
             </h1>
-            {props.description ? <Prose markdown={props.description} attr="description" /> : null}
+            {description ? <Prose markdown={description} attr="description" /> : null}
           </header>
         ) : null}
         {props.children}
@@ -72,6 +81,8 @@ export declare namespace OpenApiGuide {
   type Props = {
     /** Authored MDX content. */
     children?: ReactNode | undefined
+    /** Page frontmatter forwarded to the site layout and head configuration. */
+    frontmatter?: Frontmatter | undefined
     /** Document `<title>` and page heading (from the page's frontmatter). */
     title?: string | undefined
     /** Subtitle Markdown rendered below the heading. */
@@ -107,7 +118,7 @@ export function OpenApiPage(props: OpenApiPage.Props) {
 
   if (!ir)
     return (
-      <OpenApiLayout>
+      <OpenApiLayout frontmatter={props.frontmatter}>
         <p>No OpenAPI spec is mounted at {props.mount}.</p>
       </OpenApiLayout>
     )
@@ -117,16 +128,18 @@ export function OpenApiPage(props: OpenApiPage.Props) {
     const group = ir.groups.find((candidate) => candidate.id === props.group)
     if (!group)
       return (
-        <OpenApiLayout>
+        <OpenApiLayout frontmatter={props.frontmatter}>
           <p>
             No category “{props.group}” exists in the API mounted at {props.mount}.
           </p>
         </OpenApiLayout>
       )
 
+    const title = props.title ?? props.frontmatter?.title ?? `${group.name} · ${ir.info.title}`
+
     return (
-      <OpenApiLayout outline={false}>
-        <title>{props.title ?? `${group.name} · ${ir.info.title}`}</title>
+      <OpenApiLayout frontmatter={{ ...props.frontmatter, title }} outline={false}>
+        <title>{title}</title>
         <PlaygroundProvider client={ir.client} mount={ir.path}>
           <ReferenceGroup ir={ir} group={group} intro={props.intro} />
         </PlaygroundProvider>
@@ -135,9 +148,11 @@ export function OpenApiPage(props: OpenApiPage.Props) {
   }
 
   // Overview / landing page.
+  const title = props.title ?? props.frontmatter?.title ?? ir.info.title
+
   return (
-    <OpenApiLayout width="full">
-      <title>{props.title ?? ir.info.title}</title>
+    <OpenApiLayout frontmatter={{ ...props.frontmatter, title }} width="full">
+      <title>{title}</title>
       <ReferenceOverview
         ir={ir}
         intro={props.intro}
@@ -161,6 +176,8 @@ export declare namespace OpenApiPage {
      * header (spec title/description). The generated body still renders below.
      */
     intro?: ReactNode | undefined
+    /** Page frontmatter forwarded to the site layout and head configuration. */
+    frontmatter?: Frontmatter | undefined
     /** Document `<title>` override (e.g. from the override page's frontmatter). */
     title?: string | undefined
     /**

--- a/src/waku/internal/patches/router.test.ts
+++ b/src/waku/internal/patches/router.test.ts
@@ -1,8 +1,62 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ReactElement } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Frontmatter } from '../../../internal/config.js'
 import { getApiHandlers, hasInvalidStaticApiExports } from './api-routes.js'
+import { router } from './router.js'
+
+const routerMocks = vi.hoisted(() => ({
+  callback: undefined as
+    | ((tools: {
+        createApi: ReturnType<typeof vi.fn>
+        createLayout: ReturnType<typeof vi.fn>
+        createPage: ReturnType<typeof vi.fn>
+        createRoot: ReturnType<typeof vi.fn>
+        createSlice: ReturnType<typeof vi.fn>
+      }) => Promise<unknown>)
+    | undefined,
+  config: {
+    openapi: [{ path: '/api' }],
+  },
+  specs: {
+    '/api': {
+      groups: [{ id: 'payments' }],
+    },
+  },
+}))
+
+vi.mock('waku/router/server', () => ({
+  createPages: (callback: NonNullable<typeof routerMocks.callback>) => {
+    routerMocks.callback = callback
+    return {
+      handleBuild: vi.fn(),
+      handleRequest: vi.fn(),
+    }
+  },
+}))
+
+vi.mock('virtual:vocs/config', () => ({
+  get config() {
+    return routerMocks.config
+  },
+}))
+
+vi.mock('virtual:vocs/openapi', () => ({
+  get specs() {
+    return routerMocks.specs
+  },
+}))
+
+vi.mock('../../../react/internal/openapi/OpenApiPage.js', () => ({
+  OpenApiGuide: () => null,
+  OpenApiPage: () => null,
+}))
 
 const POST = async () => new Response(null)
 const GET = async () => new Response(null)
+
+beforeEach(() => {
+  routerMocks.callback = undefined
+})
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -49,3 +103,69 @@ describe('hasInvalidStaticApiExports', () => {
     expect(hasInvalidStaticApiExports({ GET, fund })).toBe(true)
   })
 })
+
+describe('router OpenAPI metadata', () => {
+  it('forwards complete frontmatter for authored landing and child pages', async () => {
+    const landingFrontmatter = {
+      author: 'Tempo',
+      description: 'Explore the Tempo API.',
+      socialImage: 'https://example.com/api.png',
+      title: 'Tempo API Reference',
+    } satisfies Frontmatter
+    const childFrontmatter = {
+      description: 'Authenticate Tempo API requests.',
+      lastModified: '2026-07-28T00:00:00.000Z',
+      title: 'Authentication',
+    } satisfies Frontmatter
+    const Content = () => null
+
+    const pages = await createRouterPages({
+      './pages/api.mdx': async () => ({
+        default: Content,
+        frontmatter: landingFrontmatter,
+      }),
+      './pages/api/authentication.mdx': async () => ({
+        default: Content,
+        frontmatter: childFrontmatter,
+      }),
+    })
+
+    const landing = pages.find((page) => page.path === '/api')
+    const child = pages.find((page) => page.path === '/api/authentication')
+
+    expect(landing?.component().props).toMatchObject({
+      frontmatter: landingFrontmatter,
+      title: 'Tempo API Reference',
+    })
+    expect(child?.component().props).toMatchObject({
+      frontmatter: childFrontmatter,
+      title: 'Authentication',
+    })
+  })
+})
+
+async function createRouterPages(
+  modules: Record<string, () => Promise<unknown>>,
+): Promise<{ component: () => ReactElement<Record<string, unknown>>; path: string }[]> {
+  const createPage = vi.fn()
+  const Empty = () => null
+  const builtInModules = Object.fromEntries(
+    [
+      './pages/404.tsx',
+      './pages/_api/api/feedback.tsx',
+      './pages/_api/api/mcp.tsx',
+      './pages/_api/api/og.tsx',
+      './pages/_api/api/search.tsx',
+      './pages/_root.tsx',
+    ].map((file) => [file, async () => ({ default: Empty })]),
+  )
+  router({ ...builtInModules, ...modules })
+  await routerMocks.callback?.({
+    createApi: vi.fn(),
+    createLayout: vi.fn(),
+    createPage,
+    createRoot: vi.fn(),
+    createSlice: vi.fn(),
+  })
+  return createPage.mock.calls.map(([page]) => page)
+}

--- a/src/waku/internal/patches/router.ts
+++ b/src/waku/internal/patches/router.ts
@@ -1,5 +1,6 @@
 import { createElement, type FunctionComponent, lazy, type ReactNode } from 'react'
 import { createPages } from 'waku/router/server'
+import type { Frontmatter } from '../../../internal/config.js'
 import * as DedupeHead from '../dedupe-head.js'
 import {
   type ApiHandler,
@@ -319,7 +320,7 @@ export function router(
           )
 
           // Resolves a consumer "override" page mounted at `routePath` into the
-          // props (`intro` content + frontmatter `title`) layered onto the
+          // props (`intro` content + frontmatter) layered onto the
           // generated `OpenApiPage`. Returns empty props when there is no
           // override. Uses the MDX `default` export (raw content) — not `Page` —
           // so the override is not wrapped in its own Layout.
@@ -328,11 +329,15 @@ export function router(
             if (!importFn) return {}
             const mod = (await importFn()) as {
               default?: FunctionComponent
-              frontmatter?: { title?: string }
+              frontmatter?: Frontmatter
             }
             if (!mod.default) return {}
             const Content = mod.default
-            return { intro: createElement(Content), title: mod.frontmatter?.title }
+            return {
+              frontmatter: mod.frontmatter,
+              intro: createElement(Content),
+              title: mod.frontmatter?.title,
+            }
           }
 
           for (const entry of config.openapi) {
@@ -370,14 +375,19 @@ export function router(
               if (openapiRoutePaths.has(routePath)) continue
               const mod = (await importFn()) as {
                 default?: FunctionComponent
-                frontmatter?: { title?: string }
+                frontmatter?: Frontmatter
               }
               if (!mod.default) continue
               const Content = mod.default
               const title = mod.frontmatter?.title
               createPage({
                 path: routePath,
-                component: () => createElement(OpenApiGuide, { title }, createElement(Content)),
+                component: () =>
+                  createElement(
+                    OpenApiGuide,
+                    { frontmatter: mod.frontmatter, title },
+                    createElement(Content),
+                  ),
                 render: 'static',
               } as never)
             }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -27,6 +27,10 @@ export default defineConfig({
         import.meta.dirname,
         'src/internal/test/virtual-config.stub.ts',
       ),
+      'virtual:vocs/openapi': path.resolve(
+        import.meta.dirname,
+        'src/internal/test/virtual-openapi.stub.ts',
+      ),
     },
     include: ['./src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     globals: true,


### PR DESCRIPTION
Preserve authored frontmatter through OpenAPI route composition and layouts so page-specific descriptions and social metadata reach generated head tags while generated OpenAPI titles remain unchanged.