### PR TITLE
feat: add benchmarks table directive

### DIFF
--- a/.changeset/lucky-tables-race.md
+++ b/.changeset/lucky-tables-race.md
@@ -1,0 +1,14 @@
+---
+'vocs': minor
+---
+
+Added a `:::benchmarks` directive that colors table cells by performance relative to a reference column.
+
+```md
+:::benchmarks
+| suite | Octane | React |
+| --- | --- | --- |
+| render | 1x | 2.5x |
+| memory | 1x | 0.4x |
+:::
+```

--- a/site/src/pages/writing/markdown-extensions.mdx
+++ b/site/src/pages/writing/markdown-extensions.mdx
@@ -27,6 +27,83 @@ This feature is :badge[Experimental].
 ```
 :::
 
+## Benchmarks
+
+Use the `:::benchmarks` directive to color a table by relative performance. The first column that contains numeric values is the reference. Scalar cells (`2.5x`) are cost ratios against the reference: below `1x` renders green (faster), above renders red (slower). Use `—` for missing values.
+
+::::code-group
+<div data-title="Preview">
+:::benchmarks
+| suite | Octane | React 19 | Preact 10 | Solid 2.0 |
+| --- | --- | --- | --- | --- |
+| js-framework | 1x | 2.5x | 2.4x | 1.1x |
+| chat-stream | 1x | 3.7x | 2.5x | 1.4x |
+| memo-wall | 1x | 6.1x | 7.6x | 0.40x |
+| signal-favoring | 1x | 5.9x | 3.3x | 0.69x |
+| async-waterfall | 1x | 12x | 9.0x | — |
+| bundle-size | 1x | 0.97x | 0.59x | 0.70x |
+:::
+</div>
+```md [Markdown]
+:::benchmarks
+| suite | Octane | React 19 | Preact 10 | Solid 2.0 |
+| --- | --- | --- | --- | --- |
+| js-framework | 1x | 2.5x | 2.4x | 1.1x |
+| chat-stream | 1x | 3.7x | 2.5x | 1.4x |
+| memo-wall | 1x | 6.1x | 7.6x | 0.40x |
+| signal-favoring | 1x | 5.9x | 3.3x | 0.69x |
+| async-waterfall | 1x | 12x | 9.0x | — |
+| bundle-size | 1x | 0.97x | 0.59x | 0.70x |
+:::
+```
+::::
+
+Time cells (`120ms`, `1.2s`, supporting `ns`, `us`, `ms`, `s`, and unitless values) are compared against the reference column's time in the same row.
+
+::::code-group
+<div data-title="Preview">
+:::benchmarks
+| task | vocs | webpack |
+| --- | --- | --- |
+| cold build | 1.2s | 4.8s |
+| HMR update | 45ms | 320ms |
+:::
+</div>
+```md [Markdown]
+:::benchmarks
+| task | vocs | webpack |
+| --- | --- | --- |
+| cold build | 1.2s | 4.8s |
+| HMR update | 45ms | 320ms |
+:::
+```
+::::
+
+For throughput-style tables where a higher multiplier means faster, set `scalar=speedup` to invert scalar coloring.
+
+::::code-group
+<div data-title="Preview">
+:::benchmarks{scalar=speedup}
+| suite | baseline | optimized | legacy |
+| --- | --- | --- | --- |
+| render | 1x | 2.5x | 0.80x |
+| hydrate | 1x | 1.9x | 0.65x |
+:::
+</div>
+```md [Markdown]
+:::benchmarks{scalar=speedup}
+| suite | baseline | optimized | legacy |
+| --- | --- | --- | --- |
+| render | 1x | 2.5x | 0.80x |
+| hydrate | 1x | 1.9x | 0.65x |
+:::
+```
+::::
+
+:::note
+Set `legend=false` on the directive to hide the legend.
+:::
+
 ## Blockquote
 
 To create a blockquote, add a `>` in front of a paragraph.

--- a/src/internal/mdx.test.ts
+++ b/src/internal/mdx.test.ts
@@ -254,6 +254,29 @@ describe('remarkBenchmarks', () => {
     ])
   })
 
+  it('normalizes scalars against a non-1x reference cell', async () => {
+    const table = ['| suite | a | b | c |', '| --- | --- | --- | --- |', '| r | 2x | 2x | 4x |']
+
+    const cost = await runRemark([':::benchmarks', ...table, ':::'].join('\n'), plugins)
+    expect(benchmarksCells(cost)[1]).toEqual([
+      undefined,
+      { 'data-v-benchmarks-cell': 'baseline' },
+      { 'data-v-benchmarks-cell': 'neutral' },
+      { 'data-v-benchmarks-cell': 'slower', style: '--vocs-benchmarks-intensity: 0.4' },
+    ])
+
+    const speedup = await runRemark(
+      [':::benchmarks{scalar=speedup}', ...table, ':::'].join('\n'),
+      plugins,
+    )
+    expect(benchmarksCells(speedup)[1]).toEqual([
+      undefined,
+      { 'data-v-benchmarks-cell': 'baseline' },
+      { 'data-v-benchmarks-cell': 'neutral' },
+      { 'data-v-benchmarks-cell': 'faster', style: '--vocs-benchmarks-intensity: 0.4' },
+    ])
+  })
+
   it('colors time cells relative to the reference time, normalizing units', async () => {
     const tree = await runRemark(
       [

--- a/src/internal/mdx.test.ts
+++ b/src/internal/mdx.test.ts
@@ -3,6 +3,7 @@ import type * as Estree from 'estree'
 import type * as MdAst from 'mdast'
 import remarkDirective from 'remark-directive'
 import remarkFrontmatter from 'remark-frontmatter'
+import remarkGfm from 'remark-gfm'
 import remarkParse from 'remark-parse'
 import ruby from 'shiki/langs/ruby.mjs'
 import { unified } from 'unified'
@@ -14,6 +15,7 @@ import {
   recmaMdxLayout,
   rehypeHeadingAnchors,
   rehypeLinks,
+  remarkBenchmarks,
   remarkChangelog,
   remarkCodeTitle,
   remarkDefaultFrontmatter,
@@ -174,6 +176,146 @@ describe('remarkPrompt', () => {
     expect(tree.children[0]).toMatchObject({
       type: 'containerDirective',
       name: 'note',
+    })
+  })
+})
+
+describe('remarkBenchmarks', () => {
+  const plugins = [remarkDirective, remarkGfm, remarkBenchmarks]
+
+  function benchmarksCells(tree: MdAst.Root) {
+    const directive = tree.children[0] as unknown as { children: MdAst.RootContent[] }
+    const table = directive.children.find((child) => child.type === 'table') as MdAst.Table
+    return table.children.map((row) =>
+      row.children.map(
+        (cell) => (cell.data as { hProperties?: Record<string, unknown> } | undefined)?.hProperties,
+      ),
+    )
+  }
+
+  it('colors scalar cells as cost ratios against the reference column', async () => {
+    const tree = await runRemark(
+      [
+        ':::benchmarks',
+        '| suite | Octane | React | Solid |',
+        '| --- | --- | --- | --- |',
+        '| js-framework | 1x | 2.5x | 1.0x |',
+        '| memo-wall | 1x | 6.1x | 0.40x |',
+        ':::',
+      ].join('\n'),
+      plugins,
+    )
+
+    expect((tree.children[0] as unknown as { data?: unknown }).data).toMatchObject({
+      hName: 'div',
+      hProperties: { 'data-v-benchmarks': '' },
+    })
+    expect(benchmarksCells(tree)).toEqual([
+      [
+        undefined,
+        { 'data-v-benchmarks-col': '', style: 'width: 24%' },
+        { 'data-v-benchmarks-col': '', style: 'width: 24%' },
+        { 'data-v-benchmarks-col': '', style: 'width: 24%' },
+      ],
+      [
+        undefined,
+        { 'data-v-benchmarks-cell': 'baseline' },
+        { 'data-v-benchmarks-cell': 'slower', style: '--vocs-benchmarks-intensity: 0.53' },
+        { 'data-v-benchmarks-cell': 'neutral' },
+      ],
+      [
+        undefined,
+        { 'data-v-benchmarks-cell': 'baseline' },
+        { 'data-v-benchmarks-cell': 'slower', style: '--vocs-benchmarks-intensity: 1' },
+        { 'data-v-benchmarks-cell': 'faster', style: '--vocs-benchmarks-intensity: 0.53' },
+      ],
+    ])
+  })
+
+  it('inverts scalar cost with `scalar=speedup`', async () => {
+    const tree = await runRemark(
+      [
+        ':::benchmarks{scalar=speedup}',
+        '| op | vocs | other |',
+        '| --- | --- | --- |',
+        '| build | 1x | 2.0x |',
+        ':::',
+      ].join('\n'),
+      plugins,
+    )
+
+    expect((tree.children[0] as unknown as { data?: unknown }).data).toMatchObject({
+      hProperties: { 'data-v-benchmarks': '', scalar: 'speedup' },
+    })
+    expect(benchmarksCells(tree)[1]).toEqual([
+      undefined,
+      { 'data-v-benchmarks-cell': 'baseline' },
+      { 'data-v-benchmarks-cell': 'faster', style: '--vocs-benchmarks-intensity: 0.4' },
+    ])
+  })
+
+  it('colors time cells relative to the reference time, normalizing units', async () => {
+    const tree = await runRemark(
+      [
+        ':::benchmarks',
+        '| task | a | b | c | d |',
+        '| --- | --- | --- | --- | --- |',
+        '| build | 100ms | 50ms | 0.2s | — |',
+        '| run | 10 | 9.0 | fast | 10 |',
+        ':::',
+      ].join('\n'),
+      plugins,
+    )
+
+    expect(benchmarksCells(tree).slice(1)).toEqual([
+      [
+        undefined,
+        { 'data-v-benchmarks-cell': 'baseline' },
+        { 'data-v-benchmarks-cell': 'faster', style: '--vocs-benchmarks-intensity: 0.4' },
+        { 'data-v-benchmarks-cell': 'slower', style: '--vocs-benchmarks-intensity: 0.4' },
+        { 'data-v-benchmarks-cell': 'missing' },
+      ],
+      [
+        undefined,
+        { 'data-v-benchmarks-cell': 'baseline' },
+        { 'data-v-benchmarks-cell': 'faster', style: '--vocs-benchmarks-intensity: 0.06' },
+        undefined,
+        { 'data-v-benchmarks-cell': 'neutral' },
+      ],
+    ])
+  })
+
+  it('uses the first numeric column as reference and skips columns before it', async () => {
+    const tree = await runRemark(
+      [
+        ':::benchmarks',
+        '| suite | note | ref | other |',
+        '| --- | --- | --- | --- |',
+        '| r | - | 1x | 2x |',
+        ':::',
+      ].join('\n'),
+      plugins,
+    )
+
+    expect(benchmarksCells(tree)[1]).toEqual([
+      undefined,
+      undefined,
+      { 'data-v-benchmarks-cell': 'baseline' },
+      { 'data-v-benchmarks-cell': 'slower', style: '--vocs-benchmarks-intensity: 0.4' },
+    ])
+  })
+
+  it('ignores tables outside the directive and directives without tables', async () => {
+    const tree = await runRemark(
+      ['| a | b |', '| --- | --- |', '| 1x | 2x |', '', ':::benchmarks', 'hello', ':::'].join('\n'),
+      plugins,
+    )
+
+    const table = tree.children[0] as MdAst.Table
+    expect(table.children[1]?.children.map((cell) => cell.data)).toEqual([undefined, undefined])
+    expect((tree.children[1] as unknown as { data?: unknown }).data).toMatchObject({
+      hName: 'div',
+      hProperties: { 'data-v-benchmarks': '' },
     })
   })
 })

--- a/src/internal/mdx.test.ts
+++ b/src/internal/mdx.test.ts
@@ -277,6 +277,36 @@ describe('remarkBenchmarks', () => {
     ])
   })
 
+  it('renders zero-valued results at full intensity', async () => {
+    const cost = await runRemark(
+      [':::benchmarks', '| t | a | b |', '| --- | --- | --- |', '| r | 100ms | 0ms |', ':::'].join(
+        '\n',
+      ),
+      plugins,
+    )
+    expect(benchmarksCells(cost)[1]).toEqual([
+      undefined,
+      { 'data-v-benchmarks-cell': 'baseline' },
+      { 'data-v-benchmarks-cell': 'faster', style: '--vocs-benchmarks-intensity: 1' },
+    ])
+
+    const speedup = await runRemark(
+      [
+        ':::benchmarks{scalar=speedup}',
+        '| t | a | b |',
+        '| --- | --- | --- |',
+        '| r | 1x | 0x |',
+        ':::',
+      ].join('\n'),
+      plugins,
+    )
+    expect(benchmarksCells(speedup)[1]).toEqual([
+      undefined,
+      { 'data-v-benchmarks-cell': 'baseline' },
+      { 'data-v-benchmarks-cell': 'slower', style: '--vocs-benchmarks-intensity: 1' },
+    ])
+  })
+
   it('colors time cells relative to the reference time, normalizing units', async () => {
     const tree = await runRemark(
       [

--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -6,6 +6,7 @@ import * as EstreeUtil from 'esast-util-from-js'
 import type * as Estree from 'estree'
 import type * as HAst from 'hast'
 import type * as MdAst from 'mdast'
+import { toString as mdastToString } from 'mdast-util-to-string'
 import rehypeAutolinkHeadings from 'rehype-autolink-headings'
 import rehypeSlug from 'rehype-slug'
 import remarkDirective from 'remark-directive'
@@ -392,6 +393,7 @@ export function getCompileOptions(
           remarkDirective,
           [remarkFileTree, config] as Pluggable,
           remarkCallout,
+          remarkBenchmarks,
           remarkChangelog,
           remarkCodeGroup,
           remarkPrompt,
@@ -818,6 +820,146 @@ export function remarkCallout() {
         'data-v-context': node.name !== 'callout' ? node.name : 'info',
       }
     })
+  }
+}
+
+/**
+ * Remark plugin that transforms `:::benchmarks` container directives into
+ * color-coded benchmark tables.
+ *
+ * Tables inside the directive are scanned for a reference column – the first
+ * column that contains numeric values. Cells holding a scalar (`2.5x`) or a
+ * time (`120ms`, `1.2s`) are colored by their cost relative to the reference:
+ * green when faster, red when slower. Scalars are cost ratios by default
+ * (`2.5x` = 2.5× the reference's cost); use `:::benchmarks{scalar=speedup}`
+ * when scalars are speedup factors instead. `—` marks a missing value.
+ */
+export function remarkBenchmarks(): remarkBenchmarks.ReturnType {
+  return (tree: MdAst.Root) => {
+    UnistUtil.visit(tree, (node) => {
+      if (node.type !== 'containerDirective') return
+      if (node.name !== 'benchmarks') return
+
+      // biome-ignore lint/suspicious/noAssignInExpressions: _
+      const data = node.data || (node.data = {})
+      data.hName = 'div'
+      data.hProperties = {
+        ...(node.attributes ?? {}),
+        'data-v-benchmarks': '',
+      }
+
+      const scalar = node.attributes?.['scalar'] === 'speedup' ? 'speedup' : 'cost'
+      UnistUtil.visit(node, 'table', (table) => annotateBenchmarksTable(table, scalar))
+    })
+  }
+}
+
+export declare namespace remarkBenchmarks {
+  type ReturnType = (tree: MdAst.Root) => void
+}
+
+const benchmarksScalarRegex = /^(\d+(?:\.\d+)?)\s*[x×]$/i
+const benchmarksTimeRegex = /^(\d+(?:\.\d+)?)\s*(ns|µs|μs|us|ms|s)?$/i
+const benchmarksMissingRegex = /^(—|–|-|n\/a)$/i
+const benchmarksTimeUnits: Record<string, number> = {
+  ns: 1e-9,
+  µs: 1e-6,
+  μs: 1e-6,
+  us: 1e-6,
+  ms: 1e-3,
+  s: 1,
+}
+
+function parseBenchmarkValue(text: string): { kind: 'scalar' | 'time'; value: number } | undefined {
+  const scalar = text.match(benchmarksScalarRegex)
+  const time = scalar ? undefined : text.match(benchmarksTimeRegex)
+  const match = scalar ?? time
+  if (!match) return undefined
+
+  const value = Number.parseFloat(match[1] ?? '')
+  if (!Number.isFinite(value)) return undefined
+  if (scalar) return { kind: 'scalar', value }
+
+  const unit = benchmarksTimeUnits[(time?.[2] ?? 's').toLowerCase()] ?? 1
+  return { kind: 'time', value: value * unit }
+}
+
+function annotateBenchmarksTable(table: MdAst.Table, scalar: 'cost' | 'speedup') {
+  const [headerRow, ...rows] = table.children
+  if (!headerRow || rows.length === 0) return
+
+  const columnCount = Math.max(...table.children.map((row) => row.children.length))
+  const referenceIndex = Array.from({ length: columnCount }, (_, index) => index).find((index) =>
+    rows.some((row) => {
+      const cell = row.children[index]
+      return cell ? parseBenchmarkValue(mdastToString(cell).trim()) !== undefined : false
+    }),
+  )
+  if (referenceIndex === undefined) return
+
+  // Distribute value columns evenly; label columns share the remaining width.
+  const valueColumnWidth = Math.round((72 / (columnCount - referenceIndex)) * 10) / 10
+  for (const [index, cell] of headerRow.children.entries()) {
+    if (index < referenceIndex) continue
+    // biome-ignore lint/suspicious/noAssignInExpressions: _
+    const cellData = cell.data || (cell.data = {})
+    cellData.hProperties = {
+      ...cellData.hProperties,
+      'data-v-benchmarks-col': '',
+      style: `width: ${valueColumnWidth}%`,
+    }
+  }
+
+  for (const row of rows) {
+    const referenceCell = row.children[referenceIndex]
+    const reference = referenceCell
+      ? parseBenchmarkValue(mdastToString(referenceCell).trim())
+      : undefined
+
+    for (const [index, cell] of row.children.entries()) {
+      if (index < referenceIndex) continue
+
+      const annotate = (context: string, intensity?: number) => {
+        // biome-ignore lint/suspicious/noAssignInExpressions: _
+        const cellData = cell.data || (cell.data = {})
+        cellData.hProperties = {
+          ...cellData.hProperties,
+          'data-v-benchmarks-cell': context,
+          ...(intensity === undefined
+            ? {}
+            : { style: `--vocs-benchmarks-intensity: ${intensity}` }),
+        }
+      }
+
+      const text = mdastToString(cell).trim()
+      if (benchmarksMissingRegex.test(text)) {
+        annotate('missing')
+        continue
+      }
+
+      const value = parseBenchmarkValue(text)
+      if (!value) continue
+      if (index === referenceIndex) {
+        annotate('baseline')
+        continue
+      }
+
+      const cost = (() => {
+        if (value.kind === 'scalar') return scalar === 'speedup' ? 1 / value.value : value.value
+        if (reference?.kind !== 'time' || reference.value === 0) return undefined
+        return value.value / reference.value
+      })()
+      if (cost === undefined || !Number.isFinite(cost) || cost <= 0) continue
+
+      // Full tint at ≥ ~5.7× (2^2.5) difference; within ~±1.4% counts as neutral.
+      const shift = Math.log2(cost)
+      if (Math.abs(shift) < 0.02) {
+        annotate('neutral')
+        continue
+      }
+      const intensity = Math.round(Math.min(1, Math.abs(shift) / 2.5) * 100) / 100
+      annotate(shift > 0 ? 'slower' : 'faster', intensity)
+    }
   }
 }
 

--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -955,7 +955,9 @@ function annotateBenchmarksTable(table: MdAst.Table, scalar: 'cost' | 'speedup')
         if (reference?.kind !== 'time' || reference.value === 0) return undefined
         return value.value / reference.value
       })()
-      if (cost === undefined || !Number.isFinite(cost) || cost <= 0) continue
+      // Zero and Infinity costs (e.g. a rounded `0ms` result) clamp to full
+      // intensity below via log2(0) = -Infinity / log2(Infinity) = Infinity.
+      if (cost === undefined || Number.isNaN(cost) || cost < 0) continue
 
       // Full tint at ≥ ~5.7× (2^2.5) difference; within ~±1.4% counts as neutral.
       const shift = Math.log2(cost)

--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -945,7 +945,13 @@ function annotateBenchmarksTable(table: MdAst.Table, scalar: 'cost' | 'speedup')
       }
 
       const cost = (() => {
-        if (value.kind === 'scalar') return scalar === 'speedup' ? 1 / value.value : value.value
+        if (value.kind === 'scalar') {
+          // Scalars are already relative, but normalize anyway so a non-`1x`
+          // reference cell (e.g. `2x | 2x`) still compares correctly.
+          const referenceValue = reference?.kind === 'scalar' ? reference.value : 1
+          if (referenceValue === 0) return undefined
+          return scalar === 'speedup' ? referenceValue / value.value : value.value / referenceValue
+        }
         if (reference?.kind !== 'time' || reference.value === 0) return undefined
         return value.value / reference.value
       })()

--- a/src/mdx.tsx
+++ b/src/mdx.tsx
@@ -1,6 +1,7 @@
 import type { MDXComponents } from 'mdx/types.js'
 
 import { Callout } from './react/Callout.js'
+import { Benchmarks } from './react/internal/Benchmarks.mdx.js'
 import { Changelog } from './react/internal/Changelog.mdx.js'
 import { CodeBlock } from './react/internal/CodeBlock.mdx.js'
 import { CodeGroup } from './react/internal/CodeGroup.mdx.js'
@@ -36,6 +37,7 @@ export const components: MDXComponents = {
       }
     >,
   ) {
+    if ('data-v-benchmarks' in props) return <Benchmarks {...props} />
     if ('data-v-changelog' in props) return <Changelog {...props} />
     if ('data-v-code-group' in props) return <CodeGroup {...props} />
     if ('data-v-file-tree' in props) return <FileTree {...props} />

--- a/src/react/internal/Benchmarks.mdx.tsx
+++ b/src/react/internal/Benchmarks.mdx.tsx
@@ -1,10 +1,6 @@
 import type * as React from 'react'
 
-export function Benchmarks(
-  props: React.PropsWithChildren<
-    React.ComponentProps<'div'> & { legend?: string | undefined; scalar?: string | undefined }
-  >,
-) {
+export function Benchmarks(props: Benchmarks.Props) {
   const { children, legend, scalar: _scalar, ...rest } = props
   return (
     <div {...rest} data-v data-v-benchmarks>
@@ -22,4 +18,13 @@ export function Benchmarks(
       )}
     </div>
   )
+}
+
+export declare namespace Benchmarks {
+  type Props = React.PropsWithChildren<
+    React.ComponentProps<'div'> & {
+      legend?: string | undefined
+      scalar?: string | undefined
+    }
+  >
 }

--- a/src/react/internal/Benchmarks.mdx.tsx
+++ b/src/react/internal/Benchmarks.mdx.tsx
@@ -1,0 +1,25 @@
+import type * as React from 'react'
+
+export function Benchmarks(
+  props: React.PropsWithChildren<
+    React.ComponentProps<'div'> & { legend?: string | undefined; scalar?: string | undefined }
+  >,
+) {
+  const { children, legend, scalar: _scalar, ...rest } = props
+  return (
+    <div {...rest} data-v data-v-benchmarks>
+      {children}
+      {legend !== 'false' && (
+        <footer data-v-benchmarks-legend>
+          <span>Faster</span>
+          <span data-v-benchmarks-legend-scale />
+          <span>Slower</span>
+          <span data-v-benchmarks-legend-baseline>
+            <span data-v-benchmarks-legend-swatch />
+            baseline
+          </span>
+        </footer>
+      )}
+    </div>
+  )
+}

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -393,6 +393,99 @@ div[data-v-table-wrapper] {
 
 /* #endregion */
 
+/* #region Benchmarks */
+
+div[data-v-benchmarks] {
+  @apply vocs:mb-6;
+
+  & div[data-v-table-wrapper] {
+    @apply vocs:mb-0;
+  }
+
+  & table[data-v] {
+    & th[data-v-benchmarks-col]:not([align="left"]) {
+      @apply vocs:text-center;
+    }
+
+    & td[data-v-benchmarks-cell] {
+      @apply vocs:text-center vocs:tabular-nums vocs:whitespace-nowrap vocs:relative vocs:isolate;
+
+      /* Tint an inset layer instead of the cell so the background doesn't
+         bleed to the cell edges. */
+      &::before {
+        content: "";
+        position: absolute;
+        inset: 3px;
+        z-index: -1;
+      }
+    }
+
+    & td[data-v-benchmarks-cell="baseline"] {
+      @apply vocs:text-secondary;
+
+      &::before {
+        border: 1px dashed var(--vocs-border-color-primary);
+      }
+    }
+
+    & td[data-v-benchmarks-cell="neutral"]::before {
+      background-color: var(--vocs-background-color-surfaceTint);
+    }
+
+    & td[data-v-benchmarks-cell="faster"]::before {
+      background-color: color-mix(
+        in srgb,
+        var(--vocs-color-green) calc(6% + var(--vocs-benchmarks-intensity, 0) * 42%),
+        var(--vocs-background-color-surfaceTint)
+      );
+    }
+
+    & td[data-v-benchmarks-cell="slower"]::before {
+      background-color: color-mix(
+        in srgb,
+        var(--vocs-color-red) calc(6% + var(--vocs-benchmarks-intensity, 0) * 42%),
+        var(--vocs-background-color-surfaceTint)
+      );
+    }
+
+    & td[data-v-benchmarks-cell="missing"] {
+      @apply vocs:text-muted;
+
+      &::before {
+        background-image: repeating-linear-gradient(
+          -45deg,
+          color-mix(in srgb, var(--vocs-text-color-muted) 12%, transparent) 0 4px,
+          transparent 4px 8px
+        );
+      }
+    }
+  }
+
+  & footer[data-v-benchmarks-legend] {
+    @apply vocs:flex vocs:items-center vocs:gap-2 vocs:mt-2 vocs:text-sm vocs:text-muted;
+
+    & [data-v-benchmarks-legend-scale] {
+      @apply vocs:h-2 vocs:w-16;
+      background: linear-gradient(
+        to right,
+        color-mix(in srgb, var(--vocs-color-green) 48%, var(--vocs-background-color-surfaceTint)),
+        var(--vocs-background-color-surfaceTint),
+        color-mix(in srgb, var(--vocs-color-red) 48%, var(--vocs-background-color-surfaceTint))
+      );
+    }
+
+    & [data-v-benchmarks-legend-baseline] {
+      @apply vocs:flex vocs:items-center vocs:gap-2 vocs:ms-4;
+    }
+
+    & [data-v-benchmarks-legend-swatch] {
+      @apply vocs:inline-block vocs:h-3.5 vocs:w-6 vocs:border vocs:border-dashed vocs:border-primary;
+    }
+  }
+}
+
+/* #endregion */
+
 /* #region Superscript */
 
 sup[data-v] > a {


### PR DESCRIPTION
Adds a `:::benchmarks` directive that colors table cells by performance relative to a reference column (the first column with numeric values), so benchmark tables read at a glance.

Scalar cells (`2.5x`) are cost ratios by default and `scalar=speedup` inverts them; time cells (`ns`/`us`/`ms`/`s`) compare against the reference per row. Value columns render at equal widths, `—` marks missing values, and `legend=false` hides the legend.

```md
:::benchmarks
| suite | Octane | React |
| --- | --- | --- |
| render | 1x | 2.5x |
| memory | 1x | 0.4x |
:::
```
