### PR TITLE
fix: vary html and markdown responses

### DIFF
--- a/.changeset/calm-caches-vary.md
+++ b/.changeset/calm-caches-vary.md
@@ -1,0 +1,5 @@
+---
+'vocs': patch
+---
+
+Added `Vary: Accept, User-Agent` to HTML and Markdown responses so shared caches keep negotiated representations separate.

--- a/src/internal/markdown-negotiation.ts
+++ b/src/internal/markdown-negotiation.ts
@@ -44,6 +44,9 @@ export const searchEngineUserAgents = [
 /** Terminal HTTP clients that should receive Markdown. */
 export const terminalUserAgents = ['curl/', 'Wget/', 'HTTPie/', 'httpie-go/', 'xh/']
 
+/** Request headers that select between HTML and Markdown representations. */
+export const representationVary = 'Accept, User-Agent'
+
 /** Link-preview/Open Graph bots that must always receive HTML (for meta tags). */
 export const ogBotUserAgents = [
   'Discordbot',

--- a/src/server/openapi/handler.test.ts
+++ b/src/server/openapi/handler.test.ts
@@ -232,6 +232,47 @@ describe('Handler.openApi', () => {
       expect(response.headers.get('content-type') ?? '').not.toContain('text/markdown')
     })
 
+    test('varies cached HTML and Markdown representations by accept and user-agent', async () => {
+      const ref = openApi({ spec, path: '/api' })
+      const responses = [
+        await ref.fetch(
+          new Request('http://localhost/api', {
+            headers: {
+              accept: 'text/html',
+              'user-agent': 'Mozilla/5.0 AppleWebKit/537.36 Chrome/126 Safari/537.36',
+            },
+          }),
+        ),
+        await ref.fetch(
+          new Request('http://localhost/api', {
+            headers: { accept: 'text/html', 'user-agent': 'curl/8.7.1' },
+          }),
+        ),
+        await ref.fetch(
+          new Request('http://localhost/api', {
+            headers: { accept: 'text/html', 'user-agent': 'Googlebot/2.1' },
+          }),
+        ),
+        await ref.fetch(
+          new Request('http://localhost/api', {
+            headers: {
+              accept: 'text/markdown',
+              'user-agent': 'Mozilla/5.0 AppleWebKit/537.36 Chrome/126 Safari/537.36',
+            },
+          }),
+        ),
+      ]
+
+      expect(responses.map((response) => response.headers.get('content-type'))).toEqual([
+        'text/html; charset=UTF-8',
+        'text/markdown; charset=utf-8',
+        'text/html; charset=UTF-8',
+        'text/markdown; charset=utf-8',
+      ])
+      for (const response of responses)
+        expect(response.headers.get('vary')).toBe('Accept, User-Agent')
+    })
+
     test('prefixes overview links with the live host mount', async () => {
       const app = new Hono().basePath('/docs')
       app.route('/', openApi({ spec, path: '/api' }, { fallback: 'next' }))

--- a/src/server/openapi/handler.ts
+++ b/src/server/openapi/handler.ts
@@ -1,6 +1,6 @@
 import { getRequestListener } from '@hono/node-server'
 import { Hono } from 'hono'
-import { prefersMarkdown } from '../../internal/markdown-negotiation.js'
+import { prefersMarkdown, representationVary } from '../../internal/markdown-negotiation.js'
 import type { Payload } from '../../internal/openapi/app.js'
 import { inferMount, join, knownRoutes } from '../../internal/openapi/app.js'
 import * as Markdown from '../../internal/openapi/markdown.js'
@@ -98,7 +98,11 @@ export function openApi(config: OpenApi.Config, options: openApi.Options = {}): 
           ? mountFromRoutePath(c.req.routePath)
           : inferMount(basePathname, routes)
       const markdown = resolveMarkdown(payload, relativeRoute(basePathname, mount), mount)
-      if (markdown) return c.text(markdown, 200, { 'content-type': 'text/markdown; charset=utf-8' })
+      if (markdown)
+        return c.text(markdown, 200, {
+          'content-type': 'text/markdown; charset=utf-8',
+          vary: representationVary,
+        })
       // Explicit `.md` for an unknown route falls through to the normal handling
       // below (renders the shell, or `next()` in fallback mode).
     }
@@ -116,6 +120,8 @@ export function openApi(config: OpenApi.Config, options: openApi.Options = {}): 
       const relative = (pathname.startsWith(mount) ? pathname.slice(mount.length) : pathname) || '/'
       if (!isKnownRoute(relative, routes)) return next()
     }
+
+    c.header('Vary', representationVary)
 
     // Otherwise render the HTML shell (client-side router takes over).
     const manifest = Assets.manifest()

--- a/src/waku/internal/middleware/md-router.test.ts
+++ b/src/waku/internal/middleware/md-router.test.ts
@@ -143,6 +143,41 @@ describe('middleware', () => {
     expect(readFile).toHaveBeenCalledOnce()
   })
 
+  it('varies cached HTML and Markdown representations by accept and user-agent', async () => {
+    process.env['NODE_ENV'] = 'production'
+
+    const { readFile } = await import('node:fs/promises')
+    vi.mocked(readFile).mockResolvedValue('# Hello from disk')
+
+    const responses = [
+      await request('http://localhost/docs', {
+        accept: 'text/html',
+        'user-agent': 'Mozilla/5.0 AppleWebKit/537.36 Chrome/126 Safari/537.36',
+      }),
+      await request('http://localhost/docs', {
+        accept: 'text/html',
+        'user-agent': 'curl/8.7.1',
+      }),
+      await request('http://localhost/docs', {
+        accept: 'text/html',
+        'user-agent': 'Googlebot/2.1',
+      }),
+      await request('http://localhost/docs', {
+        accept: 'text/markdown',
+        'user-agent': 'Mozilla/5.0 AppleWebKit/537.36 Chrome/126 Safari/537.36',
+      }),
+    ]
+
+    expect(responses.map((response) => response.headers.get('content-type'))).toEqual([
+      'text/html; charset=UTF-8',
+      'text/markdown; charset=utf-8',
+      'text/html; charset=UTF-8',
+      'text/markdown; charset=utf-8',
+    ])
+    for (const response of responses)
+      expect(response.headers.get('vary')).toBe('Accept, User-Agent')
+  })
+
   it('passes static assets through for AI agents without resolving a twin', async () => {
     process.env['NODE_ENV'] = 'production'
 

--- a/src/waku/internal/middleware/md-router.ts
+++ b/src/waku/internal/middleware/md-router.ts
@@ -2,6 +2,7 @@ import type { MiddlewareHandler } from 'hono'
 import {
   aiUserAgents,
   ogBotUserAgents,
+  representationVary,
   searchEngineUserAgents,
   terminalUserAgents,
 } from '../../../internal/markdown-negotiation.js'
@@ -84,9 +85,25 @@ export function middleware(): MiddlewareHandler {
     // twin resolution would trigger a recursive self-fetch.
     if (url.pathname.startsWith('/assets/md/')) return next()
 
+    const isMarkdownRequest = url.pathname.endsWith('.md')
+
+    // A file physically present in `public/` wins over markdown-twin resolution,
+    // so static `.md` files (skill manifests, plain markdown) are served as-is.
+    if (isMarkdownRequest && (await hasPublicFile(url.pathname))) return next()
+
+    // Static assets (`.json`, `.svg`, `.png`, ...) have no markdown twin. Skip
+    // twin resolution so a disk miss never falls back to a slow self-fetch.
+    const filename = url.pathname.split('/').pop() ?? ''
+    if (!isMarkdownRequest && filename.includes('.')) return next()
+
+    const nextWithVary = async () => {
+      await next()
+      context.header('Vary', representationVary, { append: true })
+    }
+
     const userAgent = context.req.header('user-agent') ?? ''
     const isOgBot = ogBotUserAgents.some((agent) => userAgent.includes(agent))
-    if (isOgBot) return next()
+    if (isOgBot) return nextWithVary()
 
     const isAiAgent = aiUserAgents.some((agent) => userAgent.includes(agent))
     const isSearchEngine = searchEngineUserAgents.some((agent) => userAgent.includes(agent))
@@ -102,29 +119,19 @@ export function middleware(): MiddlewareHandler {
       } else {
         text = await fetchMarkdown(url, '/llms.txt', context.req.header('cookie'))
       }
-      if (!text) return next()
+      if (!text) return nextWithVary()
 
       context.res = new Response(text, {
         headers: {
           'Content-Type': 'text/markdown; charset=utf-8',
+          Vary: representationVary,
         },
       })
       return
     }
 
-    const isMarkdownRequest = url.pathname.endsWith('.md')
-
-    // A file physically present in `public/` wins over markdown-twin resolution,
-    // so static `.md` files (skill manifests, plain markdown) are served as-is.
-    if (isMarkdownRequest && (await hasPublicFile(url.pathname))) return next()
-
-    // Static assets (`.json`, `.svg`, `.png`, ...) have no markdown twin. Skip
-    // twin resolution so a disk miss never falls back to a slow self-fetch.
-    const filename = url.pathname.split('/').pop() ?? ''
-    if (!isMarkdownRequest && filename.includes('.')) return next()
-
     if (!isMarkdownRequest && (isSearchEngine || (!isAiAgent && !isTerminal && !acceptsMarkdown)))
-      return next()
+      return nextWithVary()
 
     const pagePath = url.pathname.replace(/\.md$/, '').replace(/\/index$/, '')
 
@@ -141,11 +148,12 @@ export function middleware(): MiddlewareHandler {
         : `/assets/md${url.pathname}.md`
       text = await fetchMarkdown(url, assetPath, context.req.header('cookie'))
     }
-    if (!text) return next()
+    if (!text) return nextWithVary()
 
     context.res = new Response(text, {
       headers: {
         'Content-Type': 'text/markdown; charset=utf-8',
+        Vary: representationVary,
       },
     })
     return

--- a/src/waku/internal/patches/adapters/vercel-build-enhancer.test.ts
+++ b/src/waku/internal/patches/adapters/vercel-build-enhancer.test.ts
@@ -101,6 +101,13 @@ describe('vercel build enhancer', () => {
           "src": "^/assets/(.*)$",
         },
         {
+          "continue": true,
+          "headers": {
+            "vary": "Accept, User-Agent",
+          },
+          "src": "^/(?!assets/)(?!.*\\.[^/]+$)(.*)$",
+        },
+        {
           "dest": "/RSC/",
           "has": [
             {

--- a/src/waku/internal/patches/adapters/vercel-build-enhancer.ts
+++ b/src/waku/internal/patches/adapters/vercel-build-enhancer.ts
@@ -1,7 +1,11 @@
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import { gzipSync } from 'node:zlib'
-import { aiUserAgents, terminalUserAgents } from '../../../../internal/markdown-negotiation.js'
+import {
+  aiUserAgents,
+  representationVary,
+  terminalUserAgents,
+} from '../../../../internal/markdown-negotiation.js'
 
 export type BuildOptions = {
   assetsDir: string
@@ -61,6 +65,15 @@ function markdownRoutes({
     .join('|')}).*`
 
   return {
+    // Apply Vary before the filesystem handler so prerendered HTML and routed
+    // Markdown use the same cache key.
+    headers: [
+      {
+        src: cleanPageSource,
+        headers: { vary: representationVary },
+        continue: true,
+      },
+    ],
     // Vercel's filesystem handler would serve prerendered HTML before mdRouter sees
     // the request. Route markdown-eligible clean URLs to RSC first so mdRouter can
     // choose markdown or HTML.
@@ -160,6 +173,7 @@ export default getRequestListener(
     },
     ...(serverless
       ? [
+          ...markdown.headers,
           ...markdown.beforeFilesystem,
           { handle: 'filesystem' },
           ...markdown.afterFilesystem,


### PR DESCRIPTION
Add `Vary: Accept, User-Agent` to HTML and Markdown representations, including prerendered Vercel pages, so shared caches cannot reuse browser, crawler, and terminal responses across clients.