### PR TITLE
fix: preserve repeated OpenAPI tag groups

### DIFF
--- a/.changeset/fuzzy-tags-repeat.md
+++ b/.changeset/fuzzy-tags-repeat.md
@@ -1,0 +1,5 @@
+---
+'vocs': patch
+---
+
+Allowed OpenAPI tags to appear in multiple `x-tagGroups` sidebar sections.

--- a/src/internal/openapi/parser.test.ts
+++ b/src/internal/openapi/parser.test.ts
@@ -212,16 +212,16 @@ describe('parse', () => {
     ])
   })
 
-  test('drops unknown tags, empty sections, and repeat claims from `x-tagGroups`', async () => {
+  test('drops unknown tags and empty sections but preserves repeat claims', async () => {
     const ir = await parse(
       OpenApi.from({
         spec: {
           ...spec,
           'x-tagGroups': [
-            // `missing` names no rendered group; `pets` resolves.
-            { name: 'Data API', tags: ['missing', 'pets'] },
-            // Both tags already claimed or unknown → section drops entirely.
-            { name: 'Empty', tags: ['pets', 'nope'] },
+            // Unknown and same-section duplicate tags drop; `pets` resolves once.
+            { name: 'Data API', tags: ['missing', 'pets', 'pets'] },
+            // `pets` remains in every section that names it; `nope` drops.
+            { name: 'Repeated', tags: ['pets', 'nope'] },
             // Unnamed entries are ignored.
             { tags: ['store'] },
           ],
@@ -229,7 +229,10 @@ describe('parse', () => {
         path: '/api',
       }),
     )
-    expect(ir.tagGroups).toEqual([{ name: 'Data API', groupIds: ['pets'] }])
+    expect(ir.tagGroups).toEqual([
+      { name: 'Data API', groupIds: ['pets'] },
+      { name: 'Repeated', groupIds: ['pets'] },
+    ])
   })
 
   test('omits `tagGroups` when no `x-tagGroups` entry resolves', async () => {

--- a/src/internal/openapi/parser.ts
+++ b/src/internal/openapi/parser.ts
@@ -369,24 +369,23 @@ export async function parse(config: OpenApi.Config, options: parse.Options = {})
 
 /**
  * Resolves `x-tagGroups` entries against the built categories. Tags that don't
- * resolve to a rendered category are dropped; a category claimed by multiple
- * sections stays with the first (pages are per-category, so one sidebar home).
- * Returns `undefined` when nothing resolves, so the sidebar stays flat.
+ * resolve to a rendered category are dropped; repeated categories remain in
+ * every authored section. Returns `undefined` when nothing resolves.
  */
 function buildTagGroups(document: Document, groups: IrGroup[]): IrTagGroup[] | undefined {
   const entries = document['x-tagGroups']
   if (!entries || entries.length === 0) return undefined
 
   const idByName = new Map(groups.map((group) => [group.name, group.id]))
-  const claimed = new Set<string>()
   const tagGroups: IrTagGroup[] = []
   for (const entry of entries) {
     if (!entry?.name) continue
+    const seen = new Set<string>()
     const groupIds: string[] = []
     for (const tag of entry.tags ?? []) {
       const id = idByName.get(tag)
-      if (!id || claimed.has(id)) continue
-      claimed.add(id)
+      if (!id || seen.has(id)) continue
+      seen.add(id)
       groupIds.push(id)
     }
     if (groupIds.length > 0) tagGroups.push({ name: entry.name, groupIds })

--- a/src/internal/openapi/sidebar.test.ts
+++ b/src/internal/openapi/sidebar.test.ts
@@ -142,6 +142,88 @@ describe('toSidebar', () => {
     expect(sidebar.map((item) => item.text)).toEqual(['Introduction', 'Data API', 'Internal'])
   })
 
+  test('renders a category in every tag group that claims it', () => {
+    const sidebar = toSidebar({
+      ...ir,
+      tagGroups: [
+        { name: 'Data API', groupIds: ['pets'] },
+        { name: 'Platform API', groupIds: ['pets'] },
+      ],
+    })
+    expect(sidebar).toMatchInlineSnapshot(`
+      [
+        {
+          "link": "/api",
+          "text": "Introduction",
+        },
+        {
+          "collapsed": undefined,
+          "items": [
+            {
+              "collapsed": false,
+              "items": [
+                {
+                  "link": "/api/pets",
+                  "text": "Overview",
+                },
+                {
+                  "badge": {
+                    "text": "GET",
+                    "variant": "info",
+                  },
+                  "link": "/api/pets#listpets",
+                  "text": "List pets",
+                },
+                {
+                  "badge": {
+                    "text": "POST",
+                    "variant": "success",
+                  },
+                  "link": "/api/pets#createpet",
+                  "text": "POST /pets",
+                },
+              ],
+              "text": "pets",
+            },
+          ],
+          "text": "Data API",
+        },
+        {
+          "collapsed": undefined,
+          "items": [
+            {
+              "collapsed": false,
+              "items": [
+                {
+                  "link": "/api/pets",
+                  "text": "Overview",
+                },
+                {
+                  "badge": {
+                    "text": "GET",
+                    "variant": "info",
+                  },
+                  "link": "/api/pets#listpets",
+                  "text": "List pets",
+                },
+                {
+                  "badge": {
+                    "text": "POST",
+                    "variant": "success",
+                  },
+                  "link": "/api/pets#createpet",
+                  "text": "POST /pets",
+                },
+              ],
+              "text": "pets",
+            },
+          ],
+          "text": "Platform API",
+        },
+      ]
+    `)
+  })
+
   test('flattened tag groups render their categories in place at the top level', () => {
     const sectioned: Ir = {
       ...ir,


### PR DESCRIPTION
Preserves repeated OpenAPI tag categories across every `x-tagGroups` section that names them. The parser previously assigned each category only to its first group.