### PR TITLE
fix: use openapi tag descriptions in metadata

### DIFF
--- a/.changeset/tidy-zebras-describe.md
+++ b/.changeset/tidy-zebras-describe.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Used OpenAPI tag descriptions for generated group page metadata.

--- a/src/react/internal/openapi/OpenApiPage.test.tsx
+++ b/src/react/internal/openapi/OpenApiPage.test.tsx
@@ -54,7 +54,14 @@ beforeEach(() => {
   mocks.specs = {
     '/api': {
       client: { url: 'https://example.com/openapi.json' },
-      groups: [{ id: 'payments', name: 'Payments', operations: [] }],
+      groups: [
+        {
+          description: 'Send and track payments through the API.',
+          id: 'payments',
+          name: 'Payments',
+          operations: [],
+        },
+      ],
       info: { title: 'Tempo API' },
       path: '/api',
       securitySchemes: {},
@@ -113,14 +120,21 @@ describe('OpenAPI page metadata', () => {
     expect(html).toContain('name="twitter:description" content="Authenticate Tempo API requests."')
   })
 
-  test('uses the generated group title for head metadata', () => {
+  test('uses the generated group metadata in head tags', () => {
     mocks.path = '/api/payments'
 
     const html = renderToStaticMarkup(<OpenApiPage group="payments" mount="/api" />)
 
     expect(html).toContain('<title>Payments · Tempo API</title>')
+    expect(html).toContain('name="description" content="Send and track payments through the API."')
     expect(html).toContain('property="og:title" content="Payments · Tempo API"')
+    expect(html).toContain(
+      'property="og:description" content="Send and track payments through the API."',
+    )
     expect(html).toContain('name="twitter:title" content="Payments · Tempo API"')
+    expect(html).toContain(
+      'name="twitter:description" content="Send and track payments through the API."',
+    )
   })
 })
 

--- a/src/react/internal/openapi/OpenApiPage.tsx
+++ b/src/react/internal/openapi/OpenApiPage.tsx
@@ -135,10 +135,11 @@ export function OpenApiPage(props: OpenApiPage.Props) {
         </OpenApiLayout>
       )
 
+    const description = props.frontmatter?.description ?? group.description
     const title = props.title ?? props.frontmatter?.title ?? `${group.name} · ${ir.info.title}`
 
     return (
-      <OpenApiLayout frontmatter={{ ...props.frontmatter, title }} outline={false}>
+      <OpenApiLayout frontmatter={{ ...props.frontmatter, description, title }} outline={false}>
         <title>{title}</title>
         <PlaygroundProvider mount={ir.path}>
           <ReferenceGroup ir={ir} group={group} intro={props.intro} />


### PR DESCRIPTION
Uses OpenAPI tag descriptions for generated group page metadata while preserving authored frontmatter overrides. Generated group pages previously fell back to the site-wide description because Vocs only forwarded their titles.