### PR TITLE
fix(sidebar): ignore unlinked headings in active state

### DIFF
--- a/.changeset/fix-sidebar-nested-headings.md
+++ b/.changeset/fix-sidebar-nested-headings.md
@@ -1,0 +1,5 @@
+---
+'vocs': patch
+---
+
+Keep hash-link sidebars on the current section while scrolling past nested headings.

--- a/.changeset/fix-sidebar-nested-headings.md
+++ b/.changeset/fix-sidebar-nested-headings.md
@@ -2,4 +2,4 @@
 'vocs': patch
 ---
 
-Keep hash-link sidebars on the current section while scrolling past nested headings.
+Kept hash-link sidebars on the current section while scrolling past nested headings.

--- a/src/react/internal/Sidebar.test.tsx
+++ b/src/react/internal/Sidebar.test.tsx
@@ -1,0 +1,240 @@
+/** @vitest-environment jsdom */
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type * as Sidebar_core from '../../internal/sidebar.js'
+import { Sidebar } from './Sidebar.js'
+
+const mocks = vi.hoisted(() => ({
+  path: '/docs',
+  sidebar: { items: [] } as Sidebar_core.Sidebar,
+}))
+
+vi.mock('waku', () => ({
+  useRouter: () => ({ path: mocks.path }),
+}))
+
+vi.mock('../useSidebar.js', () => ({
+  useSidebar: () => mocks.sidebar,
+}))
+
+type ObserverEntry = Pick<IntersectionObserverEntry, 'isIntersecting' | 'target'>
+
+class IntersectionObserverMock {
+  static instances: IntersectionObserverMock[] = []
+
+  readonly observed = new Set<Element>()
+  readonly callback: IntersectionObserverCallback
+  readonly disconnect = vi.fn(() => this.observed.clear())
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback
+    IntersectionObserverMock.instances.push(this)
+  }
+
+  observe = vi.fn((element: Element) => this.observed.add(element))
+
+  emit(element: Element, isIntersecting = true) {
+    const entry: ObserverEntry = { isIntersecting, target: element }
+    this.callback([entry as IntersectionObserverEntry], this as unknown as IntersectionObserver)
+  }
+
+  unobserve = vi.fn((element: Element) => this.observed.delete(element))
+  takeRecords = vi.fn(() => [])
+  root = null
+  rootMargin = '0px 0px -80% 0px'
+  scrollMargin = '0px'
+  thresholds = [0]
+}
+
+class MutationObserverMock {
+  disconnect = vi.fn()
+  observe = vi.fn()
+  takeRecords = vi.fn(() => [])
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  IntersectionObserverMock.instances = []
+  vi.stubGlobal('IntersectionObserver', IntersectionObserverMock)
+  vi.stubGlobal('MutationObserver', MutationObserverMock)
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    callback(0)
+    return 0
+  })
+  mocks.path = '/docs'
+  mocks.sidebar = sidebar([
+    { link: '/docs', text: 'Overview' },
+    { link: '/docs#installation', text: 'Installation' },
+    { link: '/docs#configuration', text: 'Configuration' },
+    { link: '/docs#api', text: 'API' },
+  ])
+  window.history.replaceState(null, '', '/docs')
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  document.body.replaceChildren()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('Sidebar in-page anchors', () => {
+  test('observes only headings represented in the sidebar', async () => {
+    addMarkdownHeadings([
+      ['h2', 'installation'],
+      ['h3', 'configuration'],
+      ['h3', 'configuration-options'],
+      ['h2', 'api'],
+      ['h3', 'mcp-tools'],
+    ])
+
+    await renderSidebar()
+
+    expect(observedIds()).toEqual(['installation', 'configuration', 'api'])
+  })
+
+  test('keeps the parent section active across unlinked nested headings', async () => {
+    addMarkdownHeadings([
+      ['h2', 'installation'],
+      ['h3', 'configuration'],
+      ['h3', 'configuration-options'],
+      ['h2', 'api'],
+      ['h3', 'mcp-tools'],
+    ])
+    await renderSidebar()
+    const observer = activeObserver()
+
+    await act(async () => observer.emit(element('configuration')))
+    expect(activeItem()).toBe('Configuration')
+    expect(observer.observed.has(element('configuration-options'))).toBe(false)
+    expect(activeItem()).toBe('Configuration')
+
+    await act(async () => observer.emit(element('api')))
+    expect(activeItem()).toBe('API')
+    expect(observer.observed.has(element('mcp-tools'))).toBe(false)
+    expect(activeItem()).toBe('API')
+  })
+
+  test('switches active state between linked sections', async () => {
+    addMarkdownHeadings([
+      ['h2', 'installation'],
+      ['h3', 'configuration'],
+      ['h2', 'api'],
+    ])
+    await renderSidebar()
+    const observer = activeObserver()
+
+    expect(activeItem()).toBe('Overview')
+    await act(async () => observer.emit(element('installation')))
+    expect(activeItem()).toBe('Installation')
+    await act(async () => observer.emit(element('configuration')))
+    expect(activeItem()).toBe('Configuration')
+    await act(async () => observer.emit(element('api')))
+    expect(activeItem()).toBe('API')
+  })
+
+  test('activates the nearest parent for a nested markdown deep link', async () => {
+    mocks.path = '/docs#mcp-tools'
+    window.history.replaceState(null, '', '/docs#mcp-tools')
+    addMarkdownHeadings([
+      ['h2', 'installation'],
+      ['h3', 'configuration'],
+      ['h2', 'api'],
+      ['h3', 'mcp-tools'],
+    ])
+
+    await renderSidebar()
+
+    expect(activeItem()).toBe('API')
+  })
+
+  test('activates the preceding operation for an OpenAPI subheading deep link', async () => {
+    mocks.path = '/api#list-pets-parameters'
+    mocks.sidebar = sidebar([
+      { link: '/api', text: 'Overview' },
+      { link: '/api#list-pets', text: 'List pets' },
+      { link: '/api#create-pet', text: 'Create pet' },
+    ])
+    window.history.replaceState(null, '', '/api#list-pets-parameters')
+    const openApi = document.createElement('div')
+    openApi.dataset['vOpenapi'] = ''
+    openApi.innerHTML = `
+      <h1 data-v-openapi-h1 id="api">API</h1>
+      <h2 data-v-openapi-operation-title id="list-pets">List pets</h2>
+      <h3 id="list-pets-parameters">Parameters</h3>
+      <h2 data-v-openapi-operation-title id="create-pet">Create pet</h2>
+    `
+    document.body.append(openApi)
+
+    await renderSidebar()
+
+    expect(activeItem()).toBe('List pets')
+    expect(observedIds()).toEqual(['list-pets', 'create-pet'])
+  })
+
+  test('keeps a guide page active when its headings are not sidebar anchors', async () => {
+    mocks.path = '/guide'
+    mocks.sidebar = sidebar([
+      { link: '/guide', text: 'Guide' },
+      { link: '/api#list-pets', text: 'List pets' },
+    ])
+    window.history.replaceState(null, '', '/guide')
+    addMarkdownHeadings([
+      ['h2', 'introduction'],
+      ['h2', 'list-pets'],
+      ['h2', 'examples'],
+    ])
+
+    await renderSidebar()
+
+    expect(activeItem()).toBe('Guide')
+    expect(IntersectionObserverMock.instances).toHaveLength(0)
+  })
+})
+
+function sidebar(items: Sidebar_core.SidebarItem[]): Sidebar_core.Sidebar {
+  return { items: [{ items, text: 'Documentation' }] }
+}
+
+function addMarkdownHeadings(headings: [tag: string, id: string][]) {
+  const article = document.createElement('article')
+  article.dataset['vContent'] = ''
+  for (const [tag, id] of headings) {
+    const heading = document.createElement(tag)
+    heading.id = id
+    article.append(heading)
+  }
+  document.body.append(article)
+}
+
+async function renderSidebar() {
+  await act(async () => root.render(<Sidebar scrollRef={{ current: null }} />))
+}
+
+function activeObserver() {
+  const observer = IntersectionObserverMock.instances[0]
+  if (!observer) throw new Error('expected an IntersectionObserver')
+  return observer
+}
+
+function observedIds() {
+  return [...activeObserver().observed].map((item) => item.id)
+}
+
+function element(id: string) {
+  const item = document.getElementById(id)
+  if (!item) throw new Error(`expected #${id}`)
+  return item
+}
+
+function activeItem() {
+  return container.querySelector('[data-v-sidebar-item][data-active]')?.textContent
+}

