### PR TITLE
fix(openapi): split schema model payloads

### DIFF
--- a/.changeset/quiet-schema-models.md
+++ b/.changeset/quiet-schema-models.md
@@ -1,0 +1,5 @@
+---
+'vocs': patch
+---
+
+Moved generated OpenAPI schema models into category-specific client chunks to reduce inline route payloads.

--- a/scripts/build-openapi-standalone.ts
+++ b/scripts/build-openapi-standalone.ts
@@ -43,6 +43,7 @@ function virtualModulesPlugin(): Plugin {
     'virtual:vocs/langs': path.resolve(appDir, 'virtual/langs.ts'),
     'virtual:vocs/openapi': path.resolve(appDir, 'virtual/openapi.ts'),
     'virtual:vocs/openapi-client': path.resolve(appDir, 'virtual/openapi-client.ts'),
+    'virtual:vocs/openapi-schema-models': path.resolve(appDir, 'virtual/openapi-schema-models.ts'),
     'virtual:vocs/search-index': path.resolve(appDir, 'virtual/search-index.ts'),
     'virtual:vocs/slots': path.resolve(appDir, 'virtual/slots.ts'),
     'virtual:vocs/user-styles': path.resolve(appDir, 'virtual/user-styles.ts'),

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -31,6 +31,13 @@ declare module 'virtual:vocs/openapi-client' {
   >
 }
 
+declare module 'virtual:vocs/openapi-schema-models' {
+  export const schemaModelDocuments: Record<
+    string,
+    () => Promise<Record<string, import('./internal/openapi/schema-model.js').SchemaModel>>
+  >
+}
+
 declare module 'virtual:vocs/search-index' {
   export function getSearchIndex(): Promise<string>
 }

--- a/src/internal/openapi/schema-model.ts
+++ b/src/internal/openapi/schema-model.ts
@@ -1,0 +1,294 @@
+import * as Markdown from '../markdown.js'
+import type { IrGroup, IrMediaType, IrOperation, IrParameter } from './parser.js'
+import { unionVariantSchemas, unwrapSingleVariant } from './union.js'
+
+type SchemaObject = Record<string, unknown>
+
+const maxDepth = 6
+
+/** Renders a human-readable type label for a JSON Schema (post-dereference). */
+export function typeLabel(schema: SchemaObject | undefined): string {
+  if (!schema) return 'unknown'
+
+  if (Array.isArray(schema['type'])) return (schema['type'] as string[]).join(' | ')
+
+  const composite = (schema['oneOf'] ?? schema['anyOf']) as SchemaObject[] | undefined
+  if (composite) return composite.map(typeLabel).join(' | ')
+
+  if (Array.isArray(schema['allOf']))
+    return (schema['allOf'] as SchemaObject[]).map(typeLabel).join(' & ')
+
+  if (schema['type'] === 'array') return `${typeLabel(schema['items'] as SchemaObject)}[]`
+
+  if (typeof schema['type'] === 'string') {
+    const format = schema['format'] ? ` <${schema['format']}>` : ''
+    return `${schema['type']}${format}`
+  }
+
+  if (Array.isArray(schema['enum'])) return 'enum'
+  if (schema['properties']) return 'object'
+  return 'unknown'
+}
+
+/**
+ * Detects a `oneOf`/`anyOf` union worth showing as a variant picker.
+ */
+export function unionVariants(schema: SchemaObject | undefined): unionVariants.Result | undefined {
+  const variants = unionVariantSchemas(schema)
+  if (!variants) return undefined
+  const target =
+    schema?.['type'] === 'array' && schema['items'] ? (schema['items'] as SchemaObject) : schema
+  const oneOf = target?.['oneOf']
+  return {
+    kind: oneOf ? 'One of' : 'Any of',
+    variants: variants.map((member, index) => ({
+      name: variantName(member, index),
+      schema: member,
+    })),
+  }
+}
+
+export declare namespace unionVariants {
+  type Result = {
+    kind: string
+    variants: { name: string; schema: SchemaObject }[]
+  }
+}
+
+function variantName(member: SchemaObject, index: number): string {
+  if (typeof member['title'] === 'string' && member['title']) return member['title']
+  if ('const' in member) return stringify(member['const'])
+  const values = enumValues(member)
+  if (values && values.length > 0) {
+    const joined = values.join(' | ')
+    if (joined.length <= 32) return joined
+    return 'enum'
+  }
+  return typeLabel(member) || `Option ${index + 1}`
+}
+
+/** Extracts a schema's enum literals as display strings. */
+export function enumValues(schema: SchemaObject | undefined): string[] | undefined {
+  if (!schema) return undefined
+  const target =
+    schema['type'] === 'array' && schema['items'] ? (schema['items'] as SchemaObject) : schema
+  const values = target['enum']
+  if (!Array.isArray(values) || values.length === 0) return undefined
+  return values.map((value) => (typeof value === 'string' ? value : JSON.stringify(value)))
+}
+
+/** Builds the constraint metadata shown beneath a property or parameter type. */
+export function schemaMeta(schema: SchemaObject | undefined): schemaMeta.Entry[] {
+  if (!schema) return []
+  const parts: schemaMeta.Entry[] = []
+
+  const num = (key: string) =>
+    typeof schema[key] === 'number' ? (schema[key] as number) : undefined
+  const min = num('minimum') ?? num('minLength') ?? num('minItems')
+  const max = num('maximum') ?? num('maxLength') ?? num('maxItems')
+  if (min !== undefined) parts.push({ label: 'min', value: String(min) })
+  if (max !== undefined) parts.push({ label: 'max', value: String(max) })
+
+  if ('const' in schema) parts.push({ label: 'const', value: stringify(schema['const']) })
+  if ('default' in schema) parts.push({ label: 'default', value: stringify(schema['default']) })
+
+  return parts
+}
+
+export declare namespace schemaMeta {
+  type Entry = { label: string; value: string }
+}
+
+function stringify(value: unknown): string {
+  if (typeof value === 'string') return value
+  return JSON.stringify(value)
+}
+
+export function formatExample(value: unknown): string {
+  if (typeof value === 'string') return value
+  return JSON.stringify(value, null, 2)
+}
+
+/** Extracts a representative example value from a schema. */
+export function schemaExample(schema: SchemaObject | undefined): string | undefined {
+  if (!schema) return undefined
+  if ('example' in schema) return formatExample(schema['example'])
+  const examples = schema['examples']
+  if (Array.isArray(examples) && examples.length > 0) return formatExample(examples[0])
+  return undefined
+}
+
+export type SchemaModel =
+  | {
+      view: 'properties'
+      properties: SchemaPropertyModel[]
+    }
+  | {
+      view: 'union'
+      label: string
+      variants: SchemaVariantModel[]
+    }
+
+export type SchemaPropertyModel = {
+  name: string
+  type?: string | undefined
+  values?: string[] | undefined
+  meta: schemaMeta.Entry[]
+  example?: string | undefined
+  required?: boolean | undefined
+  deprecated?: boolean | undefined
+  descriptionHtml?: string | undefined
+  child?: SchemaModel | undefined
+  array?: boolean | undefined
+}
+
+export type SchemaVariantModel = {
+  name: string
+  type?: string | undefined
+  values?: string[] | undefined
+  meta: schemaMeta.Entry[]
+  descriptionHtml?: string | undefined
+  child?: SchemaModel | undefined
+}
+
+/** Projects a dereferenced JSON Schema into the compact interactive display model. */
+export function toSchemaModel(
+  rawSchema: SchemaObject | undefined,
+  depth: number,
+): SchemaModel | undefined {
+  if (!rawSchema || depth > maxDepth) return undefined
+
+  const schema = unwrapSingleVariant(rawSchema) ?? rawSchema
+  const union = unionVariants(schema)
+  if (union) return toUnionModel(union, depth)
+
+  if (schema['type'] === 'array' && schema['items'])
+    return toSchemaModel(schema['items'] as SchemaObject, depth)
+
+  const allOf = schema['allOf'] as SchemaObject[] | undefined
+  const properties = (schema['properties'] ??
+    allOf?.reduce<Record<string, SchemaObject>>((acc, member) => {
+      Object.assign(acc, (member['properties'] as Record<string, SchemaObject>) ?? {})
+      return acc
+    }, {})) as Record<string, SchemaObject> | undefined
+  if (!properties || Object.keys(properties).length === 0) return undefined
+
+  const required = new Set((schema['required'] as string[] | undefined) ?? [])
+  return {
+    view: 'properties',
+    properties: Object.entries(properties).map(([name, rawProperty]) => {
+      const property = unwrapSingleVariant(rawProperty) ?? rawProperty
+      const propertyUnion = unionVariants(property)
+      return {
+        name,
+        type: propertyUnion ? undefined : typeLabel(property),
+        values: propertyUnion ? undefined : enumValues(property),
+        meta: propertyUnion ? [] : schemaMeta(property),
+        example: propertyUnion ? undefined : schemaExample(property),
+        required: required.has(name),
+        deprecated: property['deprecated'] === true,
+        descriptionHtml:
+          typeof property['description'] === 'string'
+            ? Markdown.toHtml(property['description'] as string)
+            : undefined,
+        child:
+          depth >= maxDepth
+            ? undefined
+            : propertyUnion
+              ? toUnionModel(propertyUnion, depth + 1)
+              : hasChildren(property)
+                ? toSchemaModel(property, depth + 1)
+                : undefined,
+        array: property['type'] === 'array',
+      }
+    }),
+  }
+}
+
+export function toUnionModel(union: unionVariants.Result, depth: number): SchemaModel {
+  return {
+    view: 'union',
+    label: union.kind,
+    variants: union.variants.map((variant) => {
+      const { schema } = variant
+      const items = (schema['type'] === 'array' ? schema['items'] : undefined) as
+        | SchemaObject
+        | undefined
+      const objectish = Boolean(
+        schema['properties'] || schema['allOf'] || items?.['properties'] || items?.['allOf'],
+      )
+      return {
+        name: variant.name,
+        type: objectish ? undefined : typeLabel(schema),
+        values: objectish ? undefined : enumValues(schema),
+        meta: objectish ? [] : schemaMeta(schema),
+        descriptionHtml:
+          typeof schema['description'] === 'string'
+            ? Markdown.toHtml(schema['description'] as string)
+            : undefined,
+        child: objectish ? toSchemaModel(schema, depth) : undefined,
+      }
+    }),
+  }
+}
+
+/** Stable key for the code-split schema-model document for one OpenAPI category. */
+export function schemaModelSource(mount: string, groupId: string): string {
+  return JSON.stringify([mount, groupId])
+}
+
+export function parameterSchemaModelId(
+  operationId: string,
+  parameter: Pick<IrParameter, 'in' | 'name'>,
+): string {
+  return JSON.stringify(['parameter', operationId, parameter.in, parameter.name])
+}
+
+export function requestSchemaModelId(operationId: string, media: Pick<IrMediaType, 'mediaType'>) {
+  return JSON.stringify(['request', operationId, media.mediaType])
+}
+
+export function responseSchemaModelId(
+  operationId: string,
+  status: string,
+  media: Pick<IrMediaType, 'mediaType'>,
+) {
+  return JSON.stringify(['response', operationId, status, media.mediaType])
+}
+
+/** Builds every schema model referenced by a generated OpenAPI category page. */
+export function schemaModels(group: IrGroup): Record<string, SchemaModel> {
+  const models: Record<string, SchemaModel> = {}
+  const add = (id: string, schema: SchemaObject | undefined, depth: number) => {
+    const model = toSchemaModel(schema, depth)
+    if (model) models[id] = model
+  }
+
+  for (const operation of group.operations) {
+    for (const parameter of operation.parameters)
+      add(parameterSchemaModelId(operation.id, parameter), parameter.schema, 1)
+
+    for (const media of operation.requestBody?.content ?? [])
+      add(requestSchemaModelId(operation.id, media), media.schema, 0)
+
+    addResponseModels(models, operation)
+  }
+  return models
+}
+
+function addResponseModels(models: Record<string, SchemaModel>, operation: IrOperation): void {
+  for (const response of operation.responses) {
+    for (const media of response.content) {
+      const model = toSchemaModel(media.schema, 0)
+      if (model) models[responseSchemaModelId(operation.id, response.status, media)] = model
+    }
+  }
+}
+
+function hasChildren(schema: SchemaObject): boolean {
+  if (schema['properties']) return true
+  if (schema['allOf']) return true
+  if (schema['type'] === 'array' && schema['items'])
+    return hasChildren(schema['items'] as SchemaObject)
+  return false
+}

--- a/src/internal/test/virtual-openapi-schema-models.stub.ts
+++ b/src/internal/test/virtual-openapi-schema-models.stub.ts
@@ -1,0 +1,3 @@
+import type { SchemaModel } from '../openapi/schema-model.js'
+
+export const schemaModelDocuments: Record<string, () => Promise<Record<string, SchemaModel>>> = {}

--- a/src/internal/vite-plugins.test.ts
+++ b/src/internal/vite-plugins.test.ts
@@ -8,6 +8,8 @@ import type * as OpenApi from './openapi/index.js'
 import {
   openapiClientDocument,
   openapiClientManifest,
+  openapiSchemaModelsDocument,
+  openapiSchemaModelsManifest,
   resolveSitemapInclude,
   resolveSitemapLastmod,
   sitemap,
@@ -40,6 +42,79 @@ describe('openapi client modules', () => {
 
     expect(document).toContain('first-client')
     expect(document).not.toContain('second-client')
+  })
+})
+
+describe('openapi schema model modules', () => {
+  const specs = {
+    '/first': {
+      path: '/first',
+      groups: [
+        {
+          id: 'pets',
+          operations: [
+            {
+              id: 'createpet',
+              parameters: [],
+              requestBody: {
+                content: [
+                  {
+                    mediaType: 'application/json',
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        firstMarker: { type: 'string', description: 'first schema detail' },
+                      },
+                    },
+                  },
+                ],
+              },
+              responses: [],
+            },
+          ],
+        },
+        {
+          id: 'owners',
+          operations: [
+            {
+              id: 'createowner',
+              parameters: [],
+              requestBody: {
+                content: [
+                  {
+                    mediaType: 'application/json',
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        secondMarker: { type: 'string', description: 'second schema detail' },
+                      },
+                    },
+                  },
+                ],
+              },
+              responses: [],
+            },
+          ],
+        },
+      ],
+    },
+  } as unknown as Record<string, OpenApi.Ir>
+
+  test('creates one lazy document import per category without inlining models', () => {
+    const manifest = openapiSchemaModelsManifest(specs)
+
+    expect(manifest).toContain('virtual:vocs/openapi-schema-models:')
+    expect(manifest).toContain('pets')
+    expect(manifest).toContain('owners')
+    expect(manifest).not.toContain('schema detail')
+  })
+
+  test('serializes only the requested category models', () => {
+    const source = JSON.stringify(['/first', 'pets'])
+    const document = openapiSchemaModelsDocument(specs, source)
+
+    expect(document).toContain('first schema detail')
+    expect(document).not.toContain('second schema detail')
   })
 })
 

