### PR TITLE
feat(openapi): configure tag group collapse

### DIFF
--- a/.changeset/calm-sidebar-groups.md
+++ b/.changeset/calm-sidebar-groups.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Added `openapi[].sidebar.tagGroupsCollapsed` to configure `x-tagGroups` sections independently from tag sections.

--- a/site/src/pages/features/openapi.mdx
+++ b/site/src/pages/features/openapi.mdx
@@ -76,6 +76,23 @@ x-tagGroups: # [!code focus]
 
 Grouping affects navigation only — each tag keeps its own page and URL. Tags not claimed by any group stay at the top level of the sidebar, after the sections.
 
+Use `sidebar.collapsed` to collapse generated tag sections. Set `sidebar.tagGroupsCollapsed` when the surrounding `x-tagGroups` sections need a different default.
+
+```ts [vocs.config.ts]
+export default defineConfig({
+  openapi: [
+    {
+      spec: './openapi.yaml',
+      path: '/api',
+      sidebar: { // [!code focus]
+        collapsed: true, // [!code focus]
+        tagGroupsCollapsed: false, // [!code focus]
+      }, // [!code focus]
+    },
+  ],
+})
+```
+
 To keep a primary API prominent, name it in `sidebar.flatten` — its tags render as top-level items (as without tag groups) while the other sections keep their headers.
 
 ```ts [vocs.config.ts]

--- a/src/internal/openapi/openapi.ts
+++ b/src/internal/openapi/openapi.ts
@@ -55,9 +55,9 @@ export type SidebarExtras = {
    */
   intro?: SidebarItem[] | undefined
   /**
-   * Collapse the generated category groups and `x-tagGroups` sections by default.
-   * Groups containing the active page still auto-expand, so deep links stay
-   * navigable. The generated `Introduction` entry is unaffected.
+   * Collapse generated category groups by default. Also controls `x-tagGroups`
+   * sections unless `tagGroupsCollapsed` overrides it. Groups containing the
+   * active page still auto-expand. The generated `Introduction` is unaffected.
    *
    * @default false
    */
@@ -78,6 +78,13 @@ export type SidebarExtras = {
    * @example ["Data API"]
    */
   flatten?: readonly string[] | undefined
+  /**
+   * Collapse `x-tagGroups` sections independently from their generated category
+   * groups. Defaults to the value of `collapsed`.
+   *
+   * @default collapsed
+   */
+  tagGroupsCollapsed?: boolean | undefined
 }
 
 /**

--- a/src/internal/openapi/registry.test.ts
+++ b/src/internal/openapi/registry.test.ts
@@ -101,6 +101,24 @@ describe('mergeSidebar', () => {
     ])
   })
 
+  test('forwards independent tag group collapse defaults', async () => {
+    const cfg = Config.define({
+      openapi: [
+        OpenApi.from({
+          spec: { ...spec, 'x-tagGroups': [{ name: 'Data API', tags: ['pets'] }] },
+          path: '/api',
+          sidebar: { collapsed: true, tagGroupsCollapsed: false },
+        }),
+      ],
+    })
+    await Registry.build(cfg)
+
+    const sidebar = Registry.mergeSidebar(cfg).sidebar as Record<string, { items: SidebarItem[] }>
+    const section = sidebar['/api']?.items[1]
+    expect(section?.collapsed).toBe(false)
+    expect(section?.items?.[0]?.collapsed).toBe(true)
+  })
+
   test('does not mutate the input config', async () => {
     const cfg = config([{ text: 'Home', link: '/' }])
     await Registry.build(cfg)

--- a/src/internal/openapi/registry.ts
+++ b/src/internal/openapi/registry.ts
@@ -54,8 +54,12 @@ export function sidebars(
     const collapsed = entry?.sidebar?.collapsed
     const intro = entry?.sidebar?.intro
     const flatten = entry?.sidebar?.flatten
+    const tagGroupsCollapsed = entry?.sidebar?.tagGroupsCollapsed
     const backLink = entry?.sidebar?.backLink ?? true
-    result[path] = { backLink, items: Sidebar.toSidebar(ir, { collapsed, intro, flatten }) }
+    result[path] = {
+      backLink,
+      items: Sidebar.toSidebar(ir, { collapsed, intro, flatten, tagGroupsCollapsed }),
+    }
   }
   return result
 }

--- a/src/internal/openapi/sidebar.test.ts
+++ b/src/internal/openapi/sidebar.test.ts
@@ -130,6 +130,19 @@ describe('toSidebar', () => {
     expect(section.items[0]?.collapsed).toBe(true)
   })
 
+  test('configures tag group collapse independently from categories', () => {
+    const sidebar = toSidebar(
+      { ...ir, tagGroups: [{ name: 'Data API', groupIds: ['pets'] }] },
+      { collapsed: true, tagGroupsCollapsed: false },
+    )
+    const section = sidebar[1] as {
+      collapsed?: boolean
+      items: { collapsed?: boolean }[]
+    }
+    expect(section.collapsed).toBe(false)
+    expect(section.items[0]?.collapsed).toBe(true)
+  })
+
   test('appends groups unclaimed by tagGroups at the top level', () => {
     const sidebar = toSidebar({
       ...ir,

--- a/src/internal/openapi/sidebar.ts
+++ b/src/internal/openapi/sidebar.ts
@@ -61,9 +61,10 @@ export function toSidebar(ir: Ir, options: toSidebar.Options = {}): SidebarItem<
   // group id, rendered after the group's "Overview" link.
   const groupExtras = options.groupExtras ?? new Map<string, SidebarItem[]>()
 
-  // Generated category groups and sections start collapsed when `collapsed` is
-  // set. Active groups still auto-expand at render. `Introduction` is unaffected.
+  // Generated categories inherit `collapsed`. Tag-group sections can override
+  // that default independently. Active groups still auto-expand at render.
   const groupCollapsed = options.collapsed ?? false
+  const tagGroupsCollapsed = options.tagGroupsCollapsed ?? options.collapsed
 
   const groupItem = (group: Ir['groups'][number]): SidebarItem<true> => ({
     text: group.name,
@@ -100,7 +101,7 @@ export function toSidebar(ir: Ir, options: toSidebar.Options = {}): SidebarItem<
       return group ? [groupItem(group)] : []
     })
     if (flatten.has(tagGroup.name)) return items
-    return [{ text: tagGroup.name, collapsed: options.collapsed, items }]
+    return [{ text: tagGroup.name, collapsed: tagGroupsCollapsed, items }]
   })
   return [
     introduction,
@@ -116,8 +117,8 @@ export declare namespace toSidebar {
     /** Extra items injected into a generated group, keyed by group id. */
     groupExtras?: Map<string, SidebarItem[]> | undefined
     /**
-     * Collapse generated category groups and `x-tagGroups` sections by default.
-     * Active groups still auto-expand. `Introduction` is unaffected. @default false
+     * Collapse generated category groups by default. Also controls `x-tagGroups`
+     * sections unless `tagGroupsCollapsed` overrides it. @default false
      */
     collapsed?: boolean | undefined
     /**
@@ -125,5 +126,7 @@ export declare namespace toSidebar {
      * items (in place) instead of nesting under the section header.
      */
     flatten?: readonly string[] | undefined
+    /** Collapse `x-tagGroups` sections independently. @default collapsed */
+    tagGroupsCollapsed?: boolean | undefined
   }
 }

--- a/src/server/openapi/handler.test.ts
+++ b/src/server/openapi/handler.test.ts
@@ -39,6 +39,23 @@ describe('Handler.openApi', () => {
     expect(html).toContain('listPets')
   })
 
+  test('configures tag group collapse independently from categories', async () => {
+    const ref = openApi({
+      spec: { ...spec, 'x-tagGroups': [{ name: 'Data API', tags: ['Pets'] }] },
+      sidebar: { collapsed: true, tagGroupsCollapsed: false },
+    })
+    const html = await (await ref.fetch(new Request('http://localhost/'))).text()
+    const json = html.match(
+      /<script id="vocs-openapi-data" type="application\/json">(.+)<\/script>/,
+    )?.[1]
+    expect(json).toBeDefined()
+    const payload = JSON.parse(json ?? '{}') as {
+      sidebar: { collapsed?: boolean; items?: { collapsed?: boolean }[] }[]
+    }
+    expect(payload.sidebar[1]?.collapsed).toBe(false)
+    expect(payload.sidebar[1]?.items?.[0]?.collapsed).toBe(true)
+  })
+
   test('serves the prebuilt client bundle', async () => {
     const ref = openApi({ spec })
     const response = await ref.fetch(new Request('http://localhost/_vocs/openapi/client.js'))

--- a/src/server/openapi/state.ts
+++ b/src/server/openapi/state.ts
@@ -58,6 +58,7 @@ export async function prepare(
   const intro = [...traitIntro, ...(config.sidebar?.intro ?? [])]
   const collapsed = config.sidebar?.collapsed ?? false
   const flatten = config.sidebar?.flatten
+  const tagGroupsCollapsed = config.sidebar?.tagGroupsCollapsed
   const newGroups = [...extraGroups].map(([name, items]) => ({
     text: name,
     collapsed,
@@ -65,7 +66,13 @@ export async function prepare(
   }))
   const sidebar = [
     ...top,
-    ...Sidebar.toSidebar(ir, { intro, groupExtras, collapsed, flatten }),
+    ...Sidebar.toSidebar(ir, {
+      intro,
+      groupExtras,
+      collapsed,
+      flatten,
+      tagGroupsCollapsed,
+    }),
     ...newGroups,
     ...bottom,
   ]


### PR DESCRIPTION
Adds `openapi[].sidebar.tagGroupsCollapsed` so `x-tagGroups` sections can use a different default expansion state from generated tag sections while preserving existing `collapsed` behavior.