--- a/src/react/internal/Sidebar.tsx
+++ b/src/react/internal/Sidebar.tsx
@@ -18,27 +18,25 @@ const maxDepth = 5
 const ActiveAnchorContext = React.createContext<string | null>(null)
 
 /**
- * The set of in-page anchor ids that the sidebar actually links to (the `#frag`
- * of every hash-link item). Used so page-level items only defer their active
- * state to anchors that have a corresponding sidebar item — not to arbitrary
- * headings on a standalone guide page that happens to live under a section
- * whose sidebar uses hash links elsewhere.
+ * The set of in-page anchor ids that the sidebar links to on the current page.
+ * Used so page-level items only defer their active state to corresponding
+ * sidebar items — not to arbitrary headings or hash links for another page.
  */
 const HashIdsContext = React.createContext<ReadonlySet<string>>(new Set())
 
-/** Whether any sidebar item links to an in-page anchor. */
-function hasHashLink(items: Sidebar_core.SidebarItem[]): boolean {
-  return items.some((item) => item.link?.includes('#') || (item.items && hasHashLink(item.items)))
-}
-
-/** Collects the `#fragment` ids of every hash-link sidebar item. */
-function collectHashIds(items: Sidebar_core.SidebarItem[], ids = new Set<string>()): Set<string> {
+/** Collects the `#fragment` ids of hash-link sidebar items for the current page. */
+function collectHashIds(
+  items: Sidebar_core.SidebarItem[],
+  path: string,
+  ids = new Set<string>(),
+): Set<string> {
+  const pagePath = path.split('#')[0] ?? path
   for (const item of items) {
-    if (item.link?.includes('#')) {
-      const id = item.link.split('#')[1]
-      if (id) ids.add(id)
+    if (item.link?.includes('#') && !Path.isExternal(item.link)) {
+      const [itemPath, id] = item.link.split('#')
+      if (id && (!itemPath || Path.matches(pagePath, itemPath))) ids.add(id)
     }
-    if (item.items) collectHashIds(item.items, ids)
+    if (item.items) collectHashIds(item.items, pagePath, ids)
   }
   return ids
 }
@@ -48,20 +46,11 @@ function collectHashIds(items: Sidebar_core.SidebarItem[], ids = new Set<string>
  * (used by the OpenAPI section) can show active state. Mirrors the Outline's
  * IntersectionObserver approach.
  */
-function useActiveAnchor(enabled: boolean, path: string): string | null {
+function useActiveAnchor(hashIds: ReadonlySet<string>, path: string): string | null {
   const [activeId, setActiveId] = React.useState<string | null>(null)
 
   React.useEffect(() => {
-    if (!enabled || typeof window === 'undefined') return
-
-    // Reset on every client-side navigation: derive the active section from the
-    // hash of the destination `path` (landing pages like the OpenAPI section
-    // root have none, so they start with no active section). Reading `path`
-    // here — rather than only `window.location` — keeps it a genuine effect
-    // dependency so navigation reliably re-runs this.
-    const hashFromPath = path.includes('#') ? path.slice(path.indexOf('#') + 1) : ''
-    const hash = hashFromPath || (window.location.hash ? window.location.hash.slice(1) : '')
-    setActiveId(hash || null)
+    if (hashIds.size === 0 || typeof window === 'undefined') return
 
     // OpenAPI pages render inside `article[data-v-content]` too, so the generic
     // markdown selector would also match operation sub-headings (Parameters,
@@ -73,6 +62,25 @@ function useActiveAnchor(enabled: boolean, path: string): string | null {
     const selector = isOpenApi
       ? '[data-v-openapi-h1][id], [data-v-openapi-operation-title][id]'
       : 'article[data-v-content] :is(h2, h3, h4, h5, h6)[id]'
+
+    // Reset on every client-side navigation. If the destination hash belongs
+    // to a nested heading without a sidebar item, keep its nearest preceding
+    // sidebar anchor active instead of falling back to the page-level item.
+    // Reading `path` here — rather than only `window.location` — keeps it a
+    // genuine effect dependency so navigation reliably re-runs this.
+    const hashFromPath = path.includes('#') ? path.slice(path.indexOf('#') + 1) : ''
+    const hash = hashFromPath || (window.location.hash ? window.location.hash.slice(1) : '')
+    let initialId = hashIds.has(hash) ? hash : null
+    const target = hash ? document.getElementById(hash) : null
+    if (!initialId && target) {
+      for (const element of document.querySelectorAll(selector)) {
+        const position = element.compareDocumentPosition(target)
+        if (element === target || position & Node.DOCUMENT_POSITION_PRECEDING) break
+        if (hashIds.has(element.id)) initialId = element.id
+      }
+    }
+    setActiveId(initialId)
+
     const observer = new IntersectionObserver(
       (entries) => {
         for (const entry of entries)
@@ -87,6 +95,9 @@ function useActiveAnchor(enabled: boolean, path: string): string | null {
     const observeAll = () => {
       observer.disconnect()
       for (const element of document.querySelectorAll(selector)) {
+        // Nested headings without matching sidebar items belong to the current
+        // section. Observing them would reactivate the page-level item.
+        if (!hashIds.has(element.id)) continue
         // Skip changelog release-body headings — they have no sidebar entry and
         // would hijack the active section as you scroll through the changelog.
         if (element.closest('[data-v-changelog]')) continue
@@ -105,7 +116,7 @@ function useActiveAnchor(enabled: boolean, path: string): string | null {
       observer.disconnect()
       mutation?.disconnect()
     }
-  }, [enabled, path])
+  }, [hashIds, path])
 
   return activeId
 }
@@ -118,10 +129,9 @@ export function Sidebar(props: Sidebar.Props) {
     () => Sidebar_core.length(sidebar.items, { startDepth: 2 }) > 25,
     [sidebar.items],
   )
-  const hashLinks = React.useMemo(() => hasHashLink(sidebar.items), [sidebar.items])
-  const hashIds = React.useMemo(() => collectHashIds(sidebar.items), [sidebar.items])
   const { path } = useRouter()
-  const activeAnchor = useActiveAnchor(hashLinks, path)
+  const hashIds = React.useMemo(() => collectHashIds(sidebar.items, path), [sidebar.items, path])
+  const activeAnchor = useActiveAnchor(hashIds, path)
 
   return (
     <HashIdsContext.Provider value={hashIds}>


### PR DESCRIPTION
## Summary

- restrict sidebar anchor tracking to hash links for the current page
- ignore nested headings without matching sidebar entries so the page-level item does not flicker active
- preserve the nearest linked parent for Markdown and OpenAPI subheading deep links

## Tests

- add six Sidebar regression tests covering tracked headings, nested headings, section transitions, Markdown deep links, OpenAPI deep links, and hash links belonging to other pages
- `pnpm check`
- `pnpm test` (741 passed, 3 skipped)
- `pnpm check:types`
- `pnpm build`

Prompted by: @brendanjryan