--- a/src/internal/vite-plugins.ts
+++ b/src/internal/vite-plugins.ts
@@ -15,6 +15,7 @@ import * as Llms from './llms.js'
 import * as Mdx from './mdx.js'
 import type * as OpenApi from './openapi/index.js'
 import * as OpenApiRegistry from './openapi/registry.js'
+import { type SchemaModel, schemaModelSource, schemaModels } from './openapi/schema-model.js'
 import * as Retriever from './retriever.js'
 import { SearchDocuments, SearchIndex } from './search.js'
 import * as ShikiTransformers from './shiki-transformers.js'
@@ -1355,6 +1356,10 @@ const openapiClientVirtualModuleId = 'virtual:vocs/openapi-client'
 const resolvedOpenapiClientVirtualModuleId = `\0${openapiClientVirtualModuleId}`
 const openapiClientDocumentPrefix = `${openapiClientVirtualModuleId}:`
 const resolvedOpenapiClientDocumentPrefix = `\0${openapiClientDocumentPrefix}`
+const openapiSchemaModelsVirtualModuleId = 'virtual:vocs/openapi-schema-models'
+const resolvedOpenapiSchemaModelsVirtualModuleId = `\0${openapiSchemaModelsVirtualModuleId}`
+const openapiSchemaModelsDocumentPrefix = `${openapiSchemaModelsVirtualModuleId}:`
+const resolvedOpenapiSchemaModelsDocumentPrefix = `\0${openapiSchemaModelsDocumentPrefix}`
 
 function openapiClientDocumentId(mount: string): string {
   return `${openapiClientDocumentPrefix}${encodeURIComponent(mount)}`
@@ -1367,6 +1372,19 @@ function resolvedOpenapiClientDocumentId(mount: string): string {
 function openapiClientMount(id: string): string | undefined {
   if (!id.startsWith(resolvedOpenapiClientDocumentPrefix)) return undefined
   return decodeURIComponent(id.slice(resolvedOpenapiClientDocumentPrefix.length))
+}
+
+function openapiSchemaModelsDocumentId(source: string): string {
+  return `${openapiSchemaModelsDocumentPrefix}${encodeURIComponent(source)}`
+}
+
+function resolvedOpenapiSchemaModelsDocumentId(source: string): string {
+  return `\0${openapiSchemaModelsDocumentId(source)}`
+}
+
+function openapiSchemaModelsSource(id: string): string | undefined {
+  if (!id.startsWith(resolvedOpenapiSchemaModelsDocumentPrefix)) return undefined
+  return decodeURIComponent(id.slice(resolvedOpenapiSchemaModelsDocumentPrefix.length))
 }
 
 export function openapiClientManifest(specs: Record<string, OpenApi.Ir>): string {
@@ -1384,6 +1402,35 @@ export function openapiClientDocument(
   const client = specs[mount]?.client
   if (!client) return undefined
   return `export const client = ${JSON.stringify(client)}`
+}
+
+export function openapiSchemaModelsManifest(specs: Record<string, OpenApi.Ir>): string {
+  const entries = Object.values(specs).flatMap((ir) =>
+    ir.groups.map((group) => {
+      const source = schemaModelSource(ir.path, group.id)
+      return `${JSON.stringify(source)}: () => import(${JSON.stringify(openapiSchemaModelsDocumentId(source))}).then((module) => module.models)`
+    }),
+  )
+  return `export const schemaModelDocuments = {\n${entries.join(',\n')}\n}`
+}
+
+export function openapiSchemaModelsDocument(
+  specs: Record<string, OpenApi.Ir>,
+  source: string,
+): string | undefined {
+  for (const ir of Object.values(specs)) {
+    const group = ir.groups.find((candidate) => schemaModelSource(ir.path, candidate.id) === source)
+    if (!group) continue
+    const models: Record<string, SchemaModel> = schemaModels(group)
+    return `export const models = ${JSON.stringify(models)}`
+  }
+  return undefined
+}
+
+function openapiSchemaModelSources(specs: Record<string, OpenApi.Ir>): string[] {
+  return Object.values(specs).flatMap((ir) =>
+    ir.groups.map((group) => schemaModelSource(ir.path, group.id)),
+  )
 }
 
 export function openapi(config: Config.Config): PluginOption {
@@ -1416,7 +1463,10 @@ export function openapi(config: Config.Config): PluginOption {
     resolveId(id) {
       if (id === openapiVirtualModuleId) return resolvedOpenapiVirtualModuleId
       if (id === openapiClientVirtualModuleId) return resolvedOpenapiClientVirtualModuleId
+      if (id === openapiSchemaModelsVirtualModuleId)
+        return resolvedOpenapiSchemaModelsVirtualModuleId
       if (id.startsWith(openapiClientDocumentPrefix)) return `\0${id}`
+      if (id.startsWith(openapiSchemaModelsDocumentPrefix)) return `\0${id}`
       return
     },
     configureServer(server) {
@@ -1434,7 +1484,9 @@ export function openapi(config: Config.Config): PluginOption {
         for (const moduleId of [
           resolvedOpenapiVirtualModuleId,
           resolvedOpenapiClientVirtualModuleId,
+          resolvedOpenapiSchemaModelsVirtualModuleId,
           ...Object.keys(specs).map(resolvedOpenapiClientDocumentId),
+          ...openapiSchemaModelSources(specs).map(resolvedOpenapiSchemaModelsDocumentId),
           '\0virtual:vocs/config',
         ]) {
           const mod = server.moduleGraph.getModuleById(moduleId)
@@ -1445,10 +1497,13 @@ export function openapi(config: Config.Config): PluginOption {
     },
     async load(id) {
       const clientMount = openapiClientMount(id)
+      const schemaModelsSource = openapiSchemaModelsSource(id)
       if (
         id !== resolvedOpenapiVirtualModuleId &&
         id !== resolvedOpenapiClientVirtualModuleId &&
-        clientMount === undefined
+        id !== resolvedOpenapiSchemaModelsVirtualModuleId &&
+        clientMount === undefined &&
+        schemaModelsSource === undefined
       )
         return
 
@@ -1467,10 +1522,18 @@ export function openapi(config: Config.Config): PluginOption {
       }
 
       if (id === resolvedOpenapiClientVirtualModuleId) return openapiClientManifest(specs)
+      if (id === resolvedOpenapiSchemaModelsVirtualModuleId)
+        return openapiSchemaModelsManifest(specs)
 
       if (clientMount !== undefined) {
         const document = openapiClientDocument(specs, clientMount)
         if (!document) this.error(`No OpenAPI spec is mounted at ${clientMount}.`)
+        return document
+      }
+
+      if (schemaModelsSource !== undefined) {
+        const document = openapiSchemaModelsDocument(specs, schemaModelsSource)
+        if (!document) this.error(`No OpenAPI schema models found for ${schemaModelsSource}.`)
         return document
       }
 

--- a/src/openapi-app/App.test.tsx
+++ b/src/openapi-app/App.test.tsx
@@ -1,0 +1,53 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, expect, test, vi } from 'vitest'
+import type { Payload } from '../internal/openapi/app.js'
+import { App } from './App.js'
+
+const mocks = vi.hoisted(() => ({
+  openApiPage: vi.fn((_props: { inlineSchemaModels?: boolean | undefined }) => null),
+  path: '/api/pets',
+}))
+
+vi.mock('../react/internal/openapi/OpenApiPage.js', () => ({
+  OpenApiGuide: () => null,
+  OpenApiPage: mocks.openApiPage,
+}))
+
+vi.mock('./blocks.js', () => ({
+  Blocks: () => null,
+}))
+
+vi.mock('./waku.js', () => ({
+  RouterProvider: (props: { children: React.ReactNode }) => props.children,
+  useRouter: () => ({ path: mocks.path }),
+}))
+
+beforeEach(() => {
+  mocks.openApiPage.mockClear()
+})
+
+test('keeps standalone category schema models inline', () => {
+  renderToStaticMarkup(<App payload={payload} />)
+
+  expect(mocks.openApiPage.mock.calls[0]?.[0]).toMatchObject({
+    group: 'pets',
+    inlineSchemaModels: true,
+    mount: '/api',
+  })
+})
+
+const payload: Payload = {
+  config: {} as Payload['config'],
+  ir: {
+    client: { content: {} },
+    groups: [{ id: 'pets', name: 'Pets', operations: [] }],
+    info: { title: 'Pet API' },
+    path: '/api',
+    securitySchemes: {},
+    servers: [],
+    traits: [],
+  },
+  pages: [],
+  sidebar: [],
+  title: 'Pet API',
+}

--- a/src/openapi-app/App.tsx
+++ b/src/openapi-app/App.tsx
@@ -40,7 +40,16 @@ function Content(props: App.Props) {
 
   // Category page.
   const group = ir.groups.find((candidate) => join(base, `/${candidate.id}`) === route)
-  if (group) return <OpenApiPage mount={base} group={group.id} intro={intro} title={page?.title} />
+  if (group)
+    return (
+      <OpenApiPage
+        mount={base}
+        group={group.id}
+        intro={intro}
+        title={page?.title}
+        inlineSchemaModels
+      />
+    )
 
   // Landing / overview page. Without an override the standalone Introduction
   // lists every endpoint by default (consumers can override `/` to customize).

--- a/src/openapi-app/virtual/openapi-schema-models.ts
+++ b/src/openapi-app/virtual/openapi-schema-models.ts
@@ -1,0 +1,6 @@
+import type { SchemaModel } from '../../internal/openapi/schema-model.js'
+
+// The standalone app keeps schema models inline because its payload is already
+// delivered as one external asset. Generated Vite routes replace this manifest
+// with code-split category documents.
+export const schemaModelDocuments: Record<string, () => Promise<Record<string, SchemaModel>>> = {}

--- a/src/react/internal/openapi/OpenApiPage.test.tsx
+++ b/src/react/internal/openapi/OpenApiPage.test.tsx
@@ -7,6 +7,7 @@ import { OpenApiGuide, OpenApiPage } from './OpenApiPage.js'
 const mocks = vi.hoisted(() => ({
   config: {} as Config.Config,
   path: '/api',
+  referenceGroup: vi.fn((_props: { modelSource?: string | undefined }) => null),
   specs: {} as Record<string, Ir>,
 }))
 
@@ -44,11 +45,12 @@ vi.mock('./Playground.client.js', () => ({
 
 vi.mock('./Reference.js', () => ({
   Prose: () => null,
-  ReferenceGroup: () => null,
+  ReferenceGroup: mocks.referenceGroup,
   ReferenceOverview: () => null,
 }))
 
 beforeEach(() => {
+  mocks.referenceGroup.mockClear()
   mocks.config = createConfig()
   mocks.path = '/api'
   mocks.specs = {
@@ -135,6 +137,18 @@ describe('OpenAPI page metadata', () => {
     expect(html).toContain(
       'name="twitter:description" content="Send and track payments through the API."',
     )
+  })
+
+  test('keeps standalone category schema models inline', () => {
+    renderToStaticMarkup(<OpenApiPage group="payments" inlineSchemaModels mount="/api" />)
+
+    expect(mocks.referenceGroup.mock.calls[0]?.[0].modelSource).toBeUndefined()
+  })
+
+  test('loads generated category schema models by default', () => {
+    renderToStaticMarkup(<OpenApiPage group="payments" mount="/api" />)
+
+    expect(mocks.referenceGroup.mock.calls[0]?.[0].modelSource).toBe('["/api","payments"]')
   })
 })
 

--- a/src/react/internal/openapi/OpenApiPage.tsx
+++ b/src/react/internal/openapi/OpenApiPage.tsx
@@ -147,7 +147,9 @@ export function OpenApiPage(props: OpenApiPage.Props) {
             ir={ir}
             group={group}
             intro={props.intro}
-            modelSource={schemaModelSource(ir.path, group.id)}
+            modelSource={
+              props.inlineSchemaModels ? undefined : schemaModelSource(ir.path, group.id)
+            }
           />
         </PlaygroundProvider>
       </OpenApiLayout>
@@ -187,6 +189,8 @@ export declare namespace OpenApiPage {
     frontmatter?: Frontmatter | undefined
     /** Document `<title>` override (e.g. from the override page's frontmatter). */
     title?: string | undefined
+    /** Keep schema models inline instead of loading a generated category document. */
+    inlineSchemaModels?: boolean | undefined
     /**
      * Render the domain/endpoint list on the overview page (ignored when `group`
      * or `intro` is set). The standalone handler enables this so its

--- a/src/react/internal/openapi/OpenApiPage.tsx
+++ b/src/react/internal/openapi/OpenApiPage.tsx
@@ -1,6 +1,7 @@
 import { specs } from 'virtual:vocs/openapi'
 import type { ReactNode } from 'react'
 import type { Frontmatter } from '../../../internal/config.js'
+import { schemaModelSource } from '../../../internal/openapi/schema-model.js'
 import { Layout } from '../../Layout.js'
 import * as MdxPageContext from '../../MdxPageContext.js'
 import { Endpoints } from './Endpoints.js'
@@ -142,7 +143,12 @@ export function OpenApiPage(props: OpenApiPage.Props) {
       <OpenApiLayout frontmatter={{ ...props.frontmatter, description, title }} outline={false}>
         <title>{title}</title>
         <PlaygroundProvider mount={ir.path}>
-          <ReferenceGroup ir={ir} group={group} intro={props.intro} />
+          <ReferenceGroup
+            ir={ir}
+            group={group}
+            intro={props.intro}
+            modelSource={schemaModelSource(ir.path, group.id)}
+          />
         </PlaygroundProvider>
       </OpenApiLayout>
     )

--- a/src/react/internal/openapi/Operation.tsx
+++ b/src/react/internal/openapi/Operation.tsx
@@ -8,6 +8,17 @@ import {
 } from '../../../internal/openapi/anchors.js'
 import type * as OpenApi from '../../../internal/openapi/index.js'
 import { codeSamples, responseSamples } from '../../../internal/openapi/sample.js'
+import {
+  enumValues,
+  formatExample,
+  parameterSchemaModelId,
+  requestSchemaModelId,
+  responseSchemaModelId,
+  schemaExample,
+  schemaMeta,
+  typeLabel,
+  unionVariants,
+} from '../../../internal/openapi/schema-model.js'
 import { methodVariant } from '../../../internal/openapi/sidebar.js'
 import { unwrapSingleVariant } from '../../../internal/openapi/union.js'
 import { Badge } from '../../Badge.js'
@@ -16,17 +27,7 @@ import { CollapsibleChildren } from './CollapsibleChildren.client.js'
 import { Disclosure } from './Disclosure.client.js'
 import { HeadingAnchor } from './HeadingAnchor.js'
 import { TestRequestButton } from './Playground.client.js'
-import {
-  enumValues,
-  formatExample,
-  PropertyRow,
-  Schema,
-  schemaExample,
-  schemaMeta,
-  typeLabel,
-  UnionView,
-  unionVariants,
-} from './Schema.js'
+import { PropertyRow, Schema, UnionView } from './Schema.js'
 
 const parameterGroups: { in: OpenApi.IrParameter['in']; title: string }[] = [
   { in: 'path', title: 'Path Parameters' },
@@ -45,6 +46,7 @@ export function Operation(props: Operation.Props) {
     separator = false,
     anchors = true,
     hideQueryParams = false,
+    modelSource,
   } = props
   const title = operation.summary || `${operation.method} ${operation.path}`
   const Heading = `h${headingLevel}` as 'h2' | 'h3'
@@ -82,7 +84,11 @@ export function Operation(props: Operation.Props) {
           if (params.length === 0) return null
           return (
             <Section key={group.in} id={`${operation.id}-${slug(group.title)}`} title={group.title}>
-              <ParameterList parameters={params} idPrefix={operation.id} />
+              <ParameterList
+                parameters={params}
+                idPrefix={operation.id}
+                modelSource={modelSource}
+              />
             </Section>
           )
         })}
@@ -92,6 +98,8 @@ export function Operation(props: Operation.Props) {
             <Content
               content={operation.requestBody.content}
               idBase={requestBodyIdBase(operation.id)}
+              modelId={(media) => requestSchemaModelId(operation.id, media)}
+              modelSource={modelSource}
             />
           </Section>
         )}
@@ -100,7 +108,12 @@ export function Operation(props: Operation.Props) {
           <Section id={`${operation.id}-responses`} title="Responses">
             <div data-v-openapi-responses>
               {operation.responses.map((response) => (
-                <ResponseRow key={response.status} operationId={operation.id} response={response} />
+                <ResponseRow
+                  key={response.status}
+                  operationId={operation.id}
+                  response={response}
+                  modelSource={modelSource}
+                />
               ))}
             </div>
           </Section>
@@ -163,6 +176,8 @@ export declare namespace Operation {
      * @default false
      */
     hideQueryParams?: boolean | undefined
+    /** Category schema-model document key for code-split generated routes. */
+    modelSource?: string | undefined
   }
 }
 
@@ -178,7 +193,11 @@ function Section(props: { id: string; title: string; children: React.ReactNode }
   )
 }
 
-function ParameterList(props: { parameters: OpenApi.IrParameter[]; idPrefix: string }) {
+function ParameterList(props: {
+  parameters: OpenApi.IrParameter[]
+  idPrefix: string
+  modelSource?: string | undefined
+}) {
   return (
     <div data-v-openapi-params>
       {props.parameters.map((parameter) => {
@@ -202,7 +221,13 @@ function ParameterList(props: { parameters: OpenApi.IrParameter[]; idPrefix: str
             description={parameter.description}
           >
             {union ? (
-              <UnionView union={union} depth={1} prefix={`${parameter.name}.`} />
+              <UnionView
+                union={union}
+                depth={1}
+                prefix={`${parameter.name}.`}
+                modelId={parameterSchemaModelId(props.idPrefix, parameter)}
+                modelSource={props.modelSource}
+              />
             ) : (
               schema &&
               hasChildSchema(schema) && (
@@ -212,6 +237,8 @@ function ParameterList(props: { parameters: OpenApi.IrParameter[]; idPrefix: str
                       schema={schema}
                       depth={1}
                       prefix={`${parameter.name}${schema['type'] === 'array' ? '[]' : ''}.`}
+                      modelId={parameterSchemaModelId(props.idPrefix, parameter)}
+                      modelSource={props.modelSource}
                     />
                   </div>
                 </CollapsibleChildren>
@@ -245,6 +272,8 @@ function Content(props: {
   content: OpenApi.IrMediaType[]
   hideMediaType?: boolean
   idBase?: string | undefined
+  modelId?: ((media: OpenApi.IrMediaType) => string) | undefined
+  modelSource?: string | undefined
 }) {
   if (props.content.length === 0) return null
   return (
@@ -257,7 +286,12 @@ function Content(props: {
           <div key={media.mediaType} data-v-openapi-media>
             {!props.hideMediaType && <code data-v-openapi-media-type>{media.mediaType}</code>}
             {media.schema ? (
-              <Schema schema={media.schema} idBase={schemaIdBase} />
+              <Schema
+                schema={media.schema}
+                idBase={schemaIdBase}
+                modelId={props.modelId?.(media)}
+                modelSource={props.modelSource}
+              />
             ) : media.example !== undefined ? (
               <Example value={media.example} />
             ) : null}
@@ -268,7 +302,11 @@ function Content(props: {
   )
 }
 
-function ResponseRow(props: { operationId: string; response: OpenApi.IrResponse }) {
+function ResponseRow(props: {
+  operationId: string
+  response: OpenApi.IrResponse
+  modelSource?: string | undefined
+}) {
   const { operationId, response } = props
   const headers = response.headers ?? []
   const idBase = responseIdBase(operationId, response.status)
@@ -329,7 +367,13 @@ function ResponseRow(props: { operationId: string; response: OpenApi.IrResponse 
             </CollapsibleChildren>
           )}
           {response.content.length > 0 && (
-            <Content content={response.content} hideMediaType idBase={idBase} />
+            <Content
+              content={response.content}
+              hideMediaType
+              idBase={idBase}
+              modelId={(media) => responseSchemaModelId(operationId, response.status, media)}
+              modelSource={props.modelSource}
+            />
           )}
         </div>
       </Disclosure>

--- a/src/react/internal/openapi/OperationStandalone.tsx
+++ b/src/react/internal/openapi/OperationStandalone.tsx
@@ -1,4 +1,5 @@
 import { specs } from 'virtual:vocs/openapi'
+import { schemaModelSource } from '../../../internal/openapi/schema-model.js'
 import { findOperation } from './find-operation.js'
 import { Operation as OperationView } from './Operation.js'
 import { PlaygroundProvider } from './Playground.client.js'
@@ -48,6 +49,8 @@ export function Operation(props: Operation.Props) {
       </p>
     )
 
+  const group = ir.groups.find((candidate) => candidate.operations.includes(operation))
+
   return (
     <div data-v-openapi>
       <PlaygroundProvider mount={ir.path}>
@@ -57,6 +60,7 @@ export function Operation(props: Operation.Props) {
           headingLevel={props.headingLevel ?? 2}
           anchors={props.anchors}
           hideQueryParams={props.hideQueryParams}
+          modelSource={group ? schemaModelSource(ir.path, group.id) : undefined}
         />
       </PlaygroundProvider>
     </div>

--- a/src/react/internal/openapi/Reference.tsx
+++ b/src/react/internal/openapi/Reference.tsx
@@ -79,7 +79,7 @@ export declare namespace ReferenceOverview {
  * with `PlaygroundProvider` so a single Scalar modal is shared across the page.
  */
 export function ReferenceGroup(props: ReferenceGroup.Props) {
-  const { ir, group, intro } = props
+  const { ir, group, intro, modelSource } = props
   return (
     <div data-v-openapi>
       {intro ? (
@@ -104,6 +104,7 @@ export function ReferenceGroup(props: ReferenceGroup.Props) {
           server={ir.servers[0]?.url}
           headingLevel={2}
           separator={index > 0}
+          modelSource={modelSource}
         />
       ))}
     </div>
@@ -116,5 +117,7 @@ export declare namespace ReferenceGroup {
     group: IrGroup
     /** Consumer override rendered in place of the auto-generated category header. */
     intro?: ReactNode | undefined
+    /** Category schema-model document key for code-split generated routes. */
+    modelSource?: string | undefined
   }
 }

--- a/src/react/internal/openapi/Schema.client.test.tsx
+++ b/src/react/internal/openapi/Schema.client.test.tsx
@@ -1,5 +1,6 @@
 /** @vitest-environment jsdom */
 
+import { schemaModelDocuments } from 'virtual:vocs/openapi-schema-models'
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, expect, test, vi } from 'vitest'
@@ -36,7 +37,35 @@ beforeEach(() => {
 afterEach(() => {
   act(() => root.unmount())
   container.remove()
+  for (const source of Object.keys(schemaModelDocuments)) delete schemaModelDocuments[source]
   vi.restoreAllMocks()
+})
+
+test('loads a generated schema model document by source and id', async () => {
+  const source = JSON.stringify(['/api/openapi.json', 'pets'])
+  const modelId = JSON.stringify(['response', 'getPet', '200', 'application/json'])
+  schemaModelDocuments[source] = async () => ({
+    [modelId]: {
+      view: 'properties',
+      properties: [{ name: 'external', type: 'string', meta: [] }],
+    },
+  })
+
+  await act(async () =>
+    root.render(
+      <Schema
+        modelId={modelId}
+        modelSource={source}
+        schema={{
+          type: 'object',
+          properties: { inline: { type: 'string' } },
+        }}
+      />,
+    ),
+  )
+
+  expect(container.textContent).toContain('external')
+  expect(container.textContent).not.toContain('inline')
 })
 
 test('materializes nested properties when their disclosure opens', async () => {

--- a/src/react/internal/openapi/Schema.client.tsx
+++ b/src/react/internal/openapi/Schema.client.tsx
@@ -1,8 +1,14 @@
 'use client'
 
-import { Fragment, useEffect, useLayoutEffect, useState } from 'react'
+import { schemaModelDocuments } from 'virtual:vocs/openapi-schema-models'
+import { Fragment, use, useEffect, useLayoutEffect, useState } from 'react'
 import LucideChevronDown from '~icons/lucide/chevron-down'
 import { type SchemaPath, schemaPropertyId } from '../../../internal/openapi/anchors.js'
+import type {
+  SchemaModel,
+  SchemaPropertyModel,
+  SchemaVariantModel,
+} from '../../../internal/openapi/schema-model.js'
 import { unionVariantSegment } from '../../../internal/openapi/union.js'
 import { Badge } from '../../Badge.js'
 import { registerLazyAnchor } from './anchor-navigation.client.js'
@@ -10,7 +16,8 @@ import { CollapsibleChildren } from './CollapsibleChildren.client.js'
 import { EnumValues } from './EnumValues.client.js'
 import { HeadingAnchor } from './HeadingAnchor.js'
 import { PropertyExample } from './PropertyExample.client.js'
-import type { SchemaModel, SchemaPropertyModel, SchemaVariantModel } from './Schema.js'
+
+const modelDocumentPromises = new Map<string, Promise<Record<string, SchemaModel>>>()
 
 /**
  * Renders a compact schema display model. Only the visible property level is
@@ -18,7 +25,14 @@ import type { SchemaModel, SchemaPropertyModel, SchemaVariantModel } from './Sch
  * after interaction.
  */
 export function SchemaView(props: SchemaView.Props) {
-  const { idBase, model, path } = props
+  const { idBase, path } = props
+  let model: SchemaModel
+  if (props.model) model = props.model
+  else {
+    const resolved = use(loadModelDocument(props.modelSource))[props.modelId]
+    if (!resolved) missingModel(props.modelSource, props.modelId)
+    model = resolved
+  }
   const [targetId, setTargetId] = useState<string>()
 
   useEffect(() => {
@@ -37,7 +51,29 @@ export function SchemaView(props: SchemaView.Props) {
     return () => window.clearTimeout(timeout)
   }, [targetId])
 
-  return <SchemaNode {...props} targetId={targetId} />
+  return (
+    <SchemaNode
+      model={model}
+      prefix={props.prefix}
+      idBase={idBase}
+      path={path}
+      targetId={targetId}
+    />
+  )
+}
+
+function loadModelDocument(source: string): Promise<Record<string, SchemaModel>> {
+  const existing = modelDocumentPromises.get(source)
+  if (existing) return existing
+  const loader = schemaModelDocuments[source]
+  if (!loader) throw new Error(`[vocs] No OpenAPI schema models found for ${source}.`)
+  const pending = loader()
+  modelDocumentPromises.set(source, pending)
+  return pending
+}
+
+function missingModel(source: string, id: string): never {
+  throw new Error(`[vocs] No OpenAPI schema model ${id} found in ${source}.`)
 }
 
 function hasSchemaAnchor(
@@ -64,8 +100,10 @@ function hasSchemaAnchor(
 }
 
 export declare namespace SchemaView {
-  type Props = {
-    model: SchemaModel
+  type Props = (
+    | { model: SchemaModel; modelId?: never; modelSource?: never }
+    | { model?: never; modelId: string; modelSource: string }
+  ) & {
     /** Muted ancestor path prepended to each child row's name. */
     prefix?: string | undefined
     /** Operation/media response id used to build property anchors. */
@@ -75,11 +113,13 @@ export declare namespace SchemaView {
   }
 }
 
-function SchemaNode(
-  props: SchemaView.Props & {
-    targetId?: string | undefined
-  },
-) {
+function SchemaNode(props: {
+  model: SchemaModel
+  prefix?: string | undefined
+  idBase?: string | undefined
+  path?: SchemaPath | undefined
+  targetId?: string | undefined
+}) {
   const { model, prefix = '', idBase, path = [], targetId } = props
   if (model.view === 'union')
     return (

--- a/src/react/internal/openapi/Schema.tsx
+++ b/src/react/internal/openapi/Schema.tsx
@@ -1,153 +1,17 @@
 import { Fragment } from 'react'
 import * as Markdown from '../../../internal/markdown.js'
 import type { SchemaPath } from '../../../internal/openapi/anchors.js'
-import { unionVariantSchemas, unwrapSingleVariant } from '../../../internal/openapi/union.js'
+import {
+  type schemaMeta,
+  toSchemaModel,
+  toUnionModel,
+  type unionVariants,
+} from '../../../internal/openapi/schema-model.js'
 import { Badge } from '../../Badge.js'
 import { EnumValues } from './EnumValues.client.js'
 import { HeadingAnchor } from './HeadingAnchor.js'
 import { PropertyExample } from './PropertyExample.client.js'
 import { SchemaView } from './Schema.client.js'
-
-type SchemaObject = Record<string, unknown>
-
-const maxDepth = 6
-
-/**
- * Renders a human-readable type label for a JSON Schema (post-dereference).
- */
-export function typeLabel(schema: SchemaObject | undefined): string {
-  if (!schema) return 'unknown'
-
-  if (Array.isArray(schema['type'])) return (schema['type'] as string[]).join(' | ')
-
-  const composite = (schema['oneOf'] ?? schema['anyOf']) as SchemaObject[] | undefined
-  if (composite) return composite.map(typeLabel).join(' | ')
-
-  if (Array.isArray(schema['allOf']))
-    return (schema['allOf'] as SchemaObject[]).map(typeLabel).join(' & ')
-
-  if (schema['type'] === 'array') return `${typeLabel(schema['items'] as SchemaObject)}[]`
-
-  if (typeof schema['type'] === 'string') {
-    const format = schema['format'] ? ` <${schema['format']}>` : ''
-    return `${schema['type']}${format}`
-  }
-
-  // Enum without an explicit `type`: the literal values are rendered separately
-  // as a values list (see {@link enumValues}), so just label it `enum`.
-  if (Array.isArray(schema['enum'])) return 'enum'
-
-  if (schema['properties']) return 'object'
-
-  return 'unknown'
-}
-
-/**
- * Detects a `oneOf`/`anyOf` union (unwrapping array item schemas) worth showing
- * as a variant picker, returning its variants. Trivial
- * `null` members are dropped, and plain scalar unions with no extra info (e.g.
- * `string | number`) keep their inline type label instead — the picker is only
- * used when at least one variant carries something to show (object properties,
- * an enum, a `const`, a format, or a title).
- */
-export function unionVariants(schema: SchemaObject | undefined): unionVariants.Result | undefined {
-  const variants = unionVariantSchemas(schema)
-  if (!variants) return undefined
-  const target =
-    schema?.['type'] === 'array' && schema['items'] ? (schema['items'] as SchemaObject) : schema
-  const oneOf = target?.['oneOf']
-  return {
-    kind: oneOf ? 'One of' : 'Any of',
-    variants: variants.map((member, index) => ({
-      name: variantName(member, index),
-      schema: member,
-    })),
-  }
-}
-
-/** A human-readable label for a single union variant. */
-function variantName(member: SchemaObject, index: number): string {
-  if (typeof member['title'] === 'string' && member['title']) return member['title']
-  if ('const' in member) return stringify(member['const'])
-  const values = enumValues(member)
-  if (values && values.length > 0) {
-    const joined = values.join(' | ')
-    if (joined.length <= 32) return joined
-    return 'enum'
-  }
-  return typeLabel(member) || `Option ${index + 1}`
-}
-
-export declare namespace unionVariants {
-  type Result = {
-    kind: string
-    variants: { name: string; schema: SchemaObject }[]
-  }
-}
-
-/**
- * Extracts a schema's enum literals as display strings (strings unquoted, other
- * values JSON-stringified), unwrapping array item schemas. These are rendered
- * as a separate "values" list rather than a wrapping inline union, matching the
- * Scalar/Stripe reference UI.
- */
-export function enumValues(schema: SchemaObject | undefined): string[] | undefined {
-  if (!schema) return undefined
-  const target =
-    schema['type'] === 'array' && schema['items'] ? (schema['items'] as SchemaObject) : schema
-  const values = target['enum']
-  if (!Array.isArray(values) || values.length === 0) return undefined
-  return values.map((value) => (typeof value === 'string' ? value : JSON.stringify(value)))
-}
-
-/**
- * Builds the constraint metadata shown beneath a property/parameter type as
- * `{ label, value }` pairs (e.g. `min 0`, `max 100`, `default 10`), in the
- * style of Scalar/Stripe references. The type itself is rendered separately
- * (see {@link typeLabel}).
- */
-export function schemaMeta(schema: SchemaObject | undefined): schemaMeta.Entry[] {
-  if (!schema) return []
-  const parts: schemaMeta.Entry[] = []
-
-  const num = (key: string) =>
-    typeof schema[key] === 'number' ? (schema[key] as number) : undefined
-  const min = num('minimum') ?? num('minLength') ?? num('minItems')
-  const max = num('maximum') ?? num('maxLength') ?? num('maxItems')
-  if (min !== undefined) parts.push({ label: 'min', value: String(min) })
-  if (max !== undefined) parts.push({ label: 'max', value: String(max) })
-
-  if ('const' in schema) parts.push({ label: 'const', value: stringify(schema['const']) })
-  if ('default' in schema) parts.push({ label: 'default', value: stringify(schema['default']) })
-
-  return parts
-}
-
-export declare namespace schemaMeta {
-  type Entry = { label: string; value: string }
-}
-
-function stringify(value: unknown): string {
-  if (typeof value === 'string') return value
-  return JSON.stringify(value)
-}
-
-export function formatExample(value: unknown): string {
-  if (typeof value === 'string') return value
-  return JSON.stringify(value, null, 2)
-}
-
-/**
- * Extracts a representative example value from a schema (`example` or the first
- * entry of `examples`), returned as a display string.
- */
-export function schemaExample(schema: SchemaObject | undefined): string | undefined {
-  if (!schema) return undefined
-  if ('example' in schema) return formatExample(schema['example'])
-  const examples = schema['examples']
-  if (Array.isArray(examples) && examples.length > 0) return formatExample(examples[0])
-  return undefined
-}
 
 /**
  * A single parameter/property row: name + inline metadata, an optional
@@ -253,49 +117,23 @@ export declare namespace PropertyRow {
   }
 }
 
-export type SchemaModel =
-  | {
-      view: 'properties'
-      properties: SchemaPropertyModel[]
-    }
-  | {
-      view: 'union'
-      label: string
-      variants: SchemaVariantModel[]
-    }
-
-export type SchemaPropertyModel = {
-  name: string
-  type?: string | undefined
-  values?: string[] | undefined
-  meta: schemaMeta.Entry[]
-  example?: string | undefined
-  required?: boolean | undefined
-  deprecated?: boolean | undefined
-  descriptionHtml?: string | undefined
-  child?: SchemaModel | undefined
-  array?: boolean | undefined
-}
-
-export type SchemaVariantModel = {
-  name: string
-  type?: string | undefined
-  values?: string[] | undefined
-  meta: schemaMeta.Entry[]
-  descriptionHtml?: string | undefined
-  child?: SchemaModel | undefined
-}
-
 /**
  * Recursively renders a schema's properties as a list of rows. Nested
  * object/array properties are projected into a compact display model and
  * materialized by the client only after their disclosure is opened.
  */
 export function Schema(props: Schema.Props) {
-  const { depth = 0, prefix = '', idBase, path = [] } = props
+  const { depth = 0, prefix = '', idBase, modelId, modelSource, path = [] } = props
   const model = toSchemaModel(props.schema, depth)
   if (!model) return null
-  return <SchemaView model={model} prefix={prefix} idBase={idBase} path={path} />
+  return (
+    <SchemaView
+      {...(modelId && modelSource ? { modelId, modelSource } : { model })}
+      prefix={prefix}
+      idBase={idBase}
+      path={path}
+    />
+  )
 }
 
 export declare namespace Schema {
@@ -311,6 +149,10 @@ export declare namespace Schema {
     idBase?: string | undefined
     /** Schema path (chain of property names) leading to this schema. */
     path?: SchemaPath | undefined
+    /** Key in the category's code-split schema-model document. */
+    modelId?: string | undefined
+    /** Category schema-model document key. */
+    modelSource?: string | undefined
   }
 }
 
@@ -325,97 +167,17 @@ export function UnionView(props: {
   prefix: string
   idBase?: string | undefined
   path?: SchemaPath | undefined
+  modelId?: string | undefined
+  modelSource?: string | undefined
 }) {
-  const { union, depth, prefix, idBase, path = [] } = props
+  const { union, depth, prefix, idBase, modelId, modelSource, path = [] } = props
   const model = toUnionModel(union, depth)
-  return <SchemaView model={model} prefix={prefix} idBase={idBase} path={path} />
-}
-
-function toSchemaModel(
-  rawSchema: SchemaObject | undefined,
-  depth: number,
-): SchemaModel | undefined {
-  if (!rawSchema || depth > maxDepth) return undefined
-
-  const schema = unwrapSingleVariant(rawSchema) ?? rawSchema
-  const union = unionVariants(schema)
-  if (union) return toUnionModel(union, depth)
-
-  if (schema['type'] === 'array' && schema['items'])
-    return toSchemaModel(schema['items'] as SchemaObject, depth)
-
-  const allOf = schema['allOf'] as SchemaObject[] | undefined
-  const properties = (schema['properties'] ??
-    allOf?.reduce<Record<string, SchemaObject>>((acc, member) => {
-      Object.assign(acc, (member['properties'] as Record<string, SchemaObject>) ?? {})
-      return acc
-    }, {})) as Record<string, SchemaObject> | undefined
-  if (!properties || Object.keys(properties).length === 0) return undefined
-
-  const required = new Set((schema['required'] as string[] | undefined) ?? [])
-  return {
-    view: 'properties',
-    properties: Object.entries(properties).map(([name, rawProperty]) => {
-      const property = unwrapSingleVariant(rawProperty) ?? rawProperty
-      const propertyUnion = unionVariants(property)
-      return {
-        name,
-        type: propertyUnion ? undefined : typeLabel(property),
-        values: propertyUnion ? undefined : enumValues(property),
-        meta: propertyUnion ? [] : schemaMeta(property),
-        example: propertyUnion ? undefined : schemaExample(property),
-        required: required.has(name),
-        deprecated: property['deprecated'] === true,
-        descriptionHtml:
-          typeof property['description'] === 'string'
-            ? Markdown.toHtml(property['description'] as string)
-            : undefined,
-        child:
-          depth >= maxDepth
-            ? undefined
-            : propertyUnion
-              ? toUnionModel(propertyUnion, depth + 1)
-              : hasChildren(property)
-                ? toSchemaModel(property, depth + 1)
-                : undefined,
-        array: property['type'] === 'array',
-      }
-    }),
-  }
-}
-
-function toUnionModel(union: unionVariants.Result, depth: number): SchemaModel {
-  return {
-    view: 'union',
-    label: union.kind,
-    variants: union.variants.map((variant) => {
-      const { schema } = variant
-      const items = (schema['type'] === 'array' ? schema['items'] : undefined) as
-        | SchemaObject
-        | undefined
-      const objectish = Boolean(
-        schema['properties'] || schema['allOf'] || items?.['properties'] || items?.['allOf'],
-      )
-      return {
-        name: variant.name,
-        type: objectish ? undefined : typeLabel(schema),
-        values: objectish ? undefined : enumValues(schema),
-        meta: objectish ? [] : schemaMeta(schema),
-        descriptionHtml:
-          typeof schema['description'] === 'string'
-            ? Markdown.toHtml(schema['description'] as string)
-            : undefined,
-        child: objectish ? toSchemaModel(schema, depth) : undefined,
-      }
-    }),
-  }
-}
-
-/** Whether a schema exposes nested properties worth rendering as child rows. */
-function hasChildren(schema: SchemaObject): boolean {
-  if (schema['properties']) return true
-  if (schema['allOf']) return true
-  if (schema['type'] === 'array' && schema['items'])
-    return hasChildren(schema['items'] as SchemaObject)
-  return false
+  return (
+    <SchemaView
+      {...(modelId && modelSource ? { modelId, modelSource } : { model })}
+      prefix={prefix}
+      idBase={idBase}
+      path={path}
+    />
+  )
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,6 +35,10 @@ export default defineConfig({
         import.meta.dirname,
         'src/internal/test/virtual-openapi-client.stub.ts',
       ),
+      'virtual:vocs/openapi-schema-models': path.resolve(
+        import.meta.dirname,
+        'src/internal/test/virtual-openapi-schema-models.stub.ts',
+      ),
     },
     include: ['./src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     globals: true,


### PR DESCRIPTION
Moves generated OpenAPI schema display models into category-specific client chunks while preserving lazy schema rendering. Generated routes previously serialized every model into the inline Flight payload, causing oversized HTML responses.