### PR TITLE
chore: add windows recursion changeset

### DIFF
--- a/.changeset/quiet-paths-rest.md
+++ b/.changeset/quiet-paths-rest.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Prevented infinite recursion while resolving MDX layout imports on Windows.


### PR DESCRIPTION
Adds the missing patch changeset for the Windows MDX layout recursion fix merged in https://github.com/wevm/vocs/pull/612, ensuring the fix ships in the next Vocs release.