### PR TITLE
fix: getMdxLayoutImport infinite recursion on Windows

### DIFF
--- a/src/internal/mdx.ts
+++ b/src/internal/mdx.ts
@@ -458,8 +458,18 @@ export function recmaMdxLayout(config: Config.Config) {
     )
     if (defaultExportIndex === -1) return
 
-    function getMdxLayoutImport(dir: string) {
-      if (dir === path.dirname(pagesDirPath)) return `import { Layout as _Layout } from 'vocs';`
+    function getMdxLayoutImport(dir: string): string {
+      // Normalize both sides before comparing: `dir` (derived from vfile
+      // paths) and `pagesDirPath` can differ in separator spelling on
+      // Windows (`D:/...` vs `D:\...`), so a raw `===` never matches and
+      // the walk recurses past the intended stop. The `dirname(dir) === dir`
+      // guard also terminates at filesystem roots, where `dirname` is a
+      // fixed point.
+      if (
+        path.resolve(dir) === path.resolve(path.dirname(pagesDirPath)) ||
+        path.dirname(dir) === dir
+      )
+        return `import { Layout as _Layout } from 'vocs';`
       if (layoutPaths.has(dir)) return `import _Layout from '${layoutPaths.get(dir)}';`
       const layoutPath = path.join(dir, '_mdx-wrapper.tsx')
       const layoutFile = fs.existsSync(layoutPath)


### PR DESCRIPTION
Fixes #611.

On Windows, every MDX file fails to compile with `RangeError: Maximum call stack size exceeded` out of `getMdxLayoutImport`.

The parent-directory walk stops when `dir === path.dirname(pagesDirPath)` — but on Windows the two sides can carry different separator spellings (`D:/...` from vfile-derived paths vs `D:\...` from `path.resolve`), so the compare never matches. The walk then climbs to the drive root, where `path.dirname("D:\\") === "D:\\"` is a fixed point, and recurses until the stack overflows.

The fix normalizes both sides with `path.resolve` before comparing, and adds a `path.dirname(dir) === dir` guard so the walk always terminates at a filesystem root regardless of spelling:

```ts
if (
  path.resolve(dir) === path.resolve(path.dirname(pagesDirPath)) ||
  path.dirname(dir) === dir
)
  return `import { Layout as _Layout } from 'vocs';`
```

No behavior change on POSIX (paths already compare equal there); Windows builds go from crashing to working. We've been carrying exactly this patch against the published `dist` in CI (alchemy-run/cloudflare-tools `patches/vocs@2.6.0.patch`) and verified it on GitHub's `windows-latest` runners; also confirmed the bug is still present in the published 2.8.1 tarball.